### PR TITLE
fix: make claim transaction teardown outcome-tolerant

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2727,6 +2727,23 @@ warning is separate, names the leftover path, and cannot replace that primary
 no-op cause. With `--format json`, stdout contains exactly one JSON document;
 cleanup warnings go to stderr so stdout can be piped directly to a JSON parser.
 
+## Claim transaction teardown on every outcome (G771)
+
+Cleanup is best-effort on every claim outcome. An acquire, release, takeover,
+already-held result, not-held result, holder mismatch, or retry outcome keeps its
+original status, detail, ownership fields, and exit code even when temporary-root
+cleanup also fails. The cleanup warning is separate, names the leftover path, and
+never turns a pre-commit failure into a success or hides its original cause.
+
+Each transaction creates an exclusive lease beside its temporary root. A later
+write command ensures stale transaction roots are swept with a bounded best-effort pass
+(`intent-cli-claim-*`) after a five-minute age grace period. It examines at most
+32 candidates within a 250 ms sweep budget; an active or unreadable lease is
+protected and is never removed. A stale-root delete failure is warning evidence,
+not a claim result or exit-code change. This recovers abandoned roots while
+protecting a live concurrent transaction, and does not alter the existing
+250 ms per-attempt, three-attempt cleanup contract.
+
 ---
 
 ## Version flow

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2784,6 +2784,22 @@ active record の actor と team が同じ acquire は意図した no-op です�
 ません。`--format json` の stdout は JSON 文書を 1 つだけ含み、cleanup warning は stderr
 へ出力されるため、stdout を直接 JSON parser に渡せます。
 
+## すべての claim outcome に対する transaction teardown (G771)
+
+Cleanup はすべての claim outcome で best-effort です。acquire、release、takeover、
+already-held、not-held、holder mismatch、retry の各 result は、一時 root の cleanup
+も失敗した場合でも元の status、detail、ownership fields、exit code を保持します。
+cleanup warning は別の evidence として leftover path を示し、pre-commit failure を
+success に変えず、元の原因も隠しません。
+
+各 transaction は一時 root の横に exclusive lease を作ります。後続の write command は
+5 分の age grace period 後に、`intent-cli-claim-*` に一致する stale transaction root を
+bounded に best-effort sweep します。候補は最大 32 件、sweep budget は 250 ms です。
+active または読めない lease は保護し、削除しません。stale transaction root の delete
+failure は warning evidence であり、claim result や exit code を変更しません。これにより
+放置された root を回収しながら live な concurrent transaction を保護し、既存の 250 ms
+per-attempt、3 回の cleanup contract は変更しません。
+
 ---
 
 ## バージョンフロー

--- a/src/IntentSystem.Cli/Commands/ClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimCommand.cs
@@ -19,6 +19,11 @@ internal static class ClaimCommand
     internal const int CleanupMaxAttempts = 3;
     internal static readonly TimeSpan CleanupAttemptTimeout = TimeSpan.FromMilliseconds(250);
     internal static readonly TimeSpan CleanupRetryDelay = TimeSpan.FromMilliseconds(50);
+    private const string TransactionRootPrefix = "intent-cli-claim-";
+    private const string TransactionLeaseSuffix = ".lease";
+    private const int StaleTransactionRootSweepMaxCandidates = 32;
+    private static readonly TimeSpan StaleTransactionRootMinimumAge = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan StaleTransactionRootSweepBudget = TimeSpan.FromMilliseconds(250);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -149,6 +154,8 @@ internal static class ClaimCommand
                 null, null, null,
                 "Dry-run only. Re-run with --write; ownership exists only after a successful plain push.");
         }
+        SweepStaleTransactionRoots(warningWriter, deleteDirectory);
+
 
         var targetRef = $"refs/heads/{defaultBranch}";
 
@@ -161,7 +168,8 @@ internal static class ClaimCommand
         for (var attempt = 1; attempt <= request.MaxAttempts; attempt++)
         {
             var transactionRoot = Path.Combine(
-                Path.GetTempPath(), $"intent-cli-claim-{Guid.NewGuid():N}");
+                Path.GetTempPath(), $"{TransactionRootPrefix}{Guid.NewGuid():N}");
+            using var transactionLease = ClaimTransactionLease.Create(transactionRoot);
             var committed = false;
             var tolerateCleanupFailure = false;
             Exception? transactionFailure = null;
@@ -435,7 +443,8 @@ internal static class ClaimCommand
                         committed,
                         tolerateCleanupFailure,
                         warningWriter,
-                        deleteDirectory);
+                        deleteDirectory,
+                        transactionFailure);
                 }
                 catch (Exception cleanupFailure) when (transactionFailure is not null)
                 {
@@ -794,11 +803,14 @@ internal static class ClaimCommand
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(canonicalBranch);
 
+        SweepStaleTransactionRoots(Console.Error, path => Directory.Delete(path, recursive: true));
+
         HostStateGitRetryEvidence? lastGitWriteRetry = null;
         for (var attempt = 1; attempt <= request.MaxAttempts; attempt++)
         {
             var transactionRoot = Path.Combine(
                 Path.GetTempPath(), $"intent-cli-claim-migration-{Guid.NewGuid():N}");
+            using var transactionLease = ClaimTransactionLease.Create(transactionRoot);
             var committed = false;
             Exception? transactionFailure = null;
             try
@@ -956,8 +968,9 @@ internal static class ClaimCommand
                         transactionRoot,
                         committed,
                         tolerateCleanupFailure: false,
-                        Console.Error,
-                        path => Directory.Delete(path, recursive: true));
+                        warningWriter: Console.Error,
+                        deleteDirectory: path => Directory.Delete(path, recursive: true),
+                        transactionFailure: transactionFailure);
                 }
                 catch (Exception cleanupFailure) when (transactionFailure is not null)
                 {
@@ -1228,12 +1241,182 @@ internal static class ClaimCommand
         writer.WriteLine(
             "Usage: intent-cli claim stranded migrate --current-metadata-branch <branch> --new-canonical-branch <branch> --actor <actor> --team <team> --confirm-migrate-stranded --dry-run|--write --format json|markdown");
 
+    private static void SweepStaleTransactionRoots(
+        TextWriter warningWriter,
+        Action<string> deleteDirectory)
+    {
+        var tempRoot = Path.GetTempPath();
+        string[] candidates;
+        try
+        {
+            candidates = Directory.EnumerateDirectories(
+                    tempRoot,
+                    $"{TransactionRootPrefix}*",
+                    SearchOption.TopDirectoryOnly)
+                .Take(StaleTransactionRootSweepMaxCandidates)
+                .ToArray();
+        }
+        catch (Exception exception)
+        {
+            WriteStaleTransactionSweepWarning(warningWriter, tempRoot, exception.Message);
+            return;
+        }
+
+        var staleBefore = DateTime.UtcNow - StaleTransactionRootMinimumAge;
+        var stopwatch = Stopwatch.StartNew();
+        foreach (var candidate in candidates)
+        {
+            if (stopwatch.Elapsed >= StaleTransactionRootSweepBudget) break;
+
+            try
+            {
+                if (!Directory.Exists(candidate)
+                    || Directory.GetLastWriteTimeUtc(candidate) > staleBefore
+                    || IsLiveTransactionRoot(candidate))
+                {
+                    continue;
+                }
+
+                var remaining = StaleTransactionRootSweepBudget - stopwatch.Elapsed;
+                if (remaining <= TimeSpan.Zero) break;
+
+                if (!TryDeleteTransactionRoot(
+                        candidate,
+                        deleteDirectory,
+                        out var failure,
+                        out _,
+                        remaining))
+                {
+                    WriteStaleTransactionSweepWarning(
+                        warningWriter,
+                        candidate,
+                        failure?.Message ?? "delete did not complete");
+                }
+                else
+                {
+                    TryDeleteTransactionLeaseFile(candidate);
+                }
+            }
+            catch (Exception exception)
+            {
+                WriteStaleTransactionSweepWarning(warningWriter, candidate, exception.Message);
+            }
+        }
+    }
+
+    private static bool IsLiveTransactionRoot(string transactionRoot)
+    {
+        var leasePath = TransactionLeasePath(transactionRoot);
+        if (!File.Exists(leasePath)) return false;
+
+        try
+        {
+            using var probe = new FileStream(
+                leasePath,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None);
+            return false;
+        }
+        catch
+        {
+            // An unreadable or locked lease is protected. The sweep must fail
+            // closed rather than risk deleting a live transaction workspace.
+            return true;
+        }
+    }
+
+    private static void WriteStaleTransactionSweepWarning(
+        TextWriter warningWriter,
+        string path,
+        string reason)
+    {
+        try
+        {
+            warningWriter.WriteLine(
+                $"warning: stale claim transaction root '{path}' could not be swept: {reason}");
+        }
+        catch
+        {
+            // A broken warning sink must not change the claim result.
+        }
+    }
+
+    private static string TransactionLeasePath(string transactionRoot) =>
+        transactionRoot + TransactionLeaseSuffix;
+
+    private static void TryDeleteTransactionLeaseFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // A leftover lease marker is swept with its stale transaction root.
+        }
+    }
+
+    private sealed class ClaimTransactionLease : IDisposable
+    {
+        private readonly string path;
+        private FileStream? stream;
+
+        private ClaimTransactionLease(string path, FileStream stream)
+        {
+            this.path = path;
+            this.stream = stream;
+        }
+
+        public static ClaimTransactionLease Create(string transactionRoot)
+        {
+            var path = TransactionLeasePath(transactionRoot);
+            FileStream? stream = null;
+            try
+            {
+                stream = new FileStream(
+                    path,
+                    FileMode.CreateNew,
+                    FileAccess.ReadWrite,
+                    FileShare.None);
+                stream.WriteByte(1);
+                stream.Flush(flushToDisk: true);
+                return new ClaimTransactionLease(path, stream);
+            }
+            catch
+            {
+                stream?.Dispose();
+                TryDeleteTransactionLeaseFile(path);
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            var current = Interlocked.Exchange(ref stream, null);
+            try
+            {
+                current?.Dispose();
+            }
+            catch
+            {
+                // Lease teardown is best-effort and must never mask the
+                // transaction result at the using boundary.
+            }
+            finally
+            {
+                TryDeleteTransactionLeaseFile(path);
+            }
+        }
+    }
+
     private static void CleanupTransactionRoot(
         string transactionRoot,
         bool committed,
         bool tolerateCleanupFailure,
         TextWriter warningWriter,
-        Action<string> deleteDirectory)
+        Action<string> deleteDirectory,
+        Exception? transactionFailure = null)
     {
         if (!Directory.Exists(transactionRoot)) return;
 
@@ -1289,9 +1472,31 @@ internal static class ClaimCommand
             return;
         }
 
-        throw new IOException(
-            $"Could not clean up claim transaction temporary directory '{transactionRoot}' before "
-            + "the claim state was committed.", lastFailure);
+        try
+        {
+            var cleanupDetail = lastFailure?.Message ?? "unknown cleanup failure";
+            if (transactionFailure is not null)
+            {
+                warningWriter.WriteLine(
+                    $"warning: claim transaction failed before commit; the original transaction "
+                    + $"failure is preserved. Best-effort cleanup could not remove temporary "
+                    + $"directory '{transactionRoot}' after {attempts} bounded attempt(s); "
+                    + $"cleanup also failed: {cleanupDetail}. The leftover "
+                    + "path remains under the OS temp root.");
+            }
+            else
+            {
+                warningWriter.WriteLine(
+                    $"warning: claim transaction did not commit; best-effort cleanup could not "
+                    + $"remove temporary directory '{transactionRoot}' after {attempts} bounded "
+                    + "attempt(s); the claim result and exit code are unchanged. The leftover "
+                    + "path remains under the OS temp root.");
+            }
+        }
+        catch
+        {
+            // A broken warning sink must not replace the original transaction
+        }
     }
 
     private static void WriteNoOpCleanupWarning(
@@ -1347,7 +1552,8 @@ internal static class ClaimCommand
         string transactionRoot,
         Action<string> deleteDirectory,
         out Exception? failure,
-        out bool timedOut)
+        out bool timedOut,
+        TimeSpan? timeout = null)
     {
         failure = null;
         timedOut = false;
@@ -1365,12 +1571,13 @@ internal static class ClaimCommand
 
         try
         {
-            if (!deletion.Wait(CleanupAttemptTimeout))
+            var boundedTimeout = timeout ?? CleanupAttemptTimeout;
+            if (!deletion.Wait(boundedTimeout))
             {
                 ObserveFault(deletion);
                 timedOut = true;
                 failure = new TimeoutException(
-                    $"temporary directory deletion exceeded {CleanupAttemptTimeout.TotalMilliseconds:0} ms");
+                    $"temporary directory deletion exceeded {boundedTimeout.TotalMilliseconds:0} ms");
                 return false;
             }
 

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandG679Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandG679Tests.cs
@@ -237,7 +237,7 @@ public sealed class ClaimCommandG679Tests : IDisposable
         string? leftoverPath = null;
         try
         {
-            var exception = Assert.Throws<IOException>(() => ClaimCommand.RunTransaction(
+            var result = ClaimCommand.RunTransaction(
                 repos.SecondClone,
                 new ClaimRequest(
                     ClaimOperation.Acquire,
@@ -255,11 +255,16 @@ public sealed class ClaimCommandG679Tests : IDisposable
                     leftoverPath = path;
                     deleteAttempts++;
                     throw new IOException("injected pre-commit cleanup failure");
-                }));
+                });
 
-            Assert.Contains("before the claim state was committed", exception.Message, StringComparison.Ordinal);
+            Assert.Equal("held", result.Status);
+            Assert.False(result.PushSucceeded);
+            Assert.Equal("alice", result.Holder);
+            Assert.Equal("implementation", result.HolderTeam);
             Assert.Equal(ClaimCommand.CleanupMaxAttempts, deleteAttempts);
-            Assert.Empty(warnings.ToString());
+            Assert.NotNull(leftoverPath);
+            Assert.Contains(leftoverPath!, warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("claim result and exit code are unchanged", warnings.ToString(), StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandTeardownG771Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandTeardownG771Tests.cs
@@ -1,0 +1,496 @@
+using System.Diagnostics;
+using System.Text;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class ClaimCommandTeardownG771Tests
+{
+    [Fact]
+    public void CommittedCleanupFailure_WarnsAndPreservesSuccess_G771()
+    {
+        using var repos = new ClaimRepositories();
+        using var warnings = new StringWriter();
+        var deletedPaths = new List<string>();
+
+        try
+        {
+            var result = ClaimCommand.RunTransaction(
+                repos.FirstClone,
+                Request(ClaimOperation.Acquire, "execution-unit:G771-committed", "alice", "implementation"),
+                warnings,
+                path =>
+                {
+                    deletedPaths.Add(path);
+                    throw new IOException("injected committed cleanup failure");
+                });
+
+            Assert.Equal("acquired", result.Status);
+            Assert.True(result.PushSucceeded);
+            Assert.Equal(0, ExitCode(result));
+            Assert.NotEmpty(deletedPaths);
+            var transactionRoot = deletedPaths[^1];
+            var expectedWarning =
+                $"warning: claim transaction committed successfully, but best-effort cleanup could not remove temporary directory '{transactionRoot}' after 3 bounded attempt(s); the claim result and exit code are unchanged. The leftover path remains under the OS temp root.";
+            Assert.Contains(expectedWarning, warnings.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            foreach (var path in deletedPaths.Distinct(StringComparer.Ordinal)) DeleteIfPresent(path);
+        }
+    }
+
+    [Theory]
+    [InlineData("acquired")]
+    [InlineData("held-by-another")]
+    [InlineData("not-held")]
+    [InlineData("release-by-non-holder")]
+    [InlineData("takeover-mismatch")]
+    public void CleanupFailure_PreservesEveryClaimOutcomeAndExitCode_G771(string outcome)
+    {
+        var working = RunScenario(outcome, failCleanup: false);
+        var failing = RunScenario(outcome, failCleanup: true);
+
+        Assert.Null(working.ErrorMessage);
+        Assert.Null(failing.ErrorMessage);
+        Assert.Equal(working.Status, failing.Status);
+        Assert.Equal(working.PushSucceeded, failing.PushSucceeded);
+        Assert.Equal(working.Holder, failing.Holder);
+        Assert.Equal(working.HolderTeam, failing.HolderTeam);
+        Assert.Equal(working.DisplacedHolder, failing.DisplacedHolder);
+        Assert.Equal(working.Detail, failing.Detail);
+        Assert.Equal(working.HistoryPath, failing.HistoryPath);
+        Assert.Equal(working.TargetRef, failing.TargetRef);
+        Assert.Equal(working.ExitCode, failing.ExitCode);
+        Assert.Equal(outcome == "acquired", failing.PushSucceeded);
+        Assert.Equal(outcome == "acquired" ? 0 : 1, failing.ExitCode);
+        Assert.NotNull(failing.LeftoverPath);
+        Assert.Contains(failing.LeftoverPath!, failing.Warning, StringComparison.Ordinal);
+        Assert.Contains("claim result and exit code are unchanged", failing.Warning, StringComparison.Ordinal);
+        Assert.Contains("OS temp root", failing.Warning, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PreCommitCloneFailure_PreservesOriginalCauseWhenCleanupAlsoFails_G771()
+    {
+        using var repos = new ClaimRepositories();
+        using var warnings = new StringWriter();
+        string? leftoverPath = null;
+
+        try
+        {
+            using (new GitCloneFailureShim())
+            {
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                    ClaimCommand.RunTransaction(
+                        repos.FirstClone,
+                        Request(ClaimOperation.Acquire, "execution-unit:G771-clone", "alice", "implementation"),
+                        warnings,
+                        path =>
+                        {
+                            leftoverPath = path;
+                            throw new IOException("injected cleanup failure");
+                        }));
+
+                Assert.Contains("clone claim transaction workspace", exception.Message, StringComparison.Ordinal);
+                Assert.Contains("injected clone failure", exception.Message, StringComparison.Ordinal);
+                Assert.DoesNotContain("injected cleanup failure", exception.Message, StringComparison.Ordinal);
+                Assert.DoesNotContain("could not remove temporary directory", exception.Message, StringComparison.Ordinal);
+            }
+
+            Assert.NotNull(leftoverPath);
+            Assert.Contains(leftoverPath!, warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("original transaction failure is preserved", warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("cleanup also failed", warnings.ToString(), StringComparison.Ordinal);
+            Assert.Equal(ClaimCommand.CleanupMaxAttempts, CountCleanupAttempts(warnings.ToString()));
+        }
+        finally
+        {
+            if (leftoverPath is not null && Directory.Exists(leftoverPath))
+            {
+                Directory.Delete(leftoverPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void CommittedWarningRemainsByteIdenticalToDocumentation_G771()
+    {
+        const string documentedWarning =
+            "warning: claim transaction committed successfully, but best-effort cleanup could not remove temporary directory '<path>' after 3 bounded attempt(s); the claim result and exit code are unchanged. The leftover path remains under the OS temp root.";
+
+        var english = File.ReadAllText(
+            Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", "en", "09-developer-reference.md"));
+        var japanese = File.ReadAllText(
+            Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", "ja", "09-developer-reference.md"));
+
+        Assert.Contains(documentedWarning, english, StringComparison.Ordinal);
+        Assert.Contains(documentedWarning, japanese, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StaleSweepRemovesOldRootButProtectsLiveTransactionRoot_G771()
+    {
+        using var repos = new ClaimRepositories();
+        var staleRoot = CreateOldTransactionRoot("intent-cli-claim-g771-stale-");
+        var liveRoot = CreateOldTransactionRoot("intent-cli-claim-g771-live-");
+        var liveLeasePath = liveRoot + ".lease";
+        using var liveLease = new FileStream(
+            liveLeasePath,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.None);
+        liveLease.WriteByte(1);
+        liveLease.Flush(flushToDisk: true);
+
+        try
+        {
+            using var warnings = new StringWriter();
+            var result = ClaimCommand.RunTransaction(
+                repos.FirstClone,
+                Request(ClaimOperation.Acquire, "execution-unit:G771-sweep", "alice", "implementation"),
+                warnings,
+                path => Directory.Delete(path, recursive: true));
+
+            Assert.Equal("acquired", result.Status);
+            Assert.False(Directory.Exists(staleRoot));
+            Assert.True(Directory.Exists(liveRoot));
+            Assert.DoesNotContain(staleRoot, warnings.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            liveLease.Dispose();
+            DeleteIfPresent(liveRoot);
+            DeleteIfPresent(liveLeasePath);
+            DeleteIfPresent(staleRoot);
+        }
+    }
+
+    [Fact]
+    public void StaleSweepFailureDoesNotChangeClaimResult_G771()
+    {
+        using var repos = new ClaimRepositories();
+        var staleRoot = CreateOldTransactionRoot("intent-cli-claim-g771-failing-sweep-");
+
+        try
+        {
+            using var warnings = new StringWriter();
+            var result = ClaimCommand.RunTransaction(
+                repos.FirstClone,
+                Request(ClaimOperation.Acquire, "execution-unit:G771-sweep-failure", "alice", "implementation"),
+                warnings,
+                path =>
+                {
+                    if (string.Equals(path, staleRoot, StringComparison.Ordinal))
+                    {
+                        throw new IOException("injected stale sweep failure");
+                    }
+
+                    Directory.Delete(path, recursive: true);
+                });
+
+            Assert.Equal("acquired", result.Status);
+            Assert.True(result.PushSucceeded);
+            Assert.Contains(staleRoot, warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("could not be swept", warnings.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteIfPresent(staleRoot);
+        }
+    }
+
+    [Fact]
+    public void CleanupFailureOnHeldAcquireNeverReportsOwnershipOrPushSuccess_G771()
+    {
+        using var repos = new ClaimRepositories();
+        const string scope = "execution-unit:G771-no-false-success";
+        var existing = ClaimCommand.RunTransaction(
+            repos.FirstClone,
+            Request(ClaimOperation.Acquire, scope, "alice", "implementation"));
+        Assert.Equal("acquired", existing.Status);
+
+        using var warnings = new StringWriter();
+        string? leftoverPath = null;
+        try
+        {
+            var result = ClaimCommand.RunTransaction(
+                repos.FirstClone,
+                Request(ClaimOperation.Acquire, scope, "bob", "review"),
+                warnings,
+                path =>
+                {
+                    leftoverPath = path;
+                    throw new IOException("injected held cleanup failure");
+                });
+
+            Assert.Equal("held", result.Status);
+            Assert.False(result.PushSucceeded);
+            Assert.Null(result.Commit);
+            Assert.Equal("alice", result.Holder);
+            Assert.Equal("implementation", result.HolderTeam);
+            Assert.NotNull(leftoverPath);
+            Assert.Contains(leftoverPath!, warnings.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (leftoverPath is not null && Directory.Exists(leftoverPath))
+            {
+                Directory.Delete(leftoverPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void DocumentationDescribesAllOutcomeCleanupAndStaleSweep_G771()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(root, "docs", "en", "09-developer-reference.md"));
+        var japanese = File.ReadAllText(Path.Combine(root, "docs", "ja", "09-developer-reference.md"));
+
+        Assert.Contains("Cleanup is best-effort on every claim outcome.", english, StringComparison.Ordinal);
+        Assert.Contains("stale transaction roots are swept", english, StringComparison.Ordinal);
+        Assert.Contains("すべての claim outcome", japanese, StringComparison.Ordinal);
+        Assert.Contains("stale transaction root", japanese, StringComparison.Ordinal);
+    }
+
+    private static ScenarioObservation RunScenario(string outcome, bool failCleanup)
+    {
+        using var repos = new ClaimRepositories();
+        var scope = $"execution-unit:G771-{outcome}";
+        if (outcome is "held-by-another" or "release-by-non-holder" or "takeover-mismatch")
+        {
+            var seed = ClaimCommand.RunTransaction(
+                repos.FirstClone,
+                Request(ClaimOperation.Acquire, scope, "alice", "implementation"));
+            Assert.Equal("acquired", seed.Status);
+        }
+
+        var request = outcome switch
+        {
+            "acquired" => Request(ClaimOperation.Acquire, scope, "alice", "implementation"),
+            "held-by-another" => Request(ClaimOperation.Acquire, scope, "bob", "review"),
+            "not-held" => Request(ClaimOperation.Release, scope, "alice", "implementation"),
+            "release-by-non-holder" => Request(ClaimOperation.Release, scope, "bob", "review"),
+            "takeover-mismatch" => new ClaimRequest(
+                ClaimOperation.Takeover,
+                scope,
+                "bob",
+                "review",
+                "operator reassigned",
+                "charlie",
+                true,
+                "json",
+                ClaimCommand.DefaultMaxAttempts),
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
+        };
+
+        using var warnings = new StringWriter();
+        var leftoverPaths = new List<string>();
+        ClaimTransactionResult? result = null;
+        Exception? error = null;
+        try
+        {
+            result = ClaimCommand.RunTransaction(
+                repos.FirstClone,
+                request,
+                warnings,
+                path =>
+                {
+                    leftoverPaths.Add(path);
+                    if (failCleanup)
+                    {
+                        throw new IOException("injected cleanup failure");
+                    }
+
+                    Directory.Delete(path, recursive: true);
+                });
+        }
+        catch (Exception exception)
+        {
+            error = exception;
+        }
+
+        try
+        {
+            foreach (var path in leftoverPaths.Distinct(StringComparer.Ordinal))
+            {
+                if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Test-owned cleanup only.
+        }
+
+        return new ScenarioObservation(
+            result?.Status,
+            result?.PushSucceeded,
+            result?.Holder,
+            result?.HolderTeam,
+            result?.DisplacedHolder,
+            result?.Detail,
+            result?.HistoryPath,
+            result?.TargetRef,
+            result is null ? 1 : ExitCode(result),
+            error?.Message,
+            leftoverPaths.LastOrDefault(),
+            warnings.ToString());
+    }
+
+    private static int ExitCode(ClaimTransactionResult result) =>
+        result.Status is "acquired" or "released" or "taken-over" or "planned" ? 0 : 1;
+
+    private static int CountCleanupAttempts(string warning)
+    {
+        return warning.Contains("after 3 bounded attempt(s)", StringComparison.Ordinal) ? 3 : 0;
+    }
+
+    private static string CreateOldTransactionRoot(string prefix)
+    {
+        var root = Directory.CreateTempSubdirectory(prefix).FullName;
+        File.WriteAllText(Path.Combine(root, "leftover.txt"), "stale transaction root\n");
+        Directory.SetLastWriteTimeUtc(root, DateTime.UtcNow.AddHours(-1));
+        return root;
+    }
+
+    private static void DeleteIfPresent(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        else if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static ClaimRequest Request(
+        ClaimOperation operation,
+        string scope,
+        string actor,
+        string team) =>
+        new(
+            operation,
+            scope,
+            actor,
+            team,
+            operation == ClaimOperation.Acquire ? null : "test reason",
+            operation == ClaimOperation.Takeover ? "charlie" : null,
+            true,
+            "json",
+            ClaimCommand.DefaultMaxAttempts);
+
+    private static int Run(string workdir, string fileName, params string[] arguments)
+    {
+        var info = new ProcessStartInfo(fileName)
+        {
+            WorkingDirectory = workdir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments) info.ArgumentList.Add(argument);
+        using var process = Process.Start(info)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"{fileName} {string.Join(' ', arguments)} failed: {error}");
+        return process.ExitCode;
+    }
+
+    private sealed record ScenarioObservation(
+        string? Status,
+        bool? PushSucceeded,
+        string? Holder,
+        string? HolderTeam,
+        string? DisplacedHolder,
+        string? Detail,
+        string? HistoryPath,
+        string? TargetRef,
+        int ExitCode,
+        string? ErrorMessage,
+        string? LeftoverPath,
+        string Warning);
+
+    private sealed class GitCloneFailureShim : IDisposable
+    {
+        private readonly string originalPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        private readonly string root = Directory.CreateTempSubdirectory("claim-g771-git-shim-").FullName;
+
+        public GitCloneFailureShim()
+        {
+            var wrapper = Path.Combine(root, "git");
+            File.WriteAllText(
+                wrapper,
+                "#!/bin/sh\n"
+                + "if [ \"${1:-}\" = \"clone\" ]; then\n"
+                + "  target=\"\"\n"
+                + "  for arg in \"$@\"; do target=\"$arg\"; done\n"
+                + "  mkdir -p \"$target\"\n"
+                + "  echo \"injected clone failure\" >&2\n"
+                + "  exit 77\n"
+                + "fi\n"
+                + "exec /usr/bin/git \"$@\"\n");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    wrapper,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+
+            Environment.SetEnvironmentVariable("PATH", root + Path.PathSeparator + originalPath);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private sealed class ClaimRepositories : IDisposable
+    {
+        private readonly TempDirectory temp = new("claim-repos-g771-");
+
+        public ClaimRepositories()
+        {
+            Bare = Path.Combine(temp.Path, "origin.git");
+            var seed = Path.Combine(temp.Path, "seed");
+            FirstClone = Path.Combine(temp.Path, "first");
+            Directory.CreateDirectory(Bare);
+            Run(Bare, "git", "init", "--bare", "--quiet");
+            Directory.CreateDirectory(seed);
+            Run(seed, "git", "init", "--quiet", "--initial-branch=main");
+            Run(seed, "git", "config", "user.name", "g771-fixture");
+            Run(seed, "git", "config", "user.email", "g771-fixture@example.invalid");
+            File.WriteAllText(Path.Combine(seed, "README.md"), "g771 fixture\n");
+            Run(seed, "git", "add", "README.md");
+            Run(seed, "git", "commit", "--quiet", "-m", "seed");
+            Run(seed, "git", "remote", "add", "origin", Bare);
+            Run(seed, "git", "push", "--quiet", "-u", "origin", "main");
+            Run(Bare, "git", "symbolic-ref", "HEAD", "refs/heads/main");
+            Run(temp.Path, "git", "clone", "--quiet", Bare, FirstClone);
+        }
+
+        public string Bare { get; }
+        public string FirstClone { get; }
+
+        public void Dispose() => temp.Dispose();
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory(string prefix) => Path = Directory.CreateTempSubdirectory(prefix).FullName;
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION

Closes #1681

Consumer report: #1679.

## Summary

- Preserve every claim outcome, detail, ownership field, and exit code when bounded temporary-root cleanup also fails.
- Preserve the original pre-commit transaction cause and report cleanup failure separately.
- Keep the existing committed warning byte-identical, including the leftover OS-temp path.
- Add a bounded stale-root sweep with exclusive lease markers; live or unreadable leases are protected.
- Document the teardown and stale-root contract in both developer-reference mirrors.

## Verification

- Parent `b111fc644dfca24b911c26eef6bad9c784ad6cd4`: `ClaimCommandTeardownG771Tests` failed 9/12 (cleanup exceptions, lost pre-commit cause, no stale sweep, and no live-root protection); the changed tests pass 12/12.
- Focused G771: `Failed: 0, Passed: 12, Skipped: 0, Total: 12`.
- Adjacent G738/G743/G747/G763/G766/G755 claim suites: `Failed: 0, Passed: 38, Skipped: 0, Total: 38`.
- G613: `Failed: 0, Passed: 6, Skipped: 0, Total: 6`.
- Full Release solution: `Failed: 0, Passed: 5762, Skipped: 1, Total: 5763` (NuGet audit disabled for the offline package smoke subprocesses; both package smoke tests also pass individually under that setting).
- `git diff --check`: clean.

The child selector reported G771 holder none/unheld (`wait`, `source_classification=claim-refused`) and child issue preflight reported `missing-target-declaration`/not actionable; host verification was canonical-unavailable because FETCH_HEAD was sandbox-denied. The supplied authoritative host claim on origin/main (claim commit `44bb82cad7396009b1c413cfa496eb6c62c1a592`, claim file `2f363434fe019cb2def68e6e3f49ffd81559247e9e0cdf3bbfeb96a9e7f1a267.json`) was consumed. No child execution-unit claim or host state was mutated.
