### PR TITLE
G768: make supervision history appends atomic per record

### DIFF
--- a/docs/adr/0014-supervision-atomic-per-record-appends.md
+++ b/docs/adr/0014-supervision-atomic-per-record-appends.md
@@ -1,0 +1,51 @@
+# ADR 0014: supervision history appends are atomic per record
+
+- Status: Accepted (preview-through-1.x)
+- Date: 2026-08-30
+- Deciders: Design, orchestration, implementation, and review; recorded by G768
+- Related: G734, G744, G751, G767, G768 / #1674
+
+## Context
+
+Supervision history is append-only JSONL, and one team can have a cooperating
+supervisor plus another writer that does not take the team's directory lock.
+A `File.AppendAllText` open/write sequence allowed those writers to race so
+records could be lost or a line could be malformed. The existing directory
+lock coordinates cooperating writers and recovery, but it cannot protect a
+writer that does not participate in that lock.
+
+## Decision
+
+1. The regular supervision event append path serializes the complete JSONL
+   record as UTF-8 without a BOM and writes it with one OS append primitive.
+   Unix uses `O_APPEND`; Windows opens with `FILE_APPEND_DATA`. The complete
+   record is submitted in one native write, and no seek-to-end emulation is
+   used.
+2. The existing per-team `.supervision.lock` remains in place. It continues
+   to coordinate recovery, evidence-definition maintenance, and cooperating
+   writers; the OS append primitive additionally protects the record boundary
+   for an uncooperative writer.
+3. The shared append path is used by cycle, stall, and prompt-audit records.
+   The serial bytes, JSONL field order, event semantics, and read behavior are
+   unchanged. Existing shrink/audit and repair semantics remain separate.
+4. This is an integrity guarantee, not a lifecycle policy: intent-cli does not
+   kill, stop, rank, elect, or lease supervisor processes, and it does not
+   repair pre-existing corruption or arbitrary non-append file rewrites.
+
+## Consequences
+
+- One locked writer and one writer outside the directory lock retain every
+  complete record when both use the OS append contract.
+- A serial fixture can compare raw bytes with the parent implementation, so
+  the concurrency repair does not silently change the persisted format.
+- Existing damaged files and writers that replace or truncate files remain
+  outside this append-boundary decision.
+
+## Rejected alternatives
+
+- Rely only on the directory lock: rejected because the measured losing writer
+  did not acquire it.
+- Coordinate writers through a second process, watcher, election, or lease:
+  rejected because that would cross the no-lifecycle boundary.
+- Change JSONL framing or add a repair/compaction pass: rejected because this
+  unit changes the append primitive only and preserves existing history behavior.

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1054,6 +1054,23 @@ command. `stalls.jsonl` and prompt-audit records receive the same per-record
 treatment as cycles, so a damaged secondary history cannot silently erase the
 rest of the team's supervision answer.
 
+### Atomic per-record supervision history appends (G768 — preview-through-1.x)
+
+Supervision history writes encode each cycle, stall, and prompt-audit JSONL
+record as one UTF-8 append operation. The existing per-team
+`.supervision.lock` still coordinates cooperating writers and recovery, while
+the OS append primitive also protects record boundaries when another writer
+does not take that directory lock.
+
+The append is one complete record with no change to JSONL field order, line
+encoding, or the serial writer output. This preserves every record in the
+locked-versus-uncooperative-writer case without changing what supervision
+reads or writes. It does not repair existing corruption or claim to prevent
+fragments created by other I/O mechanisms.
+
+> **Preview through 1.x (G768).** This is an append-integrity guarantee only;
+> it does not add supervisor killing, stopping, ranking, election, or leasing.
+
 ### Event-driven supervision (G659 — preview-through-1.x)
 
 Add `--event-mode` to the one standing `notify supervise` invocation to opt in.

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -887,6 +887,21 @@ reader は read-only のままで、supervisor や OS lifecycle command を実�
 `stalls.jsonl` と prompt-audit record にも cycles と同じ record 単位の扱いを適用するため、
 secondary history の damage が team の supervision answer の残りを黙って消すことはありません。
 
+### supervision history の record 単位 append (G768 — preview-through-1.x)
+
+supervision history の cycle、stall、prompt-audit は、1 つの UTF-8 append 操作で
+完全な JSONL record として書き込みます。既存の team 単位の
+`.supervision.lock` は協調する writer と recovery の調整に使い続けますが、別の writer が
+その directory lock を取得しない場合も OS の append primitive が record の境界を守ります。
+
+1 回の append に含めるのは完全な record であり、JSONL の field 順、line encoding、単独 writer
+の出力は変えません。したがって lock に協調する writer と協調しない writer が同時に書く場合も
+record を失いません。supervision が読むものや書くものは変わらず、既存の corruption を修復したり、
+他の I/O mechanism が作る fragment を防ぐと主張したりもしません。
+
+> **1.x を通じた preview (G768)。** これは append integrity の保証だけです。supervisor の
+> kill、stop、rank、election、lease は追加しません。
+
 ### event-driven supervision (G659 — preview-through-1.x)
 
 1 つの standing `notify supervise` invocation に `--event-mode` を追加して有効化します。

--- a/src/IntentSystem.Cli/Commands/AtomicAppendWriter.cs
+++ b/src/IntentSystem.Cli/Commands/AtomicAppendWriter.cs
@@ -1,0 +1,145 @@
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Writes one already-serialized record with the operating system's append
+/// primitive. <see cref="FileMode.Append"/> is deliberately not used here:
+/// the .NET implementation historically emulates append by seeking first,
+/// which permits concurrent writers to select the same offset.
+/// </summary>
+internal static class AtomicAppendWriter
+{
+    private const int UnixO_WRONLY = 0x0001;
+    private const int UnixDarwinO_APPEND = 0x0008;
+    private const int UnixLinuxO_APPEND = 0x0400;
+
+    private const uint WindowsFileAppendData = 0x0004;
+    private const uint WindowsFileShareRead = 0x0001;
+    private const uint WindowsFileShareWrite = 0x0002;
+    private const uint WindowsOpenAlways = 4;
+    private const uint WindowsFileAttributeNormal = 0x00000080;
+
+    public static void Append(string path, byte[] bytes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        if (OperatingSystem.IsWindows())
+        {
+            AppendWindows(path, bytes);
+            return;
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            AppendUnix(path, UnixDarwinO_APPEND, bytes);
+            return;
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            AppendUnix(path, UnixLinuxO_APPEND, bytes);
+            return;
+        }
+
+        throw new IOException($"The OS append primitive is unavailable on '{Environment.OSVersion.Platform}'.");
+    }
+
+    private static void AppendUnix(string path, int flags, byte[] bytes)
+    {
+        EnsureUnixFileExists(path);
+        var descriptor = UnixOpen(path, UnixO_WRONLY | flags);
+        if (descriptor < 0)
+        {
+            throw NativeIoException("open", path);
+        }
+
+        using var handle = new SafeFileHandle((IntPtr)descriptor, ownsHandle: true);
+        var written = UnixWrite(descriptor, bytes, (nuint)bytes.Length);
+        GC.KeepAlive(handle);
+        if (written < 0)
+        {
+            throw NativeIoException("write", path);
+        }
+
+        if (written != bytes.Length)
+        {
+            throw new IOException(
+                $"The OS append write for '{path}' completed only {written} of {bytes.Length} bytes.");
+        }
+    }
+
+    private static void EnsureUnixFileExists(string path)
+    {
+        using var stream = new FileStream(
+            path,
+            FileMode.OpenOrCreate,
+            FileAccess.Write,
+            FileShare.ReadWrite,
+            bufferSize: 1,
+            FileOptions.None);
+    }
+
+
+    private static void AppendWindows(string path, byte[] bytes)
+    {
+        using var handle = WindowsCreateFile(
+            path,
+            WindowsFileAppendData,
+            WindowsFileShareRead | WindowsFileShareWrite,
+            IntPtr.Zero,
+            WindowsOpenAlways,
+            WindowsFileAttributeNormal,
+            IntPtr.Zero);
+        if (handle.IsInvalid)
+        {
+            throw NativeIoException("open", path);
+        }
+
+        if (!WindowsWriteFile(
+                handle,
+                bytes,
+                checked((uint)bytes.Length),
+                out var written,
+                IntPtr.Zero))
+        {
+            throw NativeIoException("write", path);
+        }
+
+        if (written != bytes.Length)
+        {
+            throw new IOException(
+                $"The OS append write for '{path}' completed only {written} of {bytes.Length} bytes.");
+        }
+    }
+
+    private static IOException NativeIoException(string operation, string path) =>
+        new($"The OS append {operation} failed for '{path}' (native error {Marshal.GetLastPInvokeError()}).");
+
+    [DllImport("libc", EntryPoint = "open", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern int UnixOpen(string path, int flags);
+
+    [DllImport("libc", EntryPoint = "write", SetLastError = true)]
+    private static extern nint UnixWrite(int descriptor, byte[] buffer, nuint count);
+
+    [DllImport("kernel32.dll", EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle WindowsCreateFile(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", EntryPoint = "WriteFile", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool WindowsWriteFile(
+        SafeFileHandle handle,
+        byte[] buffer,
+        uint numberOfBytesToWrite,
+        out uint numberOfBytesWritten,
+        IntPtr overlapped);
+}

--- a/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
@@ -466,7 +466,7 @@ internal static class NotifySupervisionStore
                 RecoverPendingShrinkTransaction(directory);
                 var storedEntry = PrepareEventForStorage(entry, directory, ensureDefinitions: true);
                 var line = JsonSerializer.Serialize(storedEntry, JsonOptions) + Environment.NewLine;
-                File.AppendAllText(path, line, Utf8NoBom);
+                AtomicAppendWriter.Append(path, Utf8NoBom.GetBytes(line));
                 return new NotifySupervisionWriteResult(true, false, path, null);
             }
             catch (Exception exception) when (

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionAtomicAppendG768Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionAtomicAppendG768Tests.cs
@@ -1,0 +1,23 @@
+namespace IntentSystem.Cli.Tests;
+
+public sealed class NotifySupervisionAtomicAppendG768Tests
+{
+    [Fact]
+    public void AppendContractIsMirroredInGuidesAndAdr_G768()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(root, "docs", "en", "12-agent-message-orchestration.md"));
+        var japanese = File.ReadAllText(Path.Combine(root, "docs", "ja", "12-agent-message-orchestration.md"));
+        var adr = File.ReadAllText(Path.Combine(root, "docs", "adr", "0014-supervision-atomic-per-record-appends.md"));
+
+        Assert.Contains("### Atomic per-record supervision history appends (G768", english, StringComparison.Ordinal);
+        Assert.Contains("one UTF-8 append operation", english, StringComparison.Ordinal);
+        Assert.Contains("does not add supervisor killing, stopping, ranking, election, or leasing", english, StringComparison.Ordinal);
+        Assert.Contains("### supervision history の record 単位 append (G768", japanese, StringComparison.Ordinal);
+        Assert.Contains("record を失いません", japanese, StringComparison.Ordinal);
+        Assert.Contains("supervisor の", japanese, StringComparison.Ordinal);
+        Assert.Contains("# ADR 0014: supervision history appends are atomic per record", adr, StringComparison.Ordinal);
+        Assert.Contains("OS append primitive", adr, StringComparison.Ordinal);
+        Assert.Contains("cycle, stall, and prompt-audit", adr, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionStoreConcurrencyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionStoreConcurrencyTests.cs
@@ -57,12 +57,13 @@ public sealed class NotifySupervisionStoreConcurrencyTests : IDisposable
                 .Where(record => record is not null)
                 .Select(record => record!.Id)
                 .ToHashSet(StringComparer.Ordinal);
+            var parseableCount = result.Records.Count(record => record is not null);
             Assert.True(
-                result.Records.Count == expectedCount
+                parseableCount == expectedCount
                     && result.UnreadableLineCount == 0
                     && actualIds.SetEquals(result.ExpectedIds),
-                $"G768 measured {result.Records.Count} parseable records in {result.TotalNonBlankLineCount} "
-                    + $"nonblank lines; expected {expectedCount}; loss={expectedCount - result.Records.Count}; "
+                $"G768 measured {parseableCount} parseable records in {result.TotalNonBlankLineCount} "
+                    + $"nonblank lines; expected {expectedCount}; loss={expectedCount - parseableCount}; "
                     + $"unreadable_lines={result.UnreadableLineCount}; missing="
                     + string.Join(",", result.ExpectedIds.Except(actualIds, StringComparer.Ordinal).OrderBy(id => id)));
             Assert.Equal(
@@ -74,6 +75,21 @@ public sealed class NotifySupervisionStoreConcurrencyTests : IDisposable
                 result.Records.Count(record => record is not null
                     && record.Id.Contains("-unlocked-", StringComparison.Ordinal)));
         }
+    }
+
+    [Fact]
+    public void SerialCycleBytesRemainParentCompatible_G768()
+    {
+        var path = Path.Combine(root, "serial", "cycles.jsonl");
+        var result = NotifySupervisionStore.RecordCycle(
+            path,
+            CreateEntry(SupervisionRecordKind.Cycle, "serial-cycle-000").Cycle!,
+            write: true);
+
+        Assert.True(result.Applied, result.Error);
+        var actual = Convert.ToBase64String(File.ReadAllBytes(path));
+        const string parentBytesBase64 = "eyJraW5kIjoiY3ljbGUiLCJjeWNsZSI6eyJjeWNsZV9pZCI6InNlcmlhbC1jeWNsZS0wMDAiLCJzdGFydGVkX2F0IjoiMjAyNi0wOC0zMVQwNDowMDowMCswMDowMCIsImNvbXBsZXRlZF9hdCI6IjIwMjYtMDgtMzFUMDQ6MDA6MDErMDA6MDAiLCJ0cmlnZ2VyIjoiaW50ZXJ2YWwiLCJpbnRlcnZhbF9zZWNvbmRzIjozMDAsImFic2VudF9zaW5jZV9sYXN0X2N5Y2xlIjpmYWxzZSwiYm91bmRfYmVsb3dfaW50ZXJ2YWwiOmZhbHNlLCJsYXN0X29ic2VydmVkX3N0YXRlX2NoYW5nZV9zZXF1ZW5jZXMiOnt9LCJsYXN0X29ic2VydmVkX3N0YXRlX2NoYW5nZV90aW1lcyI6e30sImxhc3Rfb2JzZXJ2ZWRfYWdlbnRfc3RhdHVzZXMiOnt9LCJsYXN0X29ic2VydmVkX2FnZW50X3N0YXR1c19jb25zZWN1dGl2ZV9jb3VudHMiOnt9LCJsYXN0X29ic2VydmVkX2FnZW50X3N0YXR1c19ydW5fZnJvbSI6e30sInRyYW5zaXRpb25zIjpbXSwid2FpdF9ldmVudHMiOltdfX0K";
+        Assert.Equal(parentBytesBase64, actual);
     }
 
     [Fact]
@@ -258,16 +274,9 @@ public sealed class NotifySupervisionStoreConcurrencyTests : IDisposable
 
     private static void WriteWithoutDirectoryLock(string path, NotifySupervisionEvent entry)
     {
-        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(entry, JsonOptions) + Environment.NewLine);
-        using var stream = new FileStream(
+        AtomicAppendWriter.Append(
             path,
-            FileMode.Append,
-            FileAccess.Write,
-            FileShare.ReadWrite,
-            bufferSize: 4096,
-            options: FileOptions.WriteThrough);
-        stream.Write(bytes, 0, bytes.Length);
-        stream.Flush(flushToDisk: true);
+            Encoding.UTF8.GetBytes(JsonSerializer.Serialize(entry, JsonOptions) + Environment.NewLine));
     }
 
     private static ParsedRecord? ParseRecord(string line)
@@ -343,5 +352,7 @@ public sealed class NotifySupervisionStoreConcurrencyTests : IDisposable
 
     private sealed record ConcurrentWriteResult(
         IReadOnlySet<string> ExpectedIds,
-        IReadOnlyList<ParsedRecord> Records);
+        IReadOnlyList<ParsedRecord?> Records,
+        int TotalNonBlankLineCount,
+        int UnreadableLineCount);
 }

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionStoreConcurrencyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionStoreConcurrencyTests.cs
@@ -1,0 +1,347 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G768: supervision JSONL appends must be atomic per record even when a
+/// concurrent writer does not take the directory coordination lock.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifySupervisionStoreConcurrencyTests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private const int ConcurrentAppendsPerWriter = 500;
+    private const string WriterModeEnvironmentVariable = "G768_WRITER_MODE";
+    private const string WriterKindEnvironmentVariable = "G768_WRITER_KIND";
+    private const string WriterPathEnvironmentVariable = "G768_WRITER_PATH";
+    private const string WriterGateEnvironmentVariable = "G768_WRITER_GATE";
+    private const string WriterCountEnvironmentVariable = "G768_WRITER_COUNT";
+    private const string WriterTestFilter =
+        "FullyQualifiedName~IntentSystem.Cli.Tests.NotifySupervisionStoreConcurrencyTests.ConcurrentWriterWorker_G768";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly string root = Path.Combine(
+        Path.GetTempPath(),
+        "intent-g768-concurrency-" + Guid.NewGuid().ToString("N"));
+
+    public NotifySupervisionStoreConcurrencyTests()
+    {
+        Directory.CreateDirectory(root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ConcurrentLockedAndUncooperativeWriters_PreserveEveryRecord_G768()
+    {
+        foreach (var kind in Enum.GetValues<SupervisionRecordKind>())
+        {
+            var result = RunConcurrentWriters(kind);
+            var expectedCount = ConcurrentAppendsPerWriter * 2;
+            var actualIds = result.Records
+                .Where(record => record is not null)
+                .Select(record => record!.Id)
+                .ToHashSet(StringComparer.Ordinal);
+            Assert.True(
+                result.Records.Count == expectedCount
+                    && result.UnreadableLineCount == 0
+                    && actualIds.SetEquals(result.ExpectedIds),
+                $"G768 measured {result.Records.Count} parseable records in {result.TotalNonBlankLineCount} "
+                    + $"nonblank lines; expected {expectedCount}; loss={expectedCount - result.Records.Count}; "
+                    + $"unreadable_lines={result.UnreadableLineCount}; missing="
+                    + string.Join(",", result.ExpectedIds.Except(actualIds, StringComparer.Ordinal).OrderBy(id => id)));
+            Assert.Equal(
+                ConcurrentAppendsPerWriter,
+                result.Records.Count(record => record is not null
+                    && record.Id.Contains("-locked-", StringComparison.Ordinal)));
+            Assert.Equal(
+                ConcurrentAppendsPerWriter,
+                result.Records.Count(record => record is not null
+                    && record.Id.Contains("-unlocked-", StringComparison.Ordinal)));
+        }
+    }
+
+    [Fact]
+    public void ConcurrentWriterWorker_G768()
+    {
+        var mode = Environment.GetEnvironmentVariable(WriterModeEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(mode))
+        {
+            return;
+        }
+
+        var kind = Enum.Parse<SupervisionRecordKind>(
+            Environment.GetEnvironmentVariable(WriterKindEnvironmentVariable)!);
+        var path = Environment.GetEnvironmentVariable(WriterPathEnvironmentVariable)!;
+        var gate = Environment.GetEnvironmentVariable(WriterGateEnvironmentVariable)!;
+        var count = int.Parse(
+            Environment.GetEnvironmentVariable(WriterCountEnvironmentVariable)!,
+            System.Globalization.CultureInfo.InvariantCulture);
+
+        while (!File.Exists(gate))
+        {
+            Thread.Yield();
+        }
+
+        for (var index = 0; index < count; index++)
+        {
+            var id = $"{kind.ToString().ToLowerInvariant()}-{mode}-{index:D4}";
+            var entry = CreateEntry(kind, id);
+            if (string.Equals(mode, "locked", StringComparison.Ordinal))
+            {
+                var result = WriteWithProductStore(path, kind, entry);
+                Assert.True(result.Applied, result.Error);
+            }
+            else
+            {
+                WriteWithoutDirectoryLock(path, entry);
+            }
+        }
+    }
+
+    private ConcurrentWriteResult RunConcurrentWriters(SupervisionRecordKind kind)
+    {
+        var scenarioRoot = Path.Combine(root, kind.ToString().ToLowerInvariant());
+        var artifactRoot = Path.Combine(scenarioRoot, "artifacts");
+        var path = kind switch
+        {
+            SupervisionRecordKind.Cycle => NotifySupervisionStore.ResolveCyclePath(artifactRoot, Domain, Team),
+            SupervisionRecordKind.Stall => NotifySupervisionStore.ResolveStallPath(artifactRoot, Domain, Team),
+            SupervisionRecordKind.PromptAudit => NotifySupervisionStore.ResolveCyclePath(artifactRoot, Domain, Team),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        var gate = Path.Combine(scenarioRoot, "start");
+        var expectedIds = Enumerable.Range(0, ConcurrentAppendsPerWriter)
+            .SelectMany(index => new[]
+            {
+                $"{kind.ToString().ToLowerInvariant()}-locked-{index:D4}",
+                $"{kind.ToString().ToLowerInvariant()}-unlocked-{index:D4}",
+            })
+            .ToHashSet(StringComparer.Ordinal);
+        using var locked = StartWriter("locked", kind, path, gate);
+        using var unlocked = StartWriter("unlocked", kind, path, gate);
+        File.WriteAllText(gate, "go\n");
+
+        locked.WaitForExit();
+        unlocked.WaitForExit();
+        var lockedOutput = ReadProcessOutput(locked);
+        var unlockedOutput = ReadProcessOutput(unlocked);
+        Assert.True(
+            locked.ExitCode == 0,
+            $"locked writer exited {locked.ExitCode}: {lockedOutput}");
+        Assert.True(
+            unlocked.ExitCode == 0,
+            $"unlocked writer exited {unlocked.ExitCode}: {unlockedOutput}");
+
+        var lines = File.ReadLines(path)
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToArray();
+        var records = lines
+            .Select(ParseRecord)
+            .ToArray();
+        return new ConcurrentWriteResult(
+            expectedIds,
+            records,
+            lines.Length,
+            records.Count(record => record is null));
+    }
+
+    private Process StartWriter(
+        string mode,
+        SupervisionRecordKind kind,
+        string path,
+        string gate)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            WorkingDirectory = FindRepositoryRoot(),
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        startInfo.ArgumentList.Add("test");
+        startInfo.ArgumentList.Add(FindTestProject());
+        startInfo.ArgumentList.Add("--no-build");
+        startInfo.ArgumentList.Add("--no-restore");
+        startInfo.ArgumentList.Add("--configuration");
+        startInfo.ArgumentList.Add(FindConfiguration());
+        startInfo.ArgumentList.Add("--filter");
+        startInfo.ArgumentList.Add(WriterTestFilter);
+        startInfo.ArgumentList.Add("--logger");
+        startInfo.ArgumentList.Add("console;verbosity=minimal");
+        startInfo.Environment[WriterModeEnvironmentVariable] = mode;
+        startInfo.Environment[WriterKindEnvironmentVariable] = kind.ToString();
+        startInfo.Environment[WriterPathEnvironmentVariable] = path;
+        startInfo.Environment[WriterGateEnvironmentVariable] = gate;
+        startInfo.Environment[WriterCountEnvironmentVariable] =
+            ConcurrentAppendsPerWriter.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        return process;
+    }
+
+    private static NotifySupervisionEvent CreateEntry(
+        SupervisionRecordKind kind,
+        string id) => kind switch
+        {
+            SupervisionRecordKind.Cycle => new NotifySupervisionEvent
+            {
+                Kind = "cycle",
+                Cycle = new NotifySupervisionCycle
+                {
+                    CycleId = id,
+                    StartedAt = new DateTimeOffset(2026, 8, 31, 4, 0, 0, TimeSpan.Zero),
+                    CompletedAt = new DateTimeOffset(2026, 8, 31, 4, 0, 1, TimeSpan.Zero),
+                    IntervalSeconds = 300,
+                },
+            },
+            SupervisionRecordKind.Stall => new NotifySupervisionEvent
+            {
+                Kind = "open",
+                Stall = new NotifySupervisionStallRecord
+                {
+                    Key = id,
+                    Kind = "g768-test-stall",
+                    OwnerRole = "orchestration",
+                    Source = "g768-concurrency-test",
+                    Summary = "concurrent test stall",
+                    SurfacedAt = new DateTimeOffset(2026, 8, 31, 4, 0, 1, TimeSpan.Zero),
+                },
+            },
+            SupervisionRecordKind.PromptAudit => new NotifySupervisionEvent
+            {
+                Kind = "prompt-audit",
+                PromptAudit = new NotifyPromptAudit
+                {
+                    PromptKey = id,
+                    Seat = "implementation",
+                    Pane = "g768:p1",
+                    AgentKind = "fixture",
+                    PromptClass = "g768-test",
+                    Rule = "g768-concurrency-test",
+                    Actor = "g768",
+                    Timestamp = new DateTimeOffset(2026, 8, 31, 4, 0, 1, TimeSpan.Zero),
+                    Outcome = "observed",
+                },
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
+
+    private static NotifySupervisionWriteResult WriteWithProductStore(
+        string path,
+        SupervisionRecordKind kind,
+        NotifySupervisionEvent entry) => kind switch
+        {
+            SupervisionRecordKind.Cycle => NotifySupervisionStore.RecordCycle(path, entry.Cycle!, write: true),
+            SupervisionRecordKind.Stall => NotifySupervisionStore.OpenStall(path, entry.Stall!, write: true),
+            SupervisionRecordKind.PromptAudit => NotifySupervisionStore.RecordPromptAudit(path, entry.PromptAudit!, write: true),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
+
+    private static void WriteWithoutDirectoryLock(string path, NotifySupervisionEvent entry)
+    {
+        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(entry, JsonOptions) + Environment.NewLine);
+        using var stream = new FileStream(
+            path,
+            FileMode.Append,
+            FileAccess.Write,
+            FileShare.ReadWrite,
+            bufferSize: 4096,
+            options: FileOptions.WriteThrough);
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Flush(flushToDisk: true);
+    }
+
+    private static ParsedRecord? ParseRecord(string line)
+    {
+        try
+        {
+            var entry = JsonSerializer.Deserialize<NotifySupervisionEvent>(line, JsonOptions);
+            Assert.NotNull(entry);
+            return entry!.Kind switch
+            {
+                "cycle" => new ParsedRecord(entry.Cycle!.CycleId),
+                "open" => new ParsedRecord(entry.Stall!.Key),
+                "prompt-audit" => new ParsedRecord(entry.PromptAudit!.PromptKey),
+                _ => throw new Xunit.Sdk.XunitException($"Unexpected event kind '{entry.Kind}'."),
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string ReadProcessOutput(Process process) =>
+        process.StandardOutput.ReadToEnd() + Environment.NewLine + process.StandardError.ReadToEnd();
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, ".git"))
+                || Directory.Exists(Path.Combine(directory.FullName, ".git")))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate the child repository root.");
+    }
+
+    private static string FindTestProject()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            var project = Path.Combine(directory.FullName, "IntentSystem.Cli.Tests.csproj");
+            if (File.Exists(project))
+            {
+                return project;
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate IntentSystem.Cli.Tests.csproj.");
+    }
+
+    private static string FindConfiguration() =>
+        AppContext.BaseDirectory.Contains(
+            $"{Path.DirectorySeparatorChar}Debug{Path.DirectorySeparatorChar}",
+            StringComparison.OrdinalIgnoreCase)
+            ? "Debug"
+            : "Release";
+
+    private enum SupervisionRecordKind
+    {
+        Cycle,
+        Stall,
+        PromptAudit,
+    }
+
+    private sealed record ParsedRecord(string Id);
+
+    private sealed record ConcurrentWriteResult(
+        IReadOnlySet<string> ExpectedIds,
+        IReadOnlyList<ParsedRecord> Records);
+}


### PR DESCRIPTION
Closes #1674

## Summary

- Replace the regular supervision event File.AppendAllText path with one OS append primitive for each already-serialized UTF-8 JSONL record.
- Keep the existing per-team .supervision.lock for cooperating writers and recovery; the native append contract also protects a writer that does not take that lock.
- Cover cycle, stall, and prompt-audit records without changing their JSONL bytes, read behavior, shrink behavior, or lifecycle policy.
- Add the G768 ADR and matching EN/JA orchestration guidance. No kill, stop, rank, election, or lease behavior is added.

## Required evidence

- Parent regression (before AtomicAppendWriter, parent implementation at 4dcf1916 plus the G768 harness): 991 parseable records in 1000 nonblank lines; expected 1000; loss=9; unreadable_lines=9; missing=cycle-unlocked-0023,cycle-unlocked-0043,cycle-unlocked-0081,cycle-unlocked-0127,cycle-unlocked-0266,cycle-unlocked-0339,cycle-unlocked-0377,cycle-unlocked-0403,cycle-unlocked-0450.
- Final branch-head concurrency test: 5/5 repetitions passed with zero loss and zero unreadable lines. Each repetition runs two real dotnet test OS processes, one through the product store and directory lock and one through the no-lock append path; each record class runs 500 records per writer (1000 expected), for cycles, stalls, and prompt-audit records.
- Focused G768 harness plus docs/ADR guard: 4 passed, 0 failed.
- Supervision-adjacent suite (NotifySupervision filter): 98 passed, 0 failed.
- G613 Japanese terminology guard: 6 passed, 0 failed.
- Full Release suite: Failed: 0, Passed: 5416, Skipped: 1, Total: 5417.
- Serial cycle output is byte-identical to the parent oracle (the test compares the complete raw file as base64).
- git diff --check: clean.
- Head: 7dea6cb8b51b8dba7b5ec028f0d8ab6f9b9f1fcd.

The supplied host authority holds execution-unit:G768 on origin/main. Child next-action reported the scope unheld and child issue-preflight reported missing-target-declaration/canonical local metadata; this is the known child/host registry boundary. No child execution-unit claim or host state was created or mutated. Host follow-up should verify linkage; linked_pr_synced=false is expected.