### PR TITLE
G769: honor explicit routing root for liveness

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1019,6 +1019,15 @@ over-bound supervisor even when no supervisor process is alive. The evidence
 state is not a claim that a scheduler job is loaded or that the CLI performed
 registration; registration remains the operator's explicit action.
 
+When `--routing-root <host-root>` is supplied, liveness resolves the supervision
+store beneath that absolute root rather than the caller's current working
+directory, and reports the same absolute root in `routing_root`. The explicit
+JSON `supervision_state` distinguishes `not-found` (the resolved store is not
+present) from `empty-history` (the store exists but has no history) and
+`recorded` (history or corruption evidence is present), so a mistyped root is
+not reported as a dead supervisor. Omitting `--routing-root` preserves the
+existing current-directory resolution and payload behavior.
+
 > **Preview through 1.x (G765).** Persistence is operator-declared and
 > recorded, reconciliation names the keep/remove distinction, and liveness is
 > a read-only observer. No lifecycle execution, automatic re-arming, or

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -857,6 +857,14 @@ orchestration thread が missing / bound 超過の supervisor を報告できま
 CLI が registration を実行したという意味ではなく、registration は operator の明示的な
 action のままです。
 
+`--routing-root <host-root>` を指定した場合、liveness は caller の
+current working directory ではなく、その absolute root 配下の supervision store を読み、
+同じ absolute root を `routing_root` に返します。JSON の `supervision_state` は、解決した
+store が存在しない `not-found`、store は存在するが history が空の `empty-history`、history
+または corruption evidence がある `recorded` を区別します。これにより誤った root を
+dead supervisor として報告しません。`--routing-root` を省略した場合は、従来の current
+directory に基づく解決と payload behavior を維持します。
+
 > **1.x を通じた preview (G765)。** persistence は operator が宣言して記録し、
 > reconcile は keep/remove の違いを明示し、liveness は read-only observer です。
 > lifecycle の実行、automatic re-arming、interval / bound / cycle / shrink / archive /

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
@@ -44,11 +44,15 @@ internal static class NotifySuperviseLivenessCommand
             return 1;
         }
 
+        string routingRoot;
         string artifactRoot;
+        var hasExplicitRoutingRoot = options.RoutingRoot is not null;
         try
         {
-            _ = Path.GetFullPath(options.RoutingRoot ?? context.RepoRoot);
-            artifactRoot = context.ResolveSupervisionArtifactRootPath();
+            routingRoot = Path.GetFullPath(options.RoutingRoot ?? context.RepoRoot);
+            artifactRoot = hasExplicitRoutingRoot
+                ? ResolveSupervisionArtifactRootPath(context, routingRoot)
+                : context.ResolveSupervisionArtifactRootPath();
         }
         catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
         {
@@ -63,6 +67,9 @@ internal static class NotifySuperviseLivenessCommand
             return 1;
         }
 
+        var supervisionState = hasExplicitRoutingRoot
+            ? DetermineSupervisionState(state)
+            : null;
         var now = (NotifyCommand.UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
         var lastCycle = state.LastIntervalCycle ?? state.LastCycle;
         var elapsedSeconds = lastCycle is { } cycle
@@ -92,10 +99,11 @@ internal static class NotifySuperviseLivenessCommand
         var result = new NotifySuperviseLivenessResult
         {
             Operation = "supervise-liveness",
-            RoutingRoot = Path.GetFullPath(options.RoutingRoot ?? context.RepoRoot),
+            RoutingRoot = routingRoot,
             Domain = options.Domain,
             Team = options.Team,
             CommandMode = "read-only",
+            SupervisionState = supervisionState,
             LastCompletedCycleAt = lastCycle?.CompletedAt,
             DeclaredBoundSeconds = boundSeconds,
             ElapsedSeconds = elapsedSeconds,
@@ -114,7 +122,9 @@ internal static class NotifySuperviseLivenessCommand
                 boundSeconds,
                 elapsedSeconds,
                 schedulerInstallationEvidence,
-                state.UnreadableRecords),
+                state.UnreadableRecords,
+                supervisionState,
+                state.Directory),
         };
 
         Emit(writer, result, options.Format);
@@ -126,14 +136,21 @@ internal static class NotifySuperviseLivenessCommand
         int? boundSeconds,
         long? elapsedSeconds,
         string schedulerInstallationEvidence,
-        IReadOnlyList<NotifySupervisionUnreadableRecord> unreadableRecords)
+        IReadOnlyList<NotifySupervisionUnreadableRecord> unreadableRecords,
+        string? supervisionState,
+        string supervisionDirectory)
     {
-        var cycleSummary = lastCycle is null
-            ? "No completed supervision cycle is recorded; no supervisor process is required to produce this answer."
-            : $"The last completed supervision cycle was {elapsedSeconds}s ago."
-                + (boundSeconds is { } bound
-                    ? $" The declared detection bound is {bound}s."
-                    : " No detection bound was declared.");
+        var cycleSummary = supervisionState switch
+        {
+            "not-found" => $"No supervision state was found at '{supervisionDirectory}'; no supervisor process is required to produce this answer.",
+            "empty-history" => "The supervision store exists but its history is empty; no supervisor process is required to produce this answer.",
+            _ => lastCycle is null
+                ? "No completed supervision cycle is recorded; no supervisor process is required to produce this answer."
+                : $"The last completed supervision cycle was {elapsedSeconds}s ago."
+                    + (boundSeconds is { } bound
+                        ? $" The declared detection bound is {bound}s."
+                        : " No detection bound was declared."),
+        };
         var absenceSummary = lastCycle is null || boundSeconds is { } declared && elapsedSeconds is { } elapsed && elapsed > declared
             ? " Supervision is absent or beyond its declared bound."
             : " Supervision liveness is within the available evidence.";
@@ -145,6 +162,14 @@ internal static class NotifySuperviseLivenessCommand
             ? " No readable cycle is available, so liveness is not reported as healthy."
             : string.Empty;
         return $"Read-only liveness: {cycleSummary}{absenceSummary}{noReadableCycleSummary}{corruptionSummary} Scheduler live state=unknown; durable installation evidence={schedulerInstallationEvidence}; the supervisor was not run.";
+    }
+
+    private static string ResolveSupervisionArtifactRootPath(CliContext context, string routingRoot)
+    {
+        var configuredRoot = context.Config.Supervision.ArtifactRoot;
+        return Path.IsPathRooted(configuredRoot)
+            ? Path.GetFullPath(configuredRoot)
+            : Path.GetFullPath(Path.Combine(routingRoot, configuredRoot));
     }
 
     private static void EmitFailure(TextWriter writer, string error, string format)
@@ -165,6 +190,11 @@ internal static class NotifySuperviseLivenessCommand
         writer.WriteLine($"supervise-liveness-failed: {error}");
     }
 
+    private static string DetermineSupervisionState(NotifySupervisionReadResult state) =>
+        !Directory.Exists(state.Directory)
+            ? "not-found"
+            : state.CycleHistory.Count == 0 && state.StallHistory.Count == 0 && state.PromptAudits.Count == 0 && state.UnreadableRecords.Count == 0 ? "empty-history" : "recorded";
+
     private static void Emit(TextWriter writer, NotifySuperviseLivenessResult result, string format)
     {
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
@@ -177,6 +207,10 @@ internal static class NotifySuperviseLivenessCommand
         writer.WriteLine();
         writer.WriteLine($"- domain/team: {result.Domain}/{result.Team}");
         writer.WriteLine($"- command mode: {result.CommandMode}");
+        if (result.SupervisionState is { } supervisionState)
+        {
+            writer.WriteLine($"- supervision state: {supervisionState}");
+        }
         writer.WriteLine($"- last completed cycle: {result.LastCompletedCycleAt?.ToString("O") ?? "<none>"}");
         writer.WriteLine($"- declared bound: {result.DeclaredBoundSeconds?.ToString(CultureInfo.InvariantCulture) ?? "<unrecorded>"}s");
         writer.WriteLine($"- elapsed: {result.ElapsedSeconds?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}s");
@@ -293,6 +327,7 @@ internal sealed record NotifySuperviseLivenessResult
     [JsonPropertyName("domain")] public required string Domain { get; init; }
     [JsonPropertyName("team")] public required string Team { get; init; }
     [JsonPropertyName("command_mode")] public required string CommandMode { get; init; }
+    [JsonPropertyName("supervision_state")] public string? SupervisionState { get; init; }
     [JsonPropertyName("last_completed_cycle_at")] public DateTimeOffset? LastCompletedCycleAt { get; init; }
     [JsonPropertyName("declared_bound_seconds")] public int? DeclaredBoundSeconds { get; init; }
     [JsonPropertyName("elapsed_seconds")] public long? ElapsedSeconds { get; init; }

--- a/tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs
@@ -168,6 +168,63 @@ public sealed class NotifySuperviseCommandTests : IDisposable
     }
 
     [Fact]
+    public void Liveness_ExplicitRoutingRootIsIndependentOfWorkingDirectory_G769()
+    {
+        var routingRoot = Path.Combine(root, "routing-root");
+        var firstWorkingDirectory = Path.Combine(root, "working-directory-a");
+        var secondWorkingDirectory = Path.Combine(root, "working-directory-b");
+        WriteCycle(
+            ArtifactRoot(routingRoot),
+            "routing-root-cycle",
+            now.AddHours(-3));
+        WriteCycle(
+            ArtifactRoot(firstWorkingDirectory),
+            "wrong-working-directory-a",
+            now.AddHours(-1));
+        WriteCycle(
+            ArtifactRoot(secondWorkingDirectory),
+            "wrong-working-directory-b",
+            now.AddHours(-2));
+
+        var first = RunLiveness(firstWorkingDirectory, routingRoot);
+        var second = RunLiveness(secondWorkingDirectory, routingRoot);
+
+        Assert.Equal(0, first.ExitCode);
+        Assert.Equal(0, second.ExitCode);
+        Assert.Equal(first.Payload, second.Payload);
+        using var document = JsonDocument.Parse(first.Payload);
+        var result = document.RootElement;
+        Assert.Equal(Path.GetFullPath(routingRoot), result.GetProperty("routing_root").GetString());
+        Assert.Equal(10_800, result.GetProperty("elapsed_seconds").GetInt64());
+        Assert.Equal("recorded", result.GetProperty("supervision_state").GetString());
+    }
+
+    [Fact]
+    public void Liveness_ExplicitRoutingRootDistinguishesNotFoundFromEmptyHistory_G769()
+    {
+        var workingDirectory = Path.Combine(root, "working-directory");
+        var missingRoot = Path.Combine(root, "missing-root");
+        var emptyRoot = Path.Combine(root, "empty-root");
+        Directory.CreateDirectory(Path.Combine(ArtifactRoot(emptyRoot), Domain, Team));
+
+        var missing = RunLiveness(workingDirectory, missingRoot);
+        var empty = RunLiveness(workingDirectory, emptyRoot);
+
+        Assert.Equal(0, missing.ExitCode);
+        Assert.Equal(0, empty.ExitCode);
+        using var missingDocument = JsonDocument.Parse(missing.Payload);
+        using var emptyDocument = JsonDocument.Parse(empty.Payload);
+        var missingResult = missingDocument.RootElement;
+        var emptyResult = emptyDocument.RootElement;
+        Assert.Equal("not-found", missingResult.GetProperty("supervision_state").GetString());
+        Assert.Equal("empty-history", emptyResult.GetProperty("supervision_state").GetString());
+        Assert.NotEqual(missing.Payload, empty.Payload);
+        Assert.Contains("No supervision state was found", missingResult.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("No completed supervision cycle", missingResult.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Contains("the supervision store exists but its history is empty", emptyResult.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Liveness_DoesNotClaimAnUnregisteredArtifactIsLoaded()
     {
         var artifact = CreateArtifact("authored-but-unregistered", "authored but never registered");
@@ -222,6 +279,11 @@ public sealed class NotifySuperviseCommandTests : IDisposable
         Assert.Contains("launchctl", document, StringComparison.Ordinal);
         Assert.Contains("scheduler_installation_evidence", document, StringComparison.Ordinal);
         Assert.Contains("scheduler_live_state", document, StringComparison.Ordinal);
+        Assert.Contains("--routing-root <host-root>", document, StringComparison.Ordinal);
+        Assert.Contains("supervision_state", document, StringComparison.Ordinal);
+        Assert.Contains("not-found", document, StringComparison.Ordinal);
+        Assert.Contains("empty-history", document, StringComparison.Ordinal);
+        Assert.Contains("recorded", document, StringComparison.Ordinal);
         if (language == "en")
         {
             Assert.Contains("does not execute", document, StringComparison.OrdinalIgnoreCase);
@@ -242,6 +304,34 @@ public sealed class NotifySuperviseCommandTests : IDisposable
         Assert.Contains("notify supervise liveness", residual, StringComparison.Ordinal);
         Assert.Contains("read-only", residual, StringComparison.OrdinalIgnoreCase);
     }
+
+    private (int ExitCode, string Payload) RunLiveness(string repoRoot, string? routingRoot = null)
+    {
+        using var writer = new StringWriter();
+        string[] args = routingRoot is null
+            ? ["liveness", "--domain", Domain, "--team", Team, "--format", "json"]
+            : ["liveness", "--domain", Domain, "--team", Team, "--routing-root", routingRoot, "--format", "json"];
+        var exitCode = NotifyCommand.ExecuteSupervise(CreateContext(repoRoot), args, writer);
+        return (exitCode, writer.ToString());
+    }
+
+    private void WriteCycle(string artifactRoot, string cycleId, DateTimeOffset completedAt)
+    {
+        var path = NotifySupervisionStore.ResolveCyclePath(artifactRoot, Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        Assert.True(NotifySupervisionStore.RecordCycle(
+            path,
+            new NotifySupervisionCycle
+            {
+                CycleId = cycleId,
+                StartedAt = completedAt.AddSeconds(-1),
+                CompletedAt = completedAt,
+                IntervalSeconds = 300,
+            },
+            write: true).Applied);
+    }
+
+    private static string ArtifactRoot(string repoRoot) => Path.Combine(repoRoot, ".intent-cli", "supervision");
 
     private string NotifySupervisionArtifactRoot() => Path.Combine(root, ".intent-cli", "supervision");
 
@@ -281,9 +371,9 @@ public sealed class NotifySuperviseCommandTests : IDisposable
         ObservedAt = now.AddSeconds(1),
     };
 
-    private CliContext CreateContext() => new()
+    private CliContext CreateContext(string? repoRoot = null) => new()
     {
-        RepoRoot = root,
+        RepoRoot = repoRoot ?? root,
         Config = new CliConfig
         {
             Project = new ProjectConfig


### PR DESCRIPTION
Closes #1675

## Summary

- Resolve an explicit `--routing-root <host-root>` as the base for the configured supervision artifact store instead of reading from the caller's current working directory.
- Report the supplied absolute root in `routing_root` and add explicit JSON/markdown `supervision_state` values: `not-found`, `empty-history`, or `recorded`.
- Keep the omitted-root path and payload byte-compatible, including the unchanged G767 clean payload oracle.
- Keep `notify status`, `notify supervise shrink`, lifecycle-query boundaries, and all G765/G767 behavior unchanged.

## Evidence

- Parent oracle run before the source fix:
  `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --filter 'FullyQualifiedName~Liveness_ExplicitRoutingRoot' --verbosity minimal`
  failed 2/2 as required. The explicit-root test reported the expected/actual cycle timestamp difference at position 305 (expected the routing-root cycle at 11:00, actual the working-directory cycle at 10:00). The not-found/empty-history test failed with `KeyNotFoundException` for the absent `supervision_state` property.
- The issue packet's three-cwd reproduction measured `unreadable_record_count=9` at the host root and `0` from both a submodule and `/tmp`; all three parent responses printed the host root, proving the explicit root was ignored.
- Post-fix focused G769: 2 passed, 0 failed.
- Preserved liveness plus unchanged G767 corruption oracle and G613: 23 passed, 0 failed.
- Adjacent supervision/reconcile/shrink/archive/runtime-local/event-mode/installation/concurrency coverage: 64 passed, 0 failed.
- Full CLI Debug suite: 5,418 passed, 1 skipped, 0 failed, 5,419 total.
- Full Release suite (`dotnet build IntentSystem.sln --configuration Release --no-restore` followed by `dotnet test IntentSystem.sln --configuration Release --no-build --no-restore --verbosity minimal`): 5,748 passed, 1 skipped, 0 failed, 5,749 total across all 11 assemblies. The CLI assembly was 5,418/1/0/5,419; the other assemblies totaled 330 passed and 0 skipped/failed.
- `git diff --check`: clean.

## Scope and coordination

Changed paths are exactly:

- `src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs`
- `tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs`
- `docs/en/12-agent-message-orchestration.md`
- `docs/ja/12-agent-message-orchestration.md`

The child `intent-cli guide start` could not find `.intent-cli/config.toml`; worker guidance was then loaded through the installed guide/model/onboarding/commands/automation surfaces. The child next-action reported G769 unheld while the supplied authoritative host claim says execution-unit:G769 is held by implementation/team intent-cli-dev; this stale child/host registry distinction was recorded and no execution-unit claim was created, modified, verified, or released in the child. Issue preflight also returned `missing-target-declaration` because its parser expected a literal `Target paths:` declaration although the complete issue uses `Target Repo / Path / Part`; the standalone issue body was used as the contract.

The canonical issue worker claim proceeded without label mutation because the existing `intent-issue-in-progress` label is stale shadow state. `linked_pr_synced=false` is expected host follow-up.
