### PR TITLE
G770: expose supervision state on default liveness

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1025,8 +1025,12 @@ directory, and reports the same absolute root in `routing_root`. The explicit
 JSON `supervision_state` distinguishes `not-found` (the resolved store is not
 present) from `empty-history` (the store exists but has no history) and
 `recorded` (history or corruption evidence is present), so a mistyped root is
-not reported as a dead supervisor. Omitting `--routing-root` preserves the
-existing current-directory resolution and payload behavior.
+not reported as a dead supervisor. Every successful liveness response, including
+the no-flag invocation, includes `supervision_state` with one of these values.
+Omitting `--routing-root` preserves the existing current-directory root
+resolution. The `guide design-thread` residual check prescribes
+`intent-cli notify supervise liveness --domain <domain> --team <team> --routing-root <host-root> --format json`,
+so the documented invocation and the safe invocation agree.
 
 > **Preview through 1.x (G765).** Persistence is operator-declared and
 > recorded, reconciliation names the keep/remove distinction, and liveness is

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -862,8 +862,12 @@ current working directory ではなく、その absolute root 配下の supervis
 同じ absolute root を `routing_root` に返します。JSON の `supervision_state` は、解決した
 store が存在しない `not-found`、store は存在するが history が空の `empty-history`、history
 または corruption evidence がある `recorded` を区別します。これにより誤った root を
-dead supervisor として報告しません。`--routing-root` を省略した場合は、従来の current
-directory に基づく解決と payload behavior を維持します。
+dead supervisor として報告しません。すべての成功した liveness 応答は、`--routing-root` の有無にかかわらず `supervision_state` を含みます。
+`--routing-root` を省略した場合も、従来の current directory に基づく root 解決を維持します。
+値は `not-found`、`empty-history`、`recorded` のいずれかで、`not-found` の no-flag 応答は
+dead supervisor と誤解させる文言を返しません。`guide design-thread` の residual check は
+`intent-cli notify supervise liveness --domain <domain> --team <team> --routing-root <host-root> --format json`
+を指定します。これにより documented invocation と安全な invocation が一致します。
 
 > **1.x を通じた preview (G765)。** persistence は operator が宣言して記録し、
 > reconcile は keep/remove の違いを明示し、liveness は read-only observer です。

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -160,7 +160,7 @@ internal static class GuideDesignThreadCommand
             Monitoring = new DesignThreadMonitoring
             {
                 Separation = "Supervision runs outside the design conversation and is consulted at most once per design wake.",
-                ResidualDesignCheck = "At low frequency, design runs the read-only `intent-cli notify supervise liveness --domain <domain> --team <team> --format json` surface. It reports the last completed supervision cycle, declared bound, elapsed age, and scheduler-load evidence without running or depending on the supervisor; compare the age with the declared supervision-liveness bound and do not use a conversational heartbeat.",
+                ResidualDesignCheck = "At low frequency, design runs the read-only `intent-cli notify supervise liveness --domain <domain> --team <team> --routing-root <host-root> --format json` surface. It reports the last completed supervision cycle, supervision state, declared bound, elapsed age, and scheduler-load evidence without running or depending on the supervisor; compare the age with the declared supervision-liveness bound and do not use a conversational heartbeat.",
                 BoundRule = "The declared detection bound must be greater than the configured wake interval plus scheduling jitter.",
                 GuideRefreshRule = "Re-read installed guides after a CLI version change or session-layer configuration change, not on every wake.",
                 DeploymentRule = $"A design seat whose agent kind has no inbound app monitor must be a recorded resident herdr seat with cwd `{root}`, where persistent AGENTS rules apply. A kind with an inbound app monitor may use that external reader. This is a deployment rule, not a recommendation.",

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
@@ -67,9 +67,7 @@ internal static class NotifySuperviseLivenessCommand
             return 1;
         }
 
-        var supervisionState = hasExplicitRoutingRoot
-            ? DetermineSupervisionState(state)
-            : null;
+        var supervisionState = DetermineSupervisionState(state);
         var now = (NotifyCommand.UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
         var lastCycle = state.LastIntervalCycle ?? state.LastCycle;
         var elapsedSeconds = lastCycle is { } cycle
@@ -137,7 +135,7 @@ internal static class NotifySuperviseLivenessCommand
         long? elapsedSeconds,
         string schedulerInstallationEvidence,
         IReadOnlyList<NotifySupervisionUnreadableRecord> unreadableRecords,
-        string? supervisionState,
+        string supervisionState,
         string supervisionDirectory)
     {
         var cycleSummary = supervisionState switch
@@ -207,10 +205,7 @@ internal static class NotifySuperviseLivenessCommand
         writer.WriteLine();
         writer.WriteLine($"- domain/team: {result.Domain}/{result.Team}");
         writer.WriteLine($"- command mode: {result.CommandMode}");
-        if (result.SupervisionState is { } supervisionState)
-        {
-            writer.WriteLine($"- supervision state: {supervisionState}");
-        }
+        writer.WriteLine($"- supervision state: {result.SupervisionState}");
         writer.WriteLine($"- last completed cycle: {result.LastCompletedCycleAt?.ToString("O") ?? "<none>"}");
         writer.WriteLine($"- declared bound: {result.DeclaredBoundSeconds?.ToString(CultureInfo.InvariantCulture) ?? "<unrecorded>"}s");
         writer.WriteLine($"- elapsed: {result.ElapsedSeconds?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}s");
@@ -327,7 +322,7 @@ internal sealed record NotifySuperviseLivenessResult
     [JsonPropertyName("domain")] public required string Domain { get; init; }
     [JsonPropertyName("team")] public required string Team { get; init; }
     [JsonPropertyName("command_mode")] public required string CommandMode { get; init; }
-    [JsonPropertyName("supervision_state")] public string? SupervisionState { get; init; }
+    [JsonPropertyName("supervision_state")] public required string SupervisionState { get; init; }
     [JsonPropertyName("last_completed_cycle_at")] public DateTimeOffset? LastCompletedCycleAt { get; init; }
     [JsonPropertyName("declared_bound_seconds")] public int? DeclaredBoundSeconds { get; init; }
     [JsonPropertyName("elapsed_seconds")] public long? ElapsedSeconds { get; init; }

--- a/tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs
@@ -225,6 +225,54 @@ public sealed class NotifySuperviseCommandTests : IDisposable
     }
 
     [Fact]
+    public void Liveness_NoFlagDistinguishesNotFoundFromEmptyHistory_G770()
+    {
+        var missingRoot = Path.Combine(root, "no-flag-missing-root");
+        var emptyRoot = Path.Combine(root, "no-flag-empty-root");
+        Directory.CreateDirectory(Path.Combine(ArtifactRoot(emptyRoot), Domain, Team));
+
+        var missing = RunLiveness(missingRoot);
+        var empty = RunLiveness(emptyRoot);
+
+        Assert.Equal(0, missing.ExitCode);
+        Assert.Equal(0, empty.ExitCode);
+        using var missingDocument = JsonDocument.Parse(missing.Payload);
+        using var emptyDocument = JsonDocument.Parse(empty.Payload);
+        var missingResult = missingDocument.RootElement;
+        var emptyResult = emptyDocument.RootElement;
+        Assert.Equal("not-found", missingResult.GetProperty("supervision_state").GetString());
+        Assert.Equal("empty-history", emptyResult.GetProperty("supervision_state").GetString());
+        Assert.NotEqual(missing.Payload, empty.Payload);
+        Assert.DoesNotContain("No completed supervision cycle", missingResult.GetProperty("summary").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Liveness_NoFlagReportsStateAndPreservesWorkingDirectoryResolution_G770()
+    {
+        var workingDirectory = Path.Combine(root, "no-flag-recorded-root");
+        var wrongWorkingDirectory = Path.Combine(root, "no-flag-wrong-root");
+        WriteCycle(ArtifactRoot(workingDirectory), "no-flag-cycle", now.AddHours(-3));
+
+        var noFlag = RunLiveness(workingDirectory);
+        var explicitRoot = RunLiveness(wrongWorkingDirectory, workingDirectory);
+
+        Assert.Equal(0, noFlag.ExitCode);
+        Assert.Equal(0, explicitRoot.ExitCode);
+        using var noFlagDocument = JsonDocument.Parse(noFlag.Payload);
+        using var explicitDocument = JsonDocument.Parse(explicitRoot.Payload);
+        var noFlagResult = noFlagDocument.RootElement;
+        var explicitResult = explicitDocument.RootElement;
+        Assert.Contains("supervision_state", noFlagResult.EnumerateObject().Select(property => property.Name));
+        Assert.Contains("supervision_state", explicitResult.EnumerateObject().Select(property => property.Name));
+        Assert.Equal(Path.GetFullPath(workingDirectory), noFlagResult.GetProperty("routing_root").GetString());
+        Assert.Equal(0, noFlagResult.GetProperty("unreadable_record_count").GetInt32());
+        Assert.Equal("recorded", noFlagResult.GetProperty("supervision_state").GetString());
+        Assert.Equal("recorded", explicitResult.GetProperty("supervision_state").GetString());
+        Assert.Equal(noFlagResult.GetProperty("routing_root").GetString(), explicitResult.GetProperty("routing_root").GetString());
+        Assert.Equal(noFlagResult.GetProperty("unreadable_record_count").GetInt32(), explicitResult.GetProperty("unreadable_record_count").GetInt32());
+    }
+
+    [Fact]
     public void Liveness_DoesNotClaimAnUnregisteredArtifactIsLoaded()
     {
         var artifact = CreateArtifact("authored-but-unregistered", "authored but never registered");
@@ -284,12 +332,15 @@ public sealed class NotifySuperviseCommandTests : IDisposable
         Assert.Contains("not-found", document, StringComparison.Ordinal);
         Assert.Contains("empty-history", document, StringComparison.Ordinal);
         Assert.Contains("recorded", document, StringComparison.Ordinal);
+        Assert.Contains("--routing-root <host-root> --format json", document, StringComparison.Ordinal);
         if (language == "en")
         {
+            Assert.Contains("Every successful liveness response", document, StringComparison.Ordinal);
             Assert.Contains("does not execute", document, StringComparison.OrdinalIgnoreCase);
         }
         else
         {
+            Assert.Contains("すべての成功した liveness 応答", document, StringComparison.Ordinal);
             Assert.Contains("実行しません", document, StringComparison.Ordinal);
         }
     }
@@ -303,6 +354,7 @@ public sealed class NotifySuperviseCommandTests : IDisposable
         var residual = document.RootElement.GetProperty("monitoring").GetProperty("residual_design_check").GetString();
         Assert.Contains("notify supervise liveness", residual, StringComparison.Ordinal);
         Assert.Contains("read-only", residual, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--routing-root <host-root>", residual, StringComparison.Ordinal);
     }
 
     private (int ExitCode, string Payload) RunLiveness(string repoRoot, string? routingRoot = null)

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionReaderCorruptionG767Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionReaderCorruptionG767Tests.cs
@@ -121,7 +121,7 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
         AssertCleanPayloadMatchesParentOracle(emptyPayload, emptyRoot);
         Assert.True(empty.GetProperty("absent_since_last_cycle").GetBoolean());
         Assert.True(corrupt.GetProperty("absent_since_last_cycle").GetBoolean());
-        Assert.Contains("No completed supervision cycle", empty.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Contains("No supervision state was found", empty.GetProperty("summary").GetString(), StringComparison.Ordinal);
         Assert.Contains("No completed supervision cycle", corrupt.GetProperty("summary").GetString(), StringComparison.Ordinal);
         Assert.Contains("No readable cycle", corrupt.GetProperty("summary").GetString(), StringComparison.Ordinal);
         Assert.False(empty.TryGetProperty("success", out _));
@@ -288,6 +288,7 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
             .EnumerateObject()
             .Select(property => (property.Name, RawValue: property.Value.GetRawText()))
             .ToArray();
+        var expectedDirectory = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "supervision", Domain, Team));
         var expected = new[]
         {
             ("operation", JsonSerializer.Serialize("supervise-liveness")),
@@ -295,6 +296,10 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
             ("domain", JsonSerializer.Serialize(Domain)),
             ("team", JsonSerializer.Serialize(Team)),
             ("command_mode", JsonSerializer.Serialize("read-only")),
+            // G770 authorizes this exact clean-payload addition so the
+            // no-flag path exposes the same state distinction as G769's
+            // explicit-root path.
+            ("supervision_state", JsonSerializer.Serialize("not-found")),
             ("absent_since_last_cycle", "true"),
             ("scheduler_installation_evidence", JsonSerializer.Serialize("unknown")),
             ("scheduler_live_state", JsonSerializer.Serialize("unknown")),
@@ -303,11 +308,11 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
             ("scheduler_artifact_paths", "[]"),
             ("commands_executed", JsonSerializer.Serialize(
                 "none (persisted supervision state and artifact metadata only)")),
-            // The only authorized delta from the parent clean payload is this
+            // The authorized G767 delta from the parent clean payload is this
             // corruption counter, which must remain zero for a clean store.
             ("unreadable_record_count", "0"),
             ("summary", JsonSerializer.Serialize(
-                "Read-only liveness: No completed supervision cycle is recorded; no supervisor process is required to produce this answer. Supervision is absent or beyond its declared bound. Scheduler live state=unknown; durable installation evidence=unknown; the supervisor was not run.")),
+                $"Read-only liveness: No supervision state was found at '{expectedDirectory}'; no supervisor process is required to produce this answer. Supervision is absent or beyond its declared bound. Scheduler live state=unknown; durable installation evidence=unknown; the supervisor was not run.")),
         };
 
         Assert.Equal(expected, actual);


### PR DESCRIPTION
Closes #1678

## Summary
- Emit `supervision_state` on every successful `notify supervise liveness` response, including the no-flag path.
- Preserve no-flag current-working-directory root resolution and distinguish `not-found`, `empty-history`, and `recorded`.
- Update the design-thread residual check to pass `--routing-root <host-root>` and keep EN/JA guidance aligned.
- Update the G767 clean-payload oracle only for the authorized `supervision_state` field and its state-specific not-found summary.

## Evidence
- Parent `a92a53fda2f8901e49b0e60d5d7c00d5c2a6c324` focused run: 19 total, 13 passed, 6 failed on the new no-flag state and guidance expectations.
- Focused G770/G767: 19 passed, 0 failed.
- Adjacent guide/topology/supervision coverage: 50 passed, 0 failed.
- G613 terminology guard: 6 passed, 0 failed.
- Release with isolated writable NuGet cache: 5,420 passed, 1 skipped, 0 failed, 5,421 total; Release build 0 warnings, 0 errors.
- `git diff --check`: clean.
- `commands_executed` remains `none (persisted supervision state and artifact metadata only)`; no lifecycle query or supervisor execution was added.

## Coordination boundary
The supplied host claim for `execution-unit:G770` at host commit `b1d31c92d` is authoritative. Child next-action reported holder none/unheld, while host claim verification was canonical-unavailable because `.git/FETCH_HEAD` was sandbox-denied; child issue-preflight also reported missing-target-declaration. No child execution-unit claim or host state was mutated.