### PR TITLE
G773: repair unreadable supervision history records

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1067,6 +1067,42 @@ command. `stalls.jsonl` and prompt-audit records receive the same per-record
 treatment as cycles, so a damaged secondary history cannot silently erase the
 rest of the team's supervision answer.
 
+### Evidence-preserving unreadable-record repair (G773 — preview-through-1.x)
+
+G773 adds the one explicit write path for damage already named by the G767
+reader:
+
+```bash
+intent-cli notify supervise repair-unreadable --domain <domain> --team <team> \
+  [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
+```
+
+`--dry-run` is the default. It lists every unreadable record with its relative
+file, one-based line number, G767 reason, and source-line byte length, while
+leaving the whole store byte-identical. A clean store is a strict no-op in
+both modes: no live file, quarantine sidecar, or audit is created or replaced,
+and the result is explicitly `nothing-to-repair` rather than a completed
+repair.
+
+With `--write`, the command takes the supervision directory lock, rescans,
+and checks each target live-file length immediately before its atomic rename.
+It copies the exact unreadable byte ranges **verbatim and in order** to a
+per-file `.unreadable.jsonl` quarantine sidecar in the same directory, then
+replaces the live file with exactly its original readable bytes. Before a
+live replacement, concurrent growth makes the operation fail closed with the
+real changed-file cause; the changed live file is not replaced. One parsable
+G768 atomic audit record is appended for each completed write run with the
+file counts, line numbers, timestamp, and writer identity.
+
+Quarantine sidecars are evidence, not history: readers do not return them to
+the live/archive read set. Thus a repaired all-corrupt existing file becomes
+`empty-history` rather than `not-found` or health, and subsequent liveness
+reports zero unreadable records. Archive history follows the same per-file
+quarantine rule, so repair neither changes G744's archive window nor asks
+shrink/archive to repair corruption. This command preserves evidence; it does
+**not reconstruct** what a damaged record once said, and it never repairs on
+read.
+
 ### Atomic per-record supervision history appends (G768 — preview-through-1.x)
 
 Supervision history writes encode each cycle, stall, and prompt-audit JSONL

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -899,6 +899,36 @@ reader は read-only のままで、supervisor や OS lifecycle command を実�
 `stalls.jsonl` と prompt-audit record にも cycles と同じ record 単位の扱いを適用するため、
 secondary history の damage が team の supervision answer の残りを黙って消すことはありません。
 
+### unreadable record を evidence として隔離する repair (G773 — preview-through-1.x)
+
+G773 は、G767 reader がすでに名前付きで示した既存 damage に対する唯一の明示的 write path を
+追加します。
+
+```bash
+intent-cli notify supervise repair-unreadable --domain <domain> --team <team> \
+  [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
+```
+
+default は `--dry-run` です。relative file、1-based line number、G767 の reason、source line の
+byte length をすべて列挙し、store 全体を byte-identical のまま残します。clean store は両 mode で
+strict no-op です。live file、quarantine sidecar、audit の作成・置換はなく、結果は completed repair
+ではなく明示的に `nothing-to-repair` になります。
+
+`--write` では supervision directory lock を取得して再走査し、各 target live file を atomic rename
+する直前に length を再確認します。読めない byte range は同じ directory の file ごとの
+`.unreadable.jsonl` quarantine sidecar へ、順序を保った **verbatim** の bytes としてコピーし、その後
+live file を元の readable bytes だけに置換します。live replacement の直前に concurrent growth を
+検出した場合は、実際に変化した file を示して安全に失敗し、その live file は置換しません。completed
+write run ごとに、file count、line number、timestamp、writer identity を含む 1 つの parsable な
+G768 atomic audit record を追記します。
+
+quarantine sidecar は history ではなく evidence です。reader は live/archive read set に戻しません。
+したがって existing all-corrupt file は repair 後に `not-found` や health ではなく `empty-history` となり、
+次の liveness は unreadable record を 0 件と報告します。archive history にも同じ file 単位の
+quarantine rule を適用するため、G744 の archive window を変更せず、shrink/archive に corruption repair を
+させません。この command は evidence を保存しますが、damaged record がかつて何を述べたかを
+**reconstruct** しません。また read 時に repair することもありません。
+
 ### supervision history の record 単位 append (G768 — preview-through-1.x)
 
 supervision history の cycle、stall、prompt-audit は、1 つの UTF-8 append 操作で

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -85,6 +85,7 @@ internal static class NotifyCommand
         + NotifySuperviseShrinkCommand.Usage + "\n"
         + NotifySuperviseArchiveCommand.Usage + "\n"
         + NotifySuperviseRepairCycleHistoryCommand.Usage + "\n"
+        + NotifySuperviseRepairUnreadableCommand.Usage + "\n"
         + NotifySuperviseInstallCommand.Usage + "\n"
         + NotifySuperviseReconcileCommand.Usage;
 
@@ -152,6 +153,8 @@ internal static class NotifyCommand
                 NotifySuperviseShrinkCommand.Execute(context, args[1..], writer),
             NotifySuperviseRepairCycleHistoryCommand.Operation =>
                 NotifySuperviseRepairCycleHistoryCommand.Execute(context, args[1..], writer),
+            NotifySuperviseRepairUnreadableCommand.Operation =>
+                NotifySuperviseRepairUnreadableCommand.Execute(context, args[1..], writer),
             NotifySuperviseInstallCommand.Operation =>
                 NotifySuperviseInstallCommand.Execute(context, args[1..], writer),
             NotifySuperviseReconcileCommand.ReconcileOperation =>

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
@@ -162,7 +162,7 @@ internal static class NotifySuperviseLivenessCommand
         return $"Read-only liveness: {cycleSummary}{absenceSummary}{noReadableCycleSummary}{corruptionSummary} Scheduler live state=unknown; durable installation evidence={schedulerInstallationEvidence}; the supervisor was not run.";
     }
 
-    private static string ResolveSupervisionArtifactRootPath(CliContext context, string routingRoot)
+    internal static string ResolveSupervisionArtifactRootPath(CliContext context, string routingRoot)
     {
         var configuredRoot = context.Config.Supervision.ArtifactRoot;
         return Path.IsPathRooted(configuredRoot)

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseRepairUnreadableCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseRepairUnreadableCommand.cs
@@ -1,0 +1,250 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G773's deliberate, evidence-preserving recovery path for JSONL records
+/// which G767 readers have already established cannot be parsed.
+/// </summary>
+internal static class NotifySuperviseRepairUnreadableCommand
+{
+    public const string Operation = "repair-unreadable";
+    public const string Usage =
+        "Usage: intent-cli notify supervise repair-unreadable --domain <d> --team <t> "
+        + "[--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]";
+
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(Usage);
+            return 0;
+        }
+
+        if (!TryParse(args, out var options, out var error))
+        {
+            EmitFailure(writer, error, options?.Format ?? FormatMarkdown);
+            writer.WriteLine(Usage);
+            return 1;
+        }
+
+        string routingRoot;
+        string artifactRoot;
+        try
+        {
+            routingRoot = Path.GetFullPath(options.RoutingRoot ?? context.RepoRoot);
+            artifactRoot = options.RoutingRoot is null
+                ? context.ResolveSupervisionArtifactRootPath()
+                : NotifySuperviseLivenessCommand.ResolveSupervisionArtifactRootPath(context, routingRoot);
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException or NotSupportedException)
+        {
+            EmitFailure(writer, $"invalid-routing-root: {exception.Message}", options.Format);
+            return 1;
+        }
+
+        var result = NotifySupervisionStore.RepairUnreadable(
+            artifactRoot,
+            options.Domain,
+            options.Team,
+            options.Write,
+            (NotifyCommand.UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
+            NotifySupervisionWriterIdentity.Current());
+        Emit(writer, options, routingRoot, result);
+        return result.Error is null ? 0 : 1;
+    }
+
+    private static void EmitFailure(TextWriter writer, string error, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(new
+            {
+                operation = "supervise-repair-unreadable",
+                success = false,
+                error,
+            }, JsonOptions));
+            return;
+        }
+
+        writer.WriteLine($"supervise-repair-unreadable-failed: {error}");
+    }
+
+    private static void Emit(
+        TextWriter writer,
+        RepairUnreadableOptions options,
+        string routingRoot,
+        NotifySupervisionRepairUnreadableResult result)
+    {
+        var repairState = ResolveRepairState(options.Write, result);
+        var payload = new
+        {
+            operation = "supervise-repair-unreadable",
+            routing_root = routingRoot,
+            domain = options.Domain,
+            team = options.Team,
+            command_mode = options.Write ? "write" : "dry-run",
+            repair_state = repairState,
+            applied = result.Applied,
+            would_repair = result.WouldRepair,
+            directory = result.Directory,
+            unreadable_record_count = result.UnreadableRecords.Count,
+            unreadable_records = result.UnreadableRecords,
+            files = result.Files,
+            audit_path = result.AuditPath,
+            audit = result.Audit,
+            quarantine_guarantee = "Unreadable line byte ranges are moved verbatim and in order to per-file sidecars before their live read-path bytes are replaced.",
+            limitation = "The repair preserves corruption as evidence and does not reconstruct what damaged records once said.",
+            error = result.Error,
+            summary = BuildSummary(options.Write, result),
+        };
+
+        if (string.Equals(options.Format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(payload, JsonOptions));
+            return;
+        }
+
+        writer.WriteLine("# notify supervise repair-unreadable");
+        writer.WriteLine();
+        writer.WriteLine($"- command mode: {(options.Write ? "write" : "dry-run")}");
+        writer.WriteLine($"- repair state: {repairState}");
+        writer.WriteLine($"- directory: `{result.Directory}`");
+        writer.WriteLine($"- unreadable records: {result.UnreadableRecords.Count}");
+        foreach (var record in result.UnreadableRecords)
+        {
+            writer.WriteLine($"- unreadable record: `{record.File}` line {record.Line} ({record.Reason}; {record.ByteLength} bytes)");
+        }
+        foreach (var file in result.Files)
+        {
+            writer.WriteLine($"- file: `{file.File}` → `{file.QuarantineFile}`; bytes {file.BeforeLiveBytes} → {file.AfterLiveBytes}; quarantined {file.QuarantinedBytes}; lines {string.Join(",", file.LineNumbers)}");
+        }
+        if (result.AuditPath is not null)
+        {
+            writer.WriteLine($"- audit path: `{result.AuditPath}`");
+        }
+        writer.WriteLine("- guarantee: unreadable line bytes are quarantined verbatim and in order before the live read path is rewritten.");
+        writer.WriteLine("- limitation: this preserves evidence and does not reconstruct damaged records.");
+        writer.WriteLine($"- summary: {BuildSummary(options.Write, result)}");
+        if (result.Error is not null)
+        {
+            writer.WriteLine($"- error: {result.Error}");
+        }
+    }
+
+    private static string ResolveRepairState(bool write, NotifySupervisionRepairUnreadableResult result) =>
+        result.Error is not null
+            ? "failed"
+            : !result.WouldRepair
+                ? "nothing-to-repair"
+                : write && result.Applied
+                    ? "completed-repair"
+                    : "would-repair";
+
+    private static string BuildSummary(bool write, NotifySupervisionRepairUnreadableResult result) =>
+        result.Error is not null
+            ? $"Unreadable supervision repair failed closed: {result.Error}"
+            : !result.WouldRepair
+                ? "Nothing to repair: the supervision store was left byte-for-byte and identity unchanged."
+                : write && result.Applied
+                    ? $"Completed evidence-preserving repair for {result.UnreadableRecords.Count} unreadable record(s); live readers now consume only readable bytes."
+                    : $"Dry-run would quarantine {result.UnreadableRecords.Count} unreadable record(s) verbatim and rewrite only their live files' readable bytes.";
+
+    private static bool TryParse(string[] args, out RepairUnreadableOptions options, out string error)
+    {
+        string? domain = null;
+        string? team = null;
+        string? routingRoot = null;
+        var write = false;
+        var format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--domain":
+                    if (!ReadValue(args, ref index, "--domain", out domain, out error)) return Fail(out options);
+                    break;
+                case "--team":
+                    if (!ReadValue(args, ref index, "--team", out team, out error)) return Fail(out options);
+                    break;
+                case "--routing-root":
+                    if (!ReadValue(args, ref index, "--routing-root", out routingRoot, out error)) return Fail(out options);
+                    break;
+                case "--write": write = true; break;
+                case "--dry-run": write = false; break;
+                case "--format":
+                    if (!ReadValue(args, ref index, "--format", out format, out error)) return Fail(out options);
+                    if (format is not FormatJson and not FormatMarkdown)
+                    {
+                        error = "--format must be markdown or json.";
+                        return Fail(out options);
+                    }
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return Fail(out options);
+            }
+        }
+
+        if (!IsSafeIdentity(domain) || !IsSafeIdentity(team))
+        {
+            error = "--domain and --team are required safe identity values.";
+            return Fail(out options);
+        }
+
+        options = new RepairUnreadableOptions(domain!, team!, routingRoot, write, format!);
+        return true;
+    }
+
+    private static bool ReadValue(
+        string[] args,
+        ref int index,
+        string argument,
+        out string? value,
+        out string error)
+    {
+        if (++index >= args.Length || string.IsNullOrWhiteSpace(args[index]))
+        {
+            value = null;
+            error = $"{argument} requires a value.";
+            return false;
+        }
+
+        value = args[index];
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool IsSafeIdentity(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && value.All(character => char.IsAsciiLetterOrDigit(character) || character is '.' or '_' or ':' or '-');
+
+    private static bool Fail(out RepairUnreadableOptions options)
+    {
+        options = null!;
+        return false;
+    }
+
+    private sealed record RepairUnreadableOptions(
+        string Domain,
+        string Team,
+        string? RoutingRoot,
+        bool Write,
+        string Format);
+}

--- a/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
@@ -23,6 +23,7 @@ internal static class NotifySupervisionStore
     public const string ShrinkAuditFileName = "shrink-audit.jsonl";
     public const string ShrinkTransactionFileName = "shrink-transaction.json";
     public const string RepairUnreadableAuditFileName = "repair-unreadable-audit.jsonl";
+    public const string RepairUnreadableTransactionFileName = "repair-unreadable-transaction.json";
     public const string CycleArchiveDirectoryName = "cycles-archive";
     public const string ArchiveTransactionFileName = "archive-transaction.json";
     public const string LocalIgnoreFileName = ".gitignore";
@@ -38,6 +39,8 @@ internal static class NotifySupervisionStore
     private const string ArchiveTransactionSchema = "intent-cli.supervision-archive-transaction/v1";
     private const string ArchiveTransactionStagePrefix = ".archive-transaction-";
     private const string RepairUnreadableAuditSchema = "intent-cli.supervision-repair-unreadable/v1";
+    private const string RepairUnreadableTransactionSchema = "intent-cli.supervision-repair-unreadable-transaction/v1";
+    private const string RepairUnreadableTransactionStagePrefix = ".repair-unreadable-transaction-";
     internal const string EvidenceSchema = "intent-cli.supervision-evidence/v1";
     internal const string HerdrRegistrationEvidenceKey = "recorded-herdr-seat-registration";
     internal const string HerdrRegistrationDefinition =
@@ -61,6 +64,7 @@ internal static class NotifySupervisionStore
     internal static Action<NotifySupervisionShrinkFaultPoint>? ShrinkFaultInjector { get; set; }
     internal static Action<NotifySupervisionArchiveFaultPoint>? ArchiveFaultInjector { get; set; }
     internal static Action? RepairUnreadableBeforeLengthRecheck { get; set; }
+    internal static Action<NotifySupervisionRepairUnreadableFaultPoint>? RepairUnreadableFaultInjector { get; set; }
 
     public static string ResolveDirectory(string artifactRoot, string domain, string team)
     {
@@ -1149,9 +1153,17 @@ internal static class NotifySupervisionStore
             // A clean store must remain a strict no-op, including in write
             // mode. Scan before opening the lock so an otherwise untouched
             // directory never gains a lock, sidecar, audit, or replacement.
+            var transactionPath = Path.Combine(directory, RepairUnreadableTransactionFileName);
             var initialPlans = PlanUnreadableRepairs(directory);
-            if (initialPlans.Count == 0)
+            if (!write)
             {
+                if (File.Exists(transactionPath))
+                {
+                    return NotifySupervisionRepairUnreadableResult.Failure(
+                        directory,
+                        "repair-unreadable-recovery-pending: a prior repair transaction requires --write to recover safely.");
+                }
+
                 return NotifySupervisionRepairUnreadableResult.FromPlans(
                     directory: directory,
                     applied: false,
@@ -1160,7 +1172,7 @@ internal static class NotifySupervisionStore
                     error: null);
             }
 
-            if (!write)
+            if (initialPlans.Count == 0 && !File.Exists(transactionPath))
             {
                 return NotifySupervisionRepairUnreadableResult.FromPlans(
                     directory: directory,
@@ -1173,108 +1185,71 @@ internal static class NotifySupervisionStore
             lock (Sync)
             {
                 using var directoryLock = AcquireDirectoryLock(directory, createDirectory: false);
-                var plans = PlanUnreadableRepairs(directory);
-                if (plans.Count == 0)
+                var transaction = ReadRepairUnreadableTransaction(directory);
+                if (transaction is null)
                 {
-                    return NotifySupervisionRepairUnreadableResult.FromPlans(
-                        directory: directory,
-                        applied: false,
-                        plans: plans,
-                        audit: null,
-                        error: null);
+                    var plans = PlanUnreadableRepairs(directory);
+                    if (plans.Count == 0)
+                    {
+                        return NotifySupervisionRepairUnreadableResult.FromPlans(
+                            directory: directory,
+                            applied: false,
+                            plans: plans,
+                            audit: null,
+                            error: null);
+                    }
+
+                    // The G768 directory lock coordinates current writers, but a
+                    // pre-G768 writer can append without it. The immediate length
+                    // check below is therefore a separate fail-closed boundary.
+                    RepairUnreadableBeforeLengthRecheck?.Invoke();
+
+                    foreach (var plan in plans)
+                    {
+                        if (!HasExpectedFileLength(plan.LivePath, plan.BeforeLiveBytes)
+                            || !string.Equals(
+                                HashFileOrNull(plan.LivePath),
+                                plan.BeforeLiveSha256,
+                                StringComparison.Ordinal))
+                        {
+                            return NotifySupervisionRepairUnreadableResult.FromPlans(
+                                directory: directory,
+                                applied: false,
+                                plans: plans,
+                                audit: null,
+                                error: BuildConcurrentGrowthError(plan));
+                        }
+
+                        if (!HasExpectedOptionalFileLength(
+                                plan.QuarantinePath,
+                                plan.QuarantineExisted,
+                                plan.BeforeQuarantineBytes)
+                            || !string.Equals(
+                                HashFileOrNull(plan.QuarantinePath),
+                                plan.BeforeQuarantineSha256,
+                                StringComparison.Ordinal))
+                        {
+                            return NotifySupervisionRepairUnreadableResult.FromPlans(
+                                directory: directory,
+                                applied: false,
+                                plans: plans,
+                                audit: null,
+                                error: $"repair-unreadable-quarantine-changed: '{plan.RelativeQuarantinePath}' changed while the repair was prepared; no live file was replaced.");
+                        }
+                    }
+
+                    transaction = PrepareRepairUnreadableTransaction(
+                        directory,
+                        plans,
+                        occurredAt,
+                        writer);
                 }
 
-                // The G768 directory lock coordinates current writers, but a
-                // pre-G768 writer can append without it. The immediate length
-                // check below is therefore a separate fail-closed boundary.
-                RepairUnreadableBeforeLengthRecheck?.Invoke();
-
-                foreach (var plan in plans)
-                {
-                    if (!HasExpectedFileLength(plan.LivePath, plan.BeforeLiveBytes))
-                    {
-                        return NotifySupervisionRepairUnreadableResult.FromPlans(
-                            directory: directory,
-                            applied: false,
-                            plans: plans,
-                            audit: null,
-                            error: BuildConcurrentGrowthError(plan));
-                    }
-
-                    if (!HasExpectedOptionalFileLength(
-                            plan.QuarantinePath,
-                            plan.QuarantineExisted,
-                            plan.BeforeQuarantineBytes))
-                    {
-                        return NotifySupervisionRepairUnreadableResult.FromPlans(
-                            directory: directory,
-                            applied: false,
-                            plans: plans,
-                            audit: null,
-                            error: $"repair-unreadable-quarantine-changed: '{plan.RelativeQuarantinePath}' changed while the repair was prepared; no live file was replaced.");
-                    }
-                }
-
-                foreach (var plan in plans)
-                {
-                    // Evidence reaches the quarantine before the source is
-                    // removed from the live read path. Its appended suffix is
-                    // exactly the original unreadable byte ranges, in order.
-                    ReplaceBytesAtomically(
-                        plan.QuarantinePath,
-                        ConcatBytes(plan.ExistingQuarantineBytes, plan.RemovedBytes));
-
-                    // This check deliberately sits immediately before the
-                    // live-file rename. A concurrent growth leaves the live
-                    // file as-is and returns its real failure cause.
-                    if (!HasExpectedFileLength(plan.LivePath, plan.BeforeLiveBytes))
-                    {
-                        return NotifySupervisionRepairUnreadableResult.FromPlans(
-                            directory: directory,
-                            applied: false,
-                            plans: plans,
-                            audit: null,
-                            error: BuildConcurrentGrowthError(plan));
-                    }
-
-                    ReplaceBytesAtomically(plan.LivePath, plan.ReadableBytes);
-                    if (!File.ReadAllBytes(plan.LivePath).AsSpan().SequenceEqual(plan.ReadableBytes))
-                    {
-                        return NotifySupervisionRepairUnreadableResult.FromPlans(
-                            directory: directory,
-                            applied: false,
-                            plans: plans,
-                            audit: null,
-                            error: $"repair-unreadable-verification-failed: rewritten live file '{plan.RelativePath}' did not match its readable bytes.");
-                    }
-                }
-
-                var audit = new NotifySupervisionRepairUnreadableAudit
-                {
-                    Schema = RepairUnreadableAuditSchema,
-                    Operation = "repair-unreadable",
-                    Outcome = "completed",
-                    OccurredAt = occurredAt.ToUniversalTime(),
-                    Writer = writer,
-                    UnreadableRecordCount = plans.Sum(plan => plan.UnreadableRecords.Count),
-                    Files = plans.Select(plan => new NotifySupervisionRepairUnreadableAuditFile
-                    {
-                        File = plan.RelativePath,
-                        QuarantineFile = plan.RelativeQuarantinePath,
-                        BeforeLiveBytes = plan.BeforeLiveBytes,
-                        AfterLiveBytes = plan.ReadableBytes.LongLength,
-                        QuarantinedBytes = plan.RemovedBytes.LongLength,
-                        UnreadableRecordCount = plan.UnreadableRecords.Count,
-                        LineNumbers = plan.UnreadableRecords.Select(record => record.Line).ToArray(),
-                    }).ToArray(),
-                };
-                AppendRepairUnreadableAudit(directory, audit);
-                return NotifySupervisionRepairUnreadableResult.FromPlans(
-                    directory: directory,
-                    applied: true,
-                    plans: plans,
-                    audit: audit,
-                    error: null);
+                var audit = ExecuteRepairUnreadableTransaction(directory, transaction);
+                return NotifySupervisionRepairUnreadableResult.FromTransaction(
+                    directory,
+                    transaction,
+                    audit);
             }
         }
         catch (Exception exception) when (
@@ -1361,12 +1336,16 @@ internal static class NotifySupervisionStore
             QuarantinePath = quarantinePath,
             RelativeQuarantinePath = GetRelativeSupervisionPath(directory, quarantinePath),
             BeforeLiveBytes = original.LongLength,
+            BeforeLiveSha256 = HashBytes(original),
             ReadableBytes = ConcatBytes(readable),
             RemovedBytes = ConcatBytes(removed),
             QuarantineExisted = File.Exists(quarantinePath),
             BeforeQuarantineBytes = File.Exists(quarantinePath)
                 ? new FileInfo(quarantinePath).Length
                 : 0,
+            BeforeQuarantineSha256 = File.Exists(quarantinePath)
+                ? HashFileOrNull(quarantinePath)
+                : null,
             ExistingQuarantineBytes = File.Exists(quarantinePath)
                 ? File.ReadAllBytes(quarantinePath)
                 : [],
@@ -1510,6 +1489,393 @@ internal static class NotifySupervisionStore
         AtomicAppendWriter.Append(
             auditPath,
             Utf8NoBom.GetBytes(JsonSerializer.Serialize(audit, JsonOptions) + Environment.NewLine));
+    }
+
+    private static NotifySupervisionRepairUnreadableTransaction PrepareRepairUnreadableTransaction(
+        string directory,
+        IReadOnlyList<NotifySupervisionUnreadableRepairPlan> plans,
+        DateTimeOffset occurredAt,
+        NotifySupervisionWriterIdentity writer)
+    {
+        var transactionId = Guid.NewGuid().ToString("N");
+        var stageDirectoryName = RepairUnreadableTransactionStagePrefix + transactionId;
+        var stageDirectory = Path.Combine(directory, stageDirectoryName);
+        Directory.CreateDirectory(stageDirectory);
+
+        try
+        {
+            var transactionFiles = new List<NotifySupervisionRepairUnreadableTransactionFile>();
+            foreach (var plan in plans)
+            {
+                StageRepairUnreadableReplacement(
+                    plan.QuarantinePath,
+                    plan.RelativeQuarantinePath,
+                    ConcatBytes(plan.ExistingQuarantineBytes, plan.RemovedBytes),
+                    plan.BeforeQuarantineSha256,
+                    plan.BeforeQuarantineBytes,
+                    isLive: false);
+                StageRepairUnreadableReplacement(
+                    plan.LivePath,
+                    plan.RelativePath,
+                    plan.ReadableBytes,
+                    plan.BeforeLiveSha256,
+                    plan.BeforeLiveBytes,
+                    isLive: true);
+            }
+
+            var audit = BuildRepairUnreadableAudit(plans, transactionId, occurredAt, writer);
+            var transaction = new NotifySupervisionRepairUnreadableTransaction
+            {
+                Schema = RepairUnreadableTransactionSchema,
+                TransactionId = transactionId,
+                Phase = "prepared",
+                StageDirectory = stageDirectoryName,
+                Files = transactionFiles,
+                Plans = plans.Select(plan => new NotifySupervisionRepairUnreadableTransactionPlan
+                {
+                    RelativePath = plan.RelativePath,
+                    RelativeQuarantinePath = plan.RelativeQuarantinePath,
+                    BeforeLiveBytes = plan.BeforeLiveBytes,
+                    AfterLiveBytes = plan.ReadableBytes.LongLength,
+                    QuarantinedBytes = plan.RemovedBytes.LongLength,
+                    UnreadableRecords = plan.UnreadableRecords,
+                }).ToArray(),
+                Audit = audit,
+            };
+            PersistRepairUnreadableTransaction(directory, transaction);
+            return transaction;
+
+            void StageRepairUnreadableReplacement(
+                string targetPath,
+                string targetName,
+                byte[] replacement,
+                string? beforeSha256,
+                long beforeBytes,
+                bool isLive)
+            {
+                if (!string.Equals(HashFileOrNull(targetPath), beforeSha256, StringComparison.Ordinal))
+                {
+                    throw new InvalidDataException(
+                        $"repair-unreadable-transaction-conflict: target '{targetName}' changed before transaction publication.");
+                }
+
+                var stageName = $"replacement-{transactionFiles.Count:D4}.jsonl";
+                var stagePath = ResolveRepairUnreadableStagePath(stageDirectory, stageName);
+                ReplaceBytesAtomically(stagePath, replacement);
+                transactionFiles.Add(new NotifySupervisionRepairUnreadableTransactionFile
+                {
+                    TargetName = targetName,
+                    StageName = stageName,
+                    BeforeSha256 = beforeSha256,
+                    AfterSha256 = HashBytes(replacement),
+                    BeforeBytes = beforeBytes,
+                    IsLive = isLive,
+                });
+            }
+        }
+        catch
+        {
+            TryDeleteRepairUnreadableStageDirectory(stageDirectory);
+            throw;
+        }
+    }
+
+    private static NotifySupervisionRepairUnreadableAudit ExecuteRepairUnreadableTransaction(
+        string directory,
+        NotifySupervisionRepairUnreadableTransaction transaction)
+    {
+        var stageDirectory = ResolveRepairUnreadableStageDirectory(directory, transaction);
+        if (RepairUnreadableAuditContainsTransaction(directory, transaction.TransactionId))
+        {
+            TryDeleteRepairUnreadableTransactionArtifacts(directory, transaction);
+            return transaction.Audit;
+        }
+
+        foreach (var transactionFile in transaction.Files)
+        {
+            var targetPath = ResolveRepairUnreadableTransactionTargetPath(directory, transactionFile.TargetName);
+            var currentHash = HashFileOrNull(targetPath);
+            if (string.Equals(currentHash, transactionFile.AfterSha256, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!string.Equals(currentHash, transactionFile.BeforeSha256, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    $"repair-unreadable-transaction-conflict: target '{transactionFile.TargetName}' changed outside the pending transaction.");
+            }
+
+            var stagePath = ResolveRepairUnreadableStagePath(stageDirectory, transactionFile.StageName);
+            if (!File.Exists(stagePath))
+            {
+                throw new InvalidDataException(
+                    $"repair-unreadable-transaction-invalid: staged replacement for '{transactionFile.TargetName}' is missing.");
+            }
+
+            var replacement = File.ReadAllBytes(stagePath);
+            if (!string.Equals(HashBytes(replacement), transactionFile.AfterSha256, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    $"repair-unreadable-transaction-invalid: staged replacement for '{transactionFile.TargetName}' is unreadable or corrupt.");
+            }
+
+            if (transactionFile.IsLive
+                && (!HasExpectedFileLength(targetPath, transactionFile.BeforeBytes)
+                    || !string.Equals(
+                        HashFileOrNull(targetPath),
+                        transactionFile.BeforeSha256,
+                        StringComparison.Ordinal)))
+            {
+                throw new InvalidDataException(
+                    $"repair-unreadable-race-detected: live file '{transactionFile.TargetName}' changed before its replacement; no live file was replaced.");
+            }
+
+            ReplaceBytesAtomically(targetPath, replacement);
+            if (!string.Equals(HashFileOrNull(targetPath), transactionFile.AfterSha256, StringComparison.Ordinal))
+            {
+                throw new InvalidDataException(
+                    $"repair-unreadable-verification-failed: replacement target '{transactionFile.TargetName}' did not match its staged bytes.");
+            }
+
+            transaction = transaction with { Phase = $"replaced:{transactionFile.TargetName}" };
+            PersistRepairUnreadableTransaction(directory, transaction);
+            if (!transactionFile.IsLive)
+            {
+                RepairUnreadableFaultInjector?.Invoke(
+                    NotifySupervisionRepairUnreadableFaultPoint.AfterQuarantinePublication);
+            }
+        }
+
+        transaction = transaction with { Phase = "audit-pending" };
+        PersistRepairUnreadableTransaction(directory, transaction);
+        if (!RepairUnreadableAuditContainsTransaction(directory, transaction.TransactionId))
+        {
+            RepairUnreadableFaultInjector?.Invoke(
+                NotifySupervisionRepairUnreadableFaultPoint.BeforeAuditAppend);
+            try
+            {
+                AppendRepairUnreadableAudit(directory, transaction.Audit);
+            }
+            catch when (RepairUnreadableAuditContainsTransaction(directory, transaction.TransactionId))
+            {
+                // Atomic append reached durable storage before a late writer
+                // error; the transaction id makes retry convergence exact.
+            }
+        }
+
+        if (!RepairUnreadableAuditContainsTransaction(directory, transaction.TransactionId))
+        {
+            throw new InvalidDataException(
+                $"repair-unreadable-audit-verification-failed: transaction '{transaction.TransactionId}' was not found after append.");
+        }
+
+        TryDeleteRepairUnreadableTransactionArtifacts(directory, transaction);
+        return transaction.Audit;
+    }
+
+    private static NotifySupervisionRepairUnreadableAudit BuildRepairUnreadableAudit(
+        IReadOnlyList<NotifySupervisionUnreadableRepairPlan> plans,
+        string transactionId,
+        DateTimeOffset occurredAt,
+        NotifySupervisionWriterIdentity writer) => new()
+    {
+        Schema = RepairUnreadableAuditSchema,
+        TransactionId = transactionId,
+        Operation = "repair-unreadable",
+        Outcome = "completed",
+        OccurredAt = occurredAt.ToUniversalTime(),
+        Writer = writer,
+        UnreadableRecordCount = plans.Sum(plan => plan.UnreadableRecords.Count),
+        Files = plans.Select(plan => new NotifySupervisionRepairUnreadableAuditFile
+        {
+            File = plan.RelativePath,
+            QuarantineFile = plan.RelativeQuarantinePath,
+            BeforeLiveBytes = plan.BeforeLiveBytes,
+            AfterLiveBytes = plan.ReadableBytes.LongLength,
+            QuarantinedBytes = plan.RemovedBytes.LongLength,
+            UnreadableRecordCount = plan.UnreadableRecords.Count,
+            LineNumbers = plan.UnreadableRecords.Select(record => record.Line).ToArray(),
+        }).ToArray(),
+    };
+
+    private static NotifySupervisionRepairUnreadableTransaction? ReadRepairUnreadableTransaction(
+        string directory)
+    {
+        var transactionPath = Path.Combine(directory, RepairUnreadableTransactionFileName);
+        if (!File.Exists(transactionPath))
+        {
+            return null;
+        }
+
+        var transaction = JsonSerializer.Deserialize<NotifySupervisionRepairUnreadableTransaction>(
+            File.ReadAllText(transactionPath, Utf8NoBom),
+            JsonOptions)
+            ?? throw new InvalidDataException("repair-unreadable-transaction-invalid: the transaction journal was empty.");
+        if (!string.Equals(transaction.Schema, RepairUnreadableTransactionSchema, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"repair-unreadable-transaction-invalid: unsupported transaction schema '{transaction.Schema}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(transaction.TransactionId)
+            || !string.Equals(transaction.Audit.TransactionId, transaction.TransactionId, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException("repair-unreadable-transaction-invalid: transaction and audit identity did not match.");
+        }
+
+        _ = ResolveRepairUnreadableStageDirectory(directory, transaction);
+        return transaction;
+    }
+
+    private static void PersistRepairUnreadableTransaction(
+        string directory,
+        NotifySupervisionRepairUnreadableTransaction transaction) =>
+        ReplaceBytesAtomically(
+            Path.Combine(directory, RepairUnreadableTransactionFileName),
+            Utf8NoBom.GetBytes(JsonSerializer.Serialize(transaction, JsonOptions) + Environment.NewLine));
+
+    private static bool RepairUnreadableAuditContainsTransaction(string directory, string transactionId)
+    {
+        var auditPath = Path.Combine(directory, RepairUnreadableAuditFileName);
+        if (!File.Exists(auditPath))
+        {
+            return false;
+        }
+
+        foreach (var line in File.ReadLines(auditPath))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(line);
+                if (document.RootElement.TryGetProperty("transaction_id", out var value)
+                    && string.Equals(value.GetString(), transactionId, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            catch (JsonException)
+            {
+                // The transaction journal remains authoritative when a prior
+                // process stopped during an audit append.
+            }
+        }
+
+        return false;
+    }
+
+    private static string ResolveRepairUnreadableStageDirectory(
+        string directory,
+        NotifySupervisionRepairUnreadableTransaction transaction)
+    {
+        if (!transaction.StageDirectory.StartsWith(RepairUnreadableTransactionStagePrefix, StringComparison.Ordinal)
+            || Path.GetFileName(transaction.StageDirectory) != transaction.StageDirectory)
+        {
+            throw new InvalidDataException("repair-unreadable-transaction-invalid: transaction stage directory is unsafe.");
+        }
+
+        return Path.Combine(directory, transaction.StageDirectory);
+    }
+
+    private static string ResolveRepairUnreadableStagePath(string stageDirectory, string stageName)
+    {
+        if (string.IsNullOrWhiteSpace(stageName)
+            || Path.GetFileName(stageName) != stageName
+            || stageName is "." or "..")
+        {
+            throw new InvalidDataException("repair-unreadable-transaction-invalid: transaction stage path is unsafe.");
+        }
+
+        return Path.Combine(stageDirectory, stageName);
+    }
+
+    private static string ResolveRepairUnreadableTransactionTargetPath(string directory, string targetName)
+    {
+        var normalizedTarget = targetName.Replace('\\', '/');
+        if (string.IsNullOrWhiteSpace(normalizedTarget)
+            || Path.IsPathRooted(normalizedTarget)
+            || normalizedTarget.Split('/').Any(segment => segment is "" or "." or ".."))
+        {
+            throw new InvalidDataException("repair-unreadable-transaction-invalid: transaction target path is unsafe.");
+        }
+
+        var livePaths = ResolveCycleHistoryPaths(directory).ToList();
+        var stallsPath = Path.Combine(directory, StallFileName);
+        if (File.Exists(stallsPath))
+        {
+            livePaths.Add(stallsPath);
+        }
+
+        var allowedTargets = livePaths
+            .SelectMany(path => new[]
+            {
+                GetRelativeSupervisionPath(directory, path),
+                GetRelativeSupervisionPath(directory, ResolveUnreadableQuarantinePath(path)),
+            })
+            .ToHashSet(StringComparer.Ordinal);
+        if (!allowedTargets.Contains(normalizedTarget))
+        {
+            throw new InvalidDataException(
+                $"repair-unreadable-transaction-invalid: unsupported transaction target '{targetName}'.");
+        }
+
+        var targetPath = Path.GetFullPath(Path.Combine(directory, normalizedTarget));
+        var directoryPrefix = Path.GetFullPath(directory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        if (!targetPath.StartsWith(directoryPrefix, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException("repair-unreadable-transaction-invalid: transaction target escaped the supervision directory.");
+        }
+
+        return targetPath;
+    }
+
+    private static void TryDeleteRepairUnreadableTransactionArtifacts(
+        string directory,
+        NotifySupervisionRepairUnreadableTransaction transaction)
+    {
+        try
+        {
+            var stageDirectory = ResolveRepairUnreadableStageDirectory(directory, transaction);
+            if (Directory.Exists(stageDirectory))
+            {
+                Directory.Delete(stageDirectory, recursive: true);
+            }
+
+            var transactionPath = Path.Combine(directory, RepairUnreadableTransactionFileName);
+            if (File.Exists(transactionPath))
+            {
+                File.Delete(transactionPath);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // The completed audit is durable. Leave the journal for the next
+            // explicit repair invocation to clean up without adding a second
+            // completed record.
+        }
+    }
+
+    private static void TryDeleteRepairUnreadableStageDirectory(string stageDirectory)
+    {
+        try
+        {
+            if (Directory.Exists(stageDirectory))
+            {
+                Directory.Delete(stageDirectory, recursive: true);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // A failed preparation left no published live or quarantine bytes;
+            // a later explicit repair can remove this isolated staging residue.
+        }
     }
 
     private static NotifySupervisionArchivePlan PlanCycleArchive(
@@ -2475,6 +2841,9 @@ internal static class NotifySupervisionStore
     private static string HashContent(string content) =>
         Convert.ToHexString(SHA256.HashData(Utf8NoBom.GetBytes(content)));
 
+    private static string HashBytes(byte[] content) =>
+        Convert.ToHexString(SHA256.HashData(content));
+
     private static string? HashFileOrNull(string path) =>
         File.Exists(path)
             ? Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path)))
@@ -3302,6 +3671,32 @@ internal sealed record NotifySupervisionRepairUnreadableResult
         Audit = audit,
         Error = error,
     };
+
+    public static NotifySupervisionRepairUnreadableResult FromTransaction(
+        string directory,
+        NotifySupervisionRepairUnreadableTransaction transaction,
+        NotifySupervisionRepairUnreadableAudit audit) => new()
+    {
+        Applied = true,
+        WouldRepair = transaction.Plans.Count > 0,
+        Directory = directory,
+        Files = transaction.Plans.Select(plan => new NotifySupervisionRepairUnreadableFile
+        {
+            File = plan.RelativePath,
+            QuarantineFile = plan.RelativeQuarantinePath,
+            BeforeLiveBytes = plan.BeforeLiveBytes,
+            AfterLiveBytes = plan.AfterLiveBytes,
+            QuarantinedBytes = plan.QuarantinedBytes,
+            UnreadableRecordCount = plan.UnreadableRecords.Count,
+            LineNumbers = plan.UnreadableRecords.Select(record => record.Line).ToArray(),
+        }).ToArray(),
+        UnreadableRecords = transaction.Plans.SelectMany(plan => plan.UnreadableRecords)
+            .OrderBy(record => record.File, StringComparer.Ordinal)
+            .ThenBy(record => record.Line)
+            .ToArray(),
+        AuditPath = Path.Combine(directory, NotifySupervisionStore.RepairUnreadableAuditFileName),
+        Audit = audit,
+    };
 }
 
 internal sealed record NotifySupervisionRepairUnreadableFile
@@ -3327,6 +3722,7 @@ internal sealed record NotifySupervisionRepairUnreadableRecord
 internal sealed record NotifySupervisionRepairUnreadableAudit
 {
     [JsonPropertyName("schema")] public required string Schema { get; init; }
+    [JsonPropertyName("transaction_id")] public required string TransactionId { get; init; }
     [JsonPropertyName("operation")] public required string Operation { get; init; }
     [JsonPropertyName("outcome")] public required string Outcome { get; init; }
     [JsonPropertyName("occurred_at")] public required DateTimeOffset OccurredAt { get; init; }
@@ -3346,6 +3742,37 @@ internal sealed record NotifySupervisionRepairUnreadableAuditFile
     [JsonPropertyName("line_numbers")] public required IReadOnlyList<int> LineNumbers { get; init; }
 }
 
+internal sealed record NotifySupervisionRepairUnreadableTransaction
+{
+    [JsonPropertyName("schema")] public required string Schema { get; init; }
+    [JsonPropertyName("transaction_id")] public required string TransactionId { get; init; }
+    [JsonPropertyName("phase")] public required string Phase { get; init; }
+    [JsonPropertyName("stage_directory")] public required string StageDirectory { get; init; }
+    [JsonPropertyName("files")] public required IReadOnlyList<NotifySupervisionRepairUnreadableTransactionFile> Files { get; init; }
+    [JsonPropertyName("plans")] public required IReadOnlyList<NotifySupervisionRepairUnreadableTransactionPlan> Plans { get; init; }
+    [JsonPropertyName("audit")] public required NotifySupervisionRepairUnreadableAudit Audit { get; init; }
+}
+
+internal sealed record NotifySupervisionRepairUnreadableTransactionFile
+{
+    [JsonPropertyName("target")] public required string TargetName { get; init; }
+    [JsonPropertyName("stage")] public required string StageName { get; init; }
+    [JsonPropertyName("before_sha256")] public string? BeforeSha256 { get; init; }
+    [JsonPropertyName("after_sha256")] public required string AfterSha256 { get; init; }
+    [JsonPropertyName("before_bytes")] public required long BeforeBytes { get; init; }
+    [JsonPropertyName("is_live")] public required bool IsLive { get; init; }
+}
+
+internal sealed record NotifySupervisionRepairUnreadableTransactionPlan
+{
+    [JsonPropertyName("file")] public required string RelativePath { get; init; }
+    [JsonPropertyName("quarantine_file")] public required string RelativeQuarantinePath { get; init; }
+    [JsonPropertyName("before_live_bytes")] public required long BeforeLiveBytes { get; init; }
+    [JsonPropertyName("after_live_bytes")] public required long AfterLiveBytes { get; init; }
+    [JsonPropertyName("quarantined_bytes")] public required long QuarantinedBytes { get; init; }
+    [JsonPropertyName("unreadable_records")] public required IReadOnlyList<NotifySupervisionRepairUnreadableRecord> UnreadableRecords { get; init; }
+}
+
 internal sealed record NotifySupervisionUnreadableRepairPlan
 {
     public required string LivePath { get; init; }
@@ -3353,10 +3780,12 @@ internal sealed record NotifySupervisionUnreadableRepairPlan
     public required string QuarantinePath { get; init; }
     public required string RelativeQuarantinePath { get; init; }
     public required long BeforeLiveBytes { get; init; }
+    public required string BeforeLiveSha256 { get; init; }
     public required byte[] ReadableBytes { get; init; }
     public required byte[] RemovedBytes { get; init; }
     public required bool QuarantineExisted { get; init; }
     public required long BeforeQuarantineBytes { get; init; }
+    public string? BeforeQuarantineSha256 { get; init; }
     public required byte[] ExistingQuarantineBytes { get; init; }
     public required IReadOnlyList<NotifySupervisionRepairUnreadableRecord> UnreadableRecords { get; init; }
 }
@@ -3366,6 +3795,12 @@ internal sealed record NotifySupervisionRawLine
     public required int Line { get; init; }
     public required byte[] ContentBytes { get; init; }
     public required byte[] FullBytes { get; init; }
+}
+
+internal enum NotifySupervisionRepairUnreadableFaultPoint
+{
+    AfterQuarantinePublication,
+    BeforeAuditAppend,
 }
 
 internal sealed record NotifySupervisionUnreadableRecord

--- a/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
@@ -22,6 +22,7 @@ internal static class NotifySupervisionStore
     public const string EvidenceDefinitionsFileName = "evidence-definitions.json";
     public const string ShrinkAuditFileName = "shrink-audit.jsonl";
     public const string ShrinkTransactionFileName = "shrink-transaction.json";
+    public const string RepairUnreadableAuditFileName = "repair-unreadable-audit.jsonl";
     public const string CycleArchiveDirectoryName = "cycles-archive";
     public const string ArchiveTransactionFileName = "archive-transaction.json";
     public const string LocalIgnoreFileName = ".gitignore";
@@ -36,6 +37,7 @@ internal static class NotifySupervisionStore
     private const string ShrinkTransactionStagePrefix = ".shrink-transaction-";
     private const string ArchiveTransactionSchema = "intent-cli.supervision-archive-transaction/v1";
     private const string ArchiveTransactionStagePrefix = ".archive-transaction-";
+    private const string RepairUnreadableAuditSchema = "intent-cli.supervision-repair-unreadable/v1";
     internal const string EvidenceSchema = "intent-cli.supervision-evidence/v1";
     internal const string HerdrRegistrationEvidenceKey = "recorded-herdr-seat-registration";
     internal const string HerdrRegistrationDefinition =
@@ -58,6 +60,7 @@ internal static class NotifySupervisionStore
     internal static Func<string, string, NotifySupervisionWriteResult>? WriteOverride { get; set; }
     internal static Action<NotifySupervisionShrinkFaultPoint>? ShrinkFaultInjector { get; set; }
     internal static Action<NotifySupervisionArchiveFaultPoint>? ArchiveFaultInjector { get; set; }
+    internal static Action? RepairUnreadableBeforeLengthRecheck { get; set; }
 
     public static string ResolveDirectory(string artifactRoot, string domain, string team)
     {
@@ -660,6 +663,7 @@ internal static class NotifySupervisionStore
         {
             paths.AddRange(
                 Directory.EnumerateFiles(archiveDirectory, "*.jsonl", SearchOption.TopDirectoryOnly)
+                    .Where(path => !IsUnreadableQuarantinePath(path))
                     .OrderBy(path => Path.GetFileName(path), StringComparer.Ordinal));
         }
 
@@ -671,6 +675,9 @@ internal static class NotifySupervisionStore
 
         return paths;
     }
+
+    private static bool IsUnreadableQuarantinePath(string path) =>
+        Path.GetFileName(path).EndsWith(".unreadable.jsonl", StringComparison.Ordinal);
 
     private static IReadOnlyList<NotifySupervisionStallRecord> ReadStalls(
         string path,
@@ -770,34 +777,48 @@ internal static class NotifySupervisionStore
         ICollection<NotifySupervisionUnreadableRecord> unreadableRecords,
         out NotifySupervisionEvent? entry)
     {
+        if (TryParseSupervisionEvent(line, out entry, out var reason))
+        {
+            return true;
+        }
+
+        AddUnreadableRecord(
+            path,
+            directory,
+            lineNumber,
+            component,
+            reason!,
+            unreadableRecords);
+        return false;
+    }
+
+    /// <summary>
+    /// G767's single record-level tolerance model. Readers and G773's
+    /// explicit repair scan both use this parser so a line is never named
+    /// unreadable by one surface and silently kept by the other.
+    /// </summary>
+    private static bool TryParseSupervisionEvent(
+        string line,
+        out NotifySupervisionEvent? entry,
+        out string? reason)
+    {
         try
         {
             entry = JsonSerializer.Deserialize<NotifySupervisionEvent>(line, JsonOptions);
             if (entry is null)
             {
-                AddUnreadableRecord(
-                    path,
-                    directory,
-                    lineNumber,
-                    component,
-                    "empty-event",
-                    unreadableRecords);
+                reason = "empty-event";
                 return false;
             }
 
             if (string.IsNullOrWhiteSpace(entry.Kind))
             {
-                AddUnreadableRecord(
-                    path,
-                    directory,
-                    lineNumber,
-                    component,
-                    "missing-event-kind",
-                    unreadableRecords);
                 entry = null;
+                reason = "missing-event-kind";
                 return false;
             }
 
+            reason = null;
             return true;
         }
         catch (JsonException)
@@ -805,13 +826,7 @@ internal static class NotifySupervisionStore
             // Match shrink's degrade-and-report shape: preserve the rest of
             // the append-only file and expose the exact unreadable line.
             entry = null;
-            AddUnreadableRecord(
-                path,
-                directory,
-                lineNumber,
-                component,
-                "invalid-json",
-                unreadableRecords);
+            reason = "invalid-json";
             return false;
         }
     }
@@ -1099,6 +1114,402 @@ internal static class NotifySupervisionStore
                 return NotifySupervisionArchiveResult.Failure(directory, liveWindowDays, exception.Message);
             }
         }
+    }
+
+    /// <summary>
+    /// G773's explicit, evidence-preserving repair. The normal readers remain
+    /// read-only and continue to name corruption; only this route moves the
+    /// exact unreadable byte ranges out of their read paths.
+    /// </summary>
+    internal static NotifySupervisionRepairUnreadableResult RepairUnreadable(
+        string artifactRoot,
+        string domain,
+        string team,
+        bool write,
+        DateTimeOffset occurredAt,
+        NotifySupervisionWriterIdentity writer)
+    {
+        string directory;
+        try
+        {
+            directory = ResolveDirectory(artifactRoot, domain, team);
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            return NotifySupervisionRepairUnreadableResult.Failure(artifactRoot, exception.Message);
+        }
+
+        if (!Directory.Exists(directory))
+        {
+            return NotifySupervisionRepairUnreadableResult.Empty(directory);
+        }
+
+        try
+        {
+            // A clean store must remain a strict no-op, including in write
+            // mode. Scan before opening the lock so an otherwise untouched
+            // directory never gains a lock, sidecar, audit, or replacement.
+            var initialPlans = PlanUnreadableRepairs(directory);
+            if (initialPlans.Count == 0)
+            {
+                return NotifySupervisionRepairUnreadableResult.FromPlans(
+                    directory: directory,
+                    applied: false,
+                    plans: initialPlans,
+                    audit: null,
+                    error: null);
+            }
+
+            if (!write)
+            {
+                return NotifySupervisionRepairUnreadableResult.FromPlans(
+                    directory: directory,
+                    applied: false,
+                    plans: initialPlans,
+                    audit: null,
+                    error: null);
+            }
+
+            lock (Sync)
+            {
+                using var directoryLock = AcquireDirectoryLock(directory, createDirectory: false);
+                var plans = PlanUnreadableRepairs(directory);
+                if (plans.Count == 0)
+                {
+                    return NotifySupervisionRepairUnreadableResult.FromPlans(
+                        directory: directory,
+                        applied: false,
+                        plans: plans,
+                        audit: null,
+                        error: null);
+                }
+
+                // The G768 directory lock coordinates current writers, but a
+                // pre-G768 writer can append without it. The immediate length
+                // check below is therefore a separate fail-closed boundary.
+                RepairUnreadableBeforeLengthRecheck?.Invoke();
+
+                foreach (var plan in plans)
+                {
+                    if (!HasExpectedFileLength(plan.LivePath, plan.BeforeLiveBytes))
+                    {
+                        return NotifySupervisionRepairUnreadableResult.FromPlans(
+                            directory: directory,
+                            applied: false,
+                            plans: plans,
+                            audit: null,
+                            error: BuildConcurrentGrowthError(plan));
+                    }
+
+                    if (!HasExpectedOptionalFileLength(
+                            plan.QuarantinePath,
+                            plan.QuarantineExisted,
+                            plan.BeforeQuarantineBytes))
+                    {
+                        return NotifySupervisionRepairUnreadableResult.FromPlans(
+                            directory: directory,
+                            applied: false,
+                            plans: plans,
+                            audit: null,
+                            error: $"repair-unreadable-quarantine-changed: '{plan.RelativeQuarantinePath}' changed while the repair was prepared; no live file was replaced.");
+                    }
+                }
+
+                foreach (var plan in plans)
+                {
+                    // Evidence reaches the quarantine before the source is
+                    // removed from the live read path. Its appended suffix is
+                    // exactly the original unreadable byte ranges, in order.
+                    ReplaceBytesAtomically(
+                        plan.QuarantinePath,
+                        ConcatBytes(plan.ExistingQuarantineBytes, plan.RemovedBytes));
+
+                    // This check deliberately sits immediately before the
+                    // live-file rename. A concurrent growth leaves the live
+                    // file as-is and returns its real failure cause.
+                    if (!HasExpectedFileLength(plan.LivePath, plan.BeforeLiveBytes))
+                    {
+                        return NotifySupervisionRepairUnreadableResult.FromPlans(
+                            directory: directory,
+                            applied: false,
+                            plans: plans,
+                            audit: null,
+                            error: BuildConcurrentGrowthError(plan));
+                    }
+
+                    ReplaceBytesAtomically(plan.LivePath, plan.ReadableBytes);
+                    if (!File.ReadAllBytes(plan.LivePath).AsSpan().SequenceEqual(plan.ReadableBytes))
+                    {
+                        return NotifySupervisionRepairUnreadableResult.FromPlans(
+                            directory: directory,
+                            applied: false,
+                            plans: plans,
+                            audit: null,
+                            error: $"repair-unreadable-verification-failed: rewritten live file '{plan.RelativePath}' did not match its readable bytes.");
+                    }
+                }
+
+                var audit = new NotifySupervisionRepairUnreadableAudit
+                {
+                    Schema = RepairUnreadableAuditSchema,
+                    Operation = "repair-unreadable",
+                    Outcome = "completed",
+                    OccurredAt = occurredAt.ToUniversalTime(),
+                    Writer = writer,
+                    UnreadableRecordCount = plans.Sum(plan => plan.UnreadableRecords.Count),
+                    Files = plans.Select(plan => new NotifySupervisionRepairUnreadableAuditFile
+                    {
+                        File = plan.RelativePath,
+                        QuarantineFile = plan.RelativeQuarantinePath,
+                        BeforeLiveBytes = plan.BeforeLiveBytes,
+                        AfterLiveBytes = plan.ReadableBytes.LongLength,
+                        QuarantinedBytes = plan.RemovedBytes.LongLength,
+                        UnreadableRecordCount = plan.UnreadableRecords.Count,
+                        LineNumbers = plan.UnreadableRecords.Select(record => record.Line).ToArray(),
+                    }).ToArray(),
+                };
+                AppendRepairUnreadableAudit(directory, audit);
+                return NotifySupervisionRepairUnreadableResult.FromPlans(
+                    directory: directory,
+                    applied: true,
+                    plans: plans,
+                    audit: audit,
+                    error: null);
+            }
+        }
+        catch (Exception exception) when (
+            exception is IOException
+                or UnauthorizedAccessException
+                or ArgumentException
+                or JsonException
+                or InvalidDataException)
+        {
+            return NotifySupervisionRepairUnreadableResult.Failure(directory, exception.Message);
+        }
+    }
+
+    private static IReadOnlyList<NotifySupervisionUnreadableRepairPlan> PlanUnreadableRepairs(
+        string directory)
+    {
+        var plans = new List<NotifySupervisionUnreadableRepairPlan>();
+        foreach (var cyclePath in ResolveCycleHistoryPaths(directory))
+        {
+            var plan = PlanUnreadableRepairFile(cyclePath, directory, "cycles");
+            if (plan is not null)
+            {
+                plans.Add(plan);
+            }
+        }
+
+        var stallsPath = Path.Combine(directory, StallFileName);
+        if (File.Exists(stallsPath))
+        {
+            var plan = PlanUnreadableRepairFile(stallsPath, directory, "stalls");
+            if (plan is not null)
+            {
+                plans.Add(plan);
+            }
+        }
+
+        return plans
+            .OrderBy(plan => plan.RelativePath, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static NotifySupervisionUnreadableRepairPlan? PlanUnreadableRepairFile(
+        string path,
+        string directory,
+        string component)
+    {
+        var original = File.ReadAllBytes(path);
+        var readable = new List<byte[]>();
+        var removed = new List<byte[]>();
+        var records = new List<NotifySupervisionRepairUnreadableRecord>();
+        var relativePath = GetRelativeSupervisionPath(directory, path);
+
+        foreach (var line in EnumerateJsonlLines(original))
+        {
+            var text = Utf8NoBom.GetString(line.ContentBytes);
+            if (string.IsNullOrWhiteSpace(text)
+                || !TryDescribeUnreadableRepairLine(component, text, out var reason))
+            {
+                readable.Add(line.FullBytes);
+                continue;
+            }
+
+            records.Add(new NotifySupervisionRepairUnreadableRecord
+            {
+                Component = component,
+                File = relativePath,
+                Line = line.Line,
+                Reason = reason!,
+                ByteLength = line.ContentBytes.Length,
+            });
+            removed.Add(line.FullBytes);
+        }
+
+        if (records.Count == 0)
+        {
+            return null;
+        }
+
+        var quarantinePath = ResolveUnreadableQuarantinePath(path);
+        return new NotifySupervisionUnreadableRepairPlan
+        {
+            LivePath = path,
+            RelativePath = relativePath,
+            QuarantinePath = quarantinePath,
+            RelativeQuarantinePath = GetRelativeSupervisionPath(directory, quarantinePath),
+            BeforeLiveBytes = original.LongLength,
+            ReadableBytes = ConcatBytes(readable),
+            RemovedBytes = ConcatBytes(removed),
+            QuarantineExisted = File.Exists(quarantinePath),
+            BeforeQuarantineBytes = File.Exists(quarantinePath)
+                ? new FileInfo(quarantinePath).Length
+                : 0,
+            ExistingQuarantineBytes = File.Exists(quarantinePath)
+                ? File.ReadAllBytes(quarantinePath)
+                : [],
+            UnreadableRecords = records,
+        };
+    }
+
+    private static bool TryDescribeUnreadableRepairLine(
+        string component,
+        string line,
+        out string? reason)
+    {
+        if (!TryParseSupervisionEvent(line, out var entry, out reason))
+        {
+            return true;
+        }
+
+        if (string.Equals(component, "cycles", StringComparison.Ordinal))
+        {
+            if (string.Equals(entry!.Kind, "cycle", StringComparison.Ordinal)
+                && entry.Cycle is null)
+            {
+                reason = "missing-cycle-payload";
+                return true;
+            }
+
+            if (string.Equals(entry.Kind, "prompt-audit", StringComparison.Ordinal)
+                && entry.PromptAudit is null)
+            {
+                reason = "missing-prompt-audit-payload";
+                return true;
+            }
+        }
+        else if (string.Equals(component, "stalls", StringComparison.Ordinal))
+        {
+            if (string.Equals(entry!.Kind, "open", StringComparison.Ordinal)
+                && entry.Stall is null)
+            {
+                reason = "missing-stall-payload";
+                return true;
+            }
+
+            if (string.Equals(entry.Kind, "clear", StringComparison.Ordinal)
+                && entry.Key is null)
+            {
+                reason = "missing-stall-key";
+                return true;
+            }
+        }
+
+        reason = null;
+        return false;
+    }
+
+    private static IEnumerable<NotifySupervisionRawLine> EnumerateJsonlLines(byte[] content)
+    {
+        var start = 0;
+        var lineNumber = 1;
+        while (start < content.Length)
+        {
+            var contentEnd = start;
+            while (contentEnd < content.Length && content[contentEnd] is not (byte)'\r' and not (byte)'\n')
+            {
+                contentEnd++;
+            }
+
+            var end = contentEnd;
+            if (end < content.Length && content[end] == (byte)'\r')
+            {
+                end++;
+                if (end < content.Length && content[end] == (byte)'\n')
+                {
+                    end++;
+                }
+            }
+            else if (end < content.Length && content[end] == (byte)'\n')
+            {
+                end++;
+            }
+
+            yield return new NotifySupervisionRawLine
+            {
+                Line = lineNumber++,
+                ContentBytes = content[start..contentEnd],
+                FullBytes = content[start..end],
+            };
+            start = end;
+        }
+    }
+
+    private static string ResolveUnreadableQuarantinePath(string path) =>
+        Path.Combine(
+            Path.GetDirectoryName(path)!,
+            Path.GetFileNameWithoutExtension(path) + ".unreadable.jsonl");
+
+    private static string GetRelativeSupervisionPath(string directory, string path) =>
+        Path.GetRelativePath(directory, path)
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/');
+
+    private static bool HasExpectedFileLength(string path, long expectedLength) =>
+        File.Exists(path) && new FileInfo(path).Length == expectedLength;
+
+    private static bool HasExpectedOptionalFileLength(
+        string path,
+        bool expectedExists,
+        long expectedLength) =>
+        File.Exists(path) == expectedExists
+        && (!expectedExists || new FileInfo(path).Length == expectedLength);
+
+    private static string BuildConcurrentGrowthError(NotifySupervisionUnreadableRepairPlan plan)
+    {
+        var observedLength = File.Exists(plan.LivePath)
+            ? new FileInfo(plan.LivePath).Length.ToString(CultureInfo.InvariantCulture)
+            : "<missing>";
+        return $"repair-unreadable-race-detected: live file '{plan.RelativePath}' changed after scan from {plan.BeforeLiveBytes.ToString(CultureInfo.InvariantCulture)} bytes to {observedLength}; no live file was replaced.";
+    }
+
+    private static byte[] ConcatBytes(IEnumerable<byte[]> parts)
+    {
+        var materialized = parts.ToArray();
+        var total = checked(materialized.Sum(part => part.Length));
+        var content = new byte[total];
+        var offset = 0;
+        foreach (var part in materialized)
+        {
+            Buffer.BlockCopy(part, 0, content, offset, part.Length);
+            offset += part.Length;
+        }
+
+        return content;
+    }
+
+    private static byte[] ConcatBytes(byte[] first, byte[] second) => ConcatBytes([first, second]);
+
+    private static void AppendRepairUnreadableAudit(
+        string directory,
+        NotifySupervisionRepairUnreadableAudit audit)
+    {
+        var auditPath = Path.Combine(directory, RepairUnreadableAuditFileName);
+        AtomicAppendWriter.Append(
+            auditPath,
+            Utf8NoBom.GetBytes(JsonSerializer.Serialize(audit, JsonOptions) + Environment.NewLine));
     }
 
     private static NotifySupervisionArchivePlan PlanCycleArchive(
@@ -2119,6 +2530,37 @@ internal static class NotifySupervisionStore
         }
     }
 
+    private static void ReplaceBytesAtomically(string path, byte[] content)
+    {
+        var directory = Path.GetDirectoryName(path)!;
+        var temporary = Path.Combine(
+            directory,
+            $".{Path.GetFileName(path)}.{Environment.ProcessId}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            using (var stream = new FileStream(
+                temporary,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 4096,
+                options: FileOptions.WriteThrough))
+            {
+                stream.Write(content, 0, content.Length);
+                stream.Flush(flushToDisk: true);
+            }
+
+            File.Move(temporary, path, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temporary))
+            {
+                File.Delete(temporary);
+            }
+        }
+    }
+
     private static FileStream AcquireDirectoryLock(string directory, bool createDirectory)
     {
         if (createDirectory)
@@ -2800,6 +3242,130 @@ internal sealed record NotifySupervisionReadResult
     public required IReadOnlyList<NotifyPromptAudit> PromptAudits { get; init; }
     public IReadOnlyList<NotifySupervisionUnreadableRecord> UnreadableRecords { get; init; } = [];
     public string? Error { get; init; }
+}
+
+internal sealed record NotifySupervisionRepairUnreadableResult
+{
+    public required bool Applied { get; init; }
+    public required bool WouldRepair { get; init; }
+    public required string Directory { get; init; }
+    public required IReadOnlyList<NotifySupervisionRepairUnreadableFile> Files { get; init; }
+    public required IReadOnlyList<NotifySupervisionRepairUnreadableRecord> UnreadableRecords { get; init; }
+    public string? AuditPath { get; init; }
+    public NotifySupervisionRepairUnreadableAudit? Audit { get; init; }
+    public string? Error { get; init; }
+
+    public static NotifySupervisionRepairUnreadableResult Empty(string directory) => new()
+    {
+        Applied = false,
+        WouldRepair = false,
+        Directory = directory,
+        Files = [],
+        UnreadableRecords = [],
+    };
+
+    public static NotifySupervisionRepairUnreadableResult Failure(string directory, string error) => new()
+    {
+        Applied = false,
+        WouldRepair = false,
+        Directory = directory,
+        Files = [],
+        UnreadableRecords = [],
+        Error = error,
+    };
+
+    public static NotifySupervisionRepairUnreadableResult FromPlans(
+        string directory,
+        bool applied,
+        IReadOnlyList<NotifySupervisionUnreadableRepairPlan> plans,
+        NotifySupervisionRepairUnreadableAudit? audit,
+        string? error) => new()
+    {
+        Applied = applied,
+        WouldRepair = plans.Count > 0,
+        Directory = directory,
+        Files = plans.Select(plan => new NotifySupervisionRepairUnreadableFile
+        {
+            File = plan.RelativePath,
+            QuarantineFile = plan.RelativeQuarantinePath,
+            BeforeLiveBytes = plan.BeforeLiveBytes,
+            AfterLiveBytes = plan.ReadableBytes.LongLength,
+            QuarantinedBytes = plan.RemovedBytes.LongLength,
+            UnreadableRecordCount = plan.UnreadableRecords.Count,
+            LineNumbers = plan.UnreadableRecords.Select(record => record.Line).ToArray(),
+        }).ToArray(),
+        UnreadableRecords = plans.SelectMany(plan => plan.UnreadableRecords)
+            .OrderBy(record => record.File, StringComparer.Ordinal)
+            .ThenBy(record => record.Line)
+            .ToArray(),
+        AuditPath = audit is null ? null : Path.Combine(directory, NotifySupervisionStore.RepairUnreadableAuditFileName),
+        Audit = audit,
+        Error = error,
+    };
+}
+
+internal sealed record NotifySupervisionRepairUnreadableFile
+{
+    [JsonPropertyName("file")] public required string File { get; init; }
+    [JsonPropertyName("quarantine_file")] public required string QuarantineFile { get; init; }
+    [JsonPropertyName("before_live_bytes")] public required long BeforeLiveBytes { get; init; }
+    [JsonPropertyName("after_live_bytes")] public required long AfterLiveBytes { get; init; }
+    [JsonPropertyName("quarantined_bytes")] public required long QuarantinedBytes { get; init; }
+    [JsonPropertyName("unreadable_record_count")] public required int UnreadableRecordCount { get; init; }
+    [JsonPropertyName("line_numbers")] public required IReadOnlyList<int> LineNumbers { get; init; }
+}
+
+internal sealed record NotifySupervisionRepairUnreadableRecord
+{
+    [JsonPropertyName("component")] public required string Component { get; init; }
+    [JsonPropertyName("file")] public required string File { get; init; }
+    [JsonPropertyName("line")] public required int Line { get; init; }
+    [JsonPropertyName("reason")] public required string Reason { get; init; }
+    [JsonPropertyName("byte_length")] public required int ByteLength { get; init; }
+}
+
+internal sealed record NotifySupervisionRepairUnreadableAudit
+{
+    [JsonPropertyName("schema")] public required string Schema { get; init; }
+    [JsonPropertyName("operation")] public required string Operation { get; init; }
+    [JsonPropertyName("outcome")] public required string Outcome { get; init; }
+    [JsonPropertyName("occurred_at")] public required DateTimeOffset OccurredAt { get; init; }
+    [JsonPropertyName("writer")] public required NotifySupervisionWriterIdentity Writer { get; init; }
+    [JsonPropertyName("unreadable_record_count")] public required int UnreadableRecordCount { get; init; }
+    [JsonPropertyName("files")] public required IReadOnlyList<NotifySupervisionRepairUnreadableAuditFile> Files { get; init; }
+}
+
+internal sealed record NotifySupervisionRepairUnreadableAuditFile
+{
+    [JsonPropertyName("file")] public required string File { get; init; }
+    [JsonPropertyName("quarantine_file")] public required string QuarantineFile { get; init; }
+    [JsonPropertyName("before_live_bytes")] public required long BeforeLiveBytes { get; init; }
+    [JsonPropertyName("after_live_bytes")] public required long AfterLiveBytes { get; init; }
+    [JsonPropertyName("quarantined_bytes")] public required long QuarantinedBytes { get; init; }
+    [JsonPropertyName("unreadable_record_count")] public required int UnreadableRecordCount { get; init; }
+    [JsonPropertyName("line_numbers")] public required IReadOnlyList<int> LineNumbers { get; init; }
+}
+
+internal sealed record NotifySupervisionUnreadableRepairPlan
+{
+    public required string LivePath { get; init; }
+    public required string RelativePath { get; init; }
+    public required string QuarantinePath { get; init; }
+    public required string RelativeQuarantinePath { get; init; }
+    public required long BeforeLiveBytes { get; init; }
+    public required byte[] ReadableBytes { get; init; }
+    public required byte[] RemovedBytes { get; init; }
+    public required bool QuarantineExisted { get; init; }
+    public required long BeforeQuarantineBytes { get; init; }
+    public required byte[] ExistingQuarantineBytes { get; init; }
+    public required IReadOnlyList<NotifySupervisionRepairUnreadableRecord> UnreadableRecords { get; init; }
+}
+
+internal sealed record NotifySupervisionRawLine
+{
+    public required int Line { get; init; }
+    public required byte[] ContentBytes { get; init; }
+    public required byte[] FullBytes { get; init; }
 }
 
 internal sealed record NotifySupervisionUnreadableRecord

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionRepairUnreadableG773Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionRepairUnreadableG773Tests.cs
@@ -1,0 +1,349 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G773: unreadable supervision records are quarantined as exact evidence by
+/// an explicit operator command. The normal reader remains read-only.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifySupervisionRepairUnreadableG773Tests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private readonly string root = Path.Combine(
+        Path.GetTempPath(),
+        "intent-g773-" + Guid.NewGuid().ToString("N"));
+    private readonly DateTimeOffset now = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+    public NotifySupervisionRepairUnreadableG773Tests()
+    {
+        Directory.CreateDirectory(root);
+        NotifyCommand.UtcNowFactory = () => now;
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.UtcNowFactory = null;
+        NotifySupervisionStore.RepairUnreadableBeforeLengthRecheck = null;
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DefaultDryRun_EnumeratesEveryUnreadableLineAndLeavesStoreByteIdentical_G773()
+    {
+        var cyclePath = WriteCycle("readable-cycle");
+        var unreadable = Encoding.UTF8.GetBytes("{bad-cycle-json}\r\n");
+        File.AppendAllBytes(cyclePath, unreadable);
+        var before = SnapshotDirectory(TeamDirectory());
+
+        var (exitCode, output) = RunRepair();
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(output);
+        var payload = document.RootElement;
+        Assert.Equal("supervise-repair-unreadable", payload.GetProperty("operation").GetString());
+        Assert.Equal("dry-run", payload.GetProperty("command_mode").GetString());
+        Assert.Equal("would-repair", payload.GetProperty("repair_state").GetString());
+        var unreadableRecord = Assert.Single(payload.GetProperty("unreadable_records").EnumerateArray());
+        Assert.Equal("cycles.jsonl", unreadableRecord.GetProperty("file").GetString());
+        Assert.Equal(2, unreadableRecord.GetProperty("line").GetInt32());
+        Assert.Equal("invalid-json", unreadableRecord.GetProperty("reason").GetString());
+        Assert.Equal("{bad-cycle-json}"u8.Length, unreadableRecord.GetProperty("byte_length").GetInt32());
+        Assert.Equal(before, SnapshotDirectory(TeamDirectory()));
+        Assert.False(File.Exists(Path.Combine(TeamDirectory(), "cycles.unreadable.jsonl")));
+        Assert.False(File.Exists(Path.Combine(TeamDirectory(), "repair-unreadable-audit.jsonl")));
+    }
+
+    [Fact]
+    public void Write_QuarantinesExactBytes_RewritesOnlyReadableBytes_AndClearsLivenessEvidence_G773()
+    {
+        var cyclePath = WriteCycle("readable-cycle");
+        var stallPath = NotifySupervisionStore.ResolveStallPath(ArtifactRoot(), Domain, Team);
+        Assert.True(NotifySupervisionStore.OpenStall(
+            stallPath,
+            new NotifySupervisionStallRecord
+            {
+                Key = "readable-stall",
+                Kind = "g773",
+                OwnerRole = "implementation",
+                Source = "g773-test",
+                Summary = "readable",
+                SurfacedAt = now,
+            },
+            write: true).Applied);
+        var cyclesBefore = File.ReadAllBytes(cyclePath);
+        var stallsBefore = File.ReadAllBytes(stallPath);
+        var unreadableCycle = Encoding.UTF8.GetBytes("{bad-cycle-json}\n");
+        var unreadableStall = Encoding.UTF8.GetBytes("{bad-stall-json}\r\n");
+        var existingCycleQuarantine = Encoding.UTF8.GetBytes("{prior-quarantine-evidence}\n");
+        File.WriteAllBytes(
+            Path.Combine(TeamDirectory(), "cycles.unreadable.jsonl"),
+            existingCycleQuarantine);
+        File.AppendAllBytes(cyclePath, unreadableCycle);
+        File.AppendAllBytes(stallPath, unreadableStall);
+
+        var (exitCode, output) = RunRepair("--write");
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(output);
+        var payload = document.RootElement;
+        Assert.Equal("write", payload.GetProperty("command_mode").GetString());
+        Assert.Equal("completed-repair", payload.GetProperty("repair_state").GetString());
+        Assert.True(payload.GetProperty("applied").GetBoolean());
+        Assert.Equal(2, payload.GetProperty("unreadable_record_count").GetInt32());
+        Assert.Equal(cyclesBefore, File.ReadAllBytes(cyclePath));
+        Assert.Equal(stallsBefore, File.ReadAllBytes(stallPath));
+        Assert.Equal(
+            existingCycleQuarantine.Concat(unreadableCycle).ToArray(),
+            File.ReadAllBytes(Path.Combine(TeamDirectory(), "cycles.unreadable.jsonl")));
+        Assert.Equal(unreadableStall, File.ReadAllBytes(Path.Combine(TeamDirectory(), "stalls.unreadable.jsonl")));
+
+        var auditPath = Path.Combine(TeamDirectory(), "repair-unreadable-audit.jsonl");
+        var auditLine = Assert.Single(File.ReadAllLines(auditPath));
+        using var audit = JsonDocument.Parse(auditLine);
+        Assert.Equal("intent-cli.supervision-repair-unreadable/v1", audit.RootElement.GetProperty("schema").GetString());
+        Assert.Equal("repair-unreadable", audit.RootElement.GetProperty("operation").GetString());
+        Assert.Equal("completed", audit.RootElement.GetProperty("outcome").GetString());
+        Assert.Equal(2, audit.RootElement.GetProperty("unreadable_record_count").GetInt32());
+        Assert.True(audit.RootElement.TryGetProperty("writer", out _));
+        Assert.True(audit.RootElement.TryGetProperty("occurred_at", out _));
+        Assert.Equal(2, audit.RootElement.GetProperty("files").GetArrayLength());
+
+        var (livenessExit, livenessOutput) = RunLiveness(root);
+        Assert.Equal(0, livenessExit);
+        using var liveness = JsonDocument.Parse(livenessOutput);
+        Assert.Equal(0, liveness.RootElement.GetProperty("unreadable_record_count").GetInt32());
+    }
+
+    [Fact]
+    public void CleanStore_IsStrictNoOpInBothModes_AndNothingToRepairDiffersFromCompletedRepair_G773()
+    {
+        WriteCycle("clean-cycle");
+        var before = SnapshotDirectory(TeamDirectory());
+
+        var (dryRunExit, dryRunOutput) = RunRepair();
+        Assert.Equal(0, dryRunExit);
+        using (var dryRun = JsonDocument.Parse(dryRunOutput))
+        {
+            Assert.Equal("nothing-to-repair", dryRun.RootElement.GetProperty("repair_state").GetString());
+            Assert.False(dryRun.RootElement.GetProperty("applied").GetBoolean());
+        }
+        Assert.Equal(before, SnapshotDirectory(TeamDirectory()));
+
+        var (writeExit, writeOutput) = RunRepair("--write");
+        Assert.Equal(0, writeExit);
+        using (var write = JsonDocument.Parse(writeOutput))
+        {
+            Assert.Equal("nothing-to-repair", write.RootElement.GetProperty("repair_state").GetString());
+            Assert.False(write.RootElement.GetProperty("applied").GetBoolean());
+        }
+        Assert.Equal(before, SnapshotDirectory(TeamDirectory()));
+        Assert.DoesNotContain("completed-repair", writeOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AllCorruptWrite_BecomesEmptyHistory_NotNotFoundOrHealthy_G773()
+    {
+        var cyclePath = NotifySupervisionStore.ResolveCyclePath(ArtifactRoot(), Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(cyclePath)!);
+        File.WriteAllBytes(cyclePath, Encoding.UTF8.GetBytes("{all-corrupt}\n"));
+
+        var (repairExit, _) = RunRepair("--write");
+        var (emptyExit, emptyOutput) = RunLiveness(root);
+        var missingRoot = Path.Combine(root, "never-existed");
+        var (missingExit, missingOutput) = RunLiveness(missingRoot);
+
+        Assert.Equal(0, repairExit);
+        Assert.Equal(0, emptyExit);
+        Assert.Equal(0, missingExit);
+        using var empty = JsonDocument.Parse(emptyOutput);
+        using var missing = JsonDocument.Parse(missingOutput);
+        Assert.Equal("empty-history", empty.RootElement.GetProperty("supervision_state").GetString());
+        Assert.Equal(0, empty.RootElement.GetProperty("unreadable_record_count").GetInt32());
+        Assert.Equal("not-found", missing.RootElement.GetProperty("supervision_state").GetString());
+        Assert.NotEqual(
+            empty.RootElement.GetProperty("supervision_state").GetString(),
+            missing.RootElement.GetProperty("supervision_state").GetString());
+        Assert.DoesNotContain("healthy", empty.RootElement.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ConcurrentGrowthAfterScan_FailsClosedAndDoesNotReplaceTheLiveFile_G773()
+    {
+        var cyclePath = WriteCycle("readable-cycle");
+        var unreadable = Encoding.UTF8.GetBytes("{bad-cycle-json}\n");
+        var concurrent = Encoding.UTF8.GetBytes("{concurrent-append}\n");
+        File.AppendAllBytes(cyclePath, unreadable);
+        var before = File.ReadAllBytes(cyclePath);
+        NotifySupervisionStore.RepairUnreadableBeforeLengthRecheck = () =>
+            AtomicAppendWriter.Append(cyclePath, concurrent);
+
+        try
+        {
+            var (exitCode, output) = RunRepair("--write");
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("changed after scan", output, StringComparison.Ordinal);
+            Assert.Equal(before.Concat(concurrent).ToArray(), File.ReadAllBytes(cyclePath));
+            Assert.False(File.Exists(Path.Combine(TeamDirectory(), "cycles.unreadable.jsonl")));
+            Assert.False(File.Exists(Path.Combine(TeamDirectory(), "repair-unreadable-audit.jsonl")));
+        }
+        finally
+        {
+            NotifySupervisionStore.RepairUnreadableBeforeLengthRecheck = null;
+        }
+    }
+
+    [Fact]
+    public void ArchiveHistory_IsRepairedWithoutReturningQuarantineToReaders_G773()
+    {
+        var artifactRoot = ArtifactRoot();
+        var archivePath = NotifySupervisionStore.ResolveCycleArchivePath(
+            artifactRoot,
+            Domain,
+            Team,
+            new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero));
+        Directory.CreateDirectory(Path.GetDirectoryName(archivePath)!);
+        File.WriteAllBytes(archivePath, Encoding.UTF8.GetBytes("{bad-archive-json}\n"));
+
+        var (repairExit, _) = RunRepair("--write");
+        var state = NotifySupervisionStore.Read(artifactRoot, Domain, Team);
+
+        Assert.Equal(0, repairExit);
+        Assert.True(state.Resolved, state.Error);
+        Assert.Empty(state.UnreadableRecords);
+        Assert.Equal(
+            Encoding.UTF8.GetBytes("{bad-archive-json}\n"),
+            File.ReadAllBytes(Path.Combine(Path.GetDirectoryName(archivePath)!, "2026-08.unreadable.jsonl")));
+    }
+
+    [Fact]
+    public void PromptAuditPayloadDamage_UsesTheExistingReaderReasonAndMarkdownListsIt_G773()
+    {
+        var cyclePath = WriteCycle("readable-cycle");
+        File.AppendAllText(cyclePath, "{\"kind\":\"prompt-audit\"}\n", Encoding.UTF8);
+
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(root),
+            [
+                "repair-unreadable", "--domain", Domain, "--team", Team,
+                "--routing-root", root, "--dry-run", "--format", "markdown",
+            ],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("# notify supervise repair-unreadable", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("missing-prompt-audit-payload", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("line 2", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DocumentationMirrorsDescribeVerbatimQuarantineWithoutReconstruction_G773(string language)
+    {
+        var path = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "docs",
+            language,
+            "12-agent-message-orchestration.md");
+        var document = File.ReadAllText(path);
+
+        Assert.Contains("repair-unreadable", document, StringComparison.Ordinal);
+        Assert.Contains("quarantine", document, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("verbatim", document, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("reconstruct", document, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string WriteCycle(string cycleId)
+    {
+        var path = NotifySupervisionStore.ResolveCyclePath(ArtifactRoot(), Domain, Team);
+        Assert.True(NotifySupervisionStore.RecordCycle(
+            path,
+            new NotifySupervisionCycle
+            {
+                CycleId = cycleId,
+                StartedAt = now.AddSeconds(-1),
+                CompletedAt = now,
+                IntervalSeconds = 300,
+            },
+            write: true).Applied);
+        return path;
+    }
+
+    private (int ExitCode, string Output) RunRepair(params string[] mode)
+    {
+        using var writer = new StringWriter();
+        var args = new List<string>
+        {
+            "repair-unreadable",
+            "--domain", Domain,
+            "--team", Team,
+            "--routing-root", root,
+        };
+        args.AddRange(mode);
+        args.AddRange(["--format", "json"]);
+        var exitCode = NotifyCommand.ExecuteSupervise(CreateContext(root), args.ToArray(), writer);
+        return (exitCode, writer.ToString());
+    }
+
+    private (int ExitCode, string Output) RunLiveness(string repoRoot)
+    {
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(repoRoot),
+            ["liveness", "--domain", Domain, "--team", Team, "--format", "json"],
+            writer);
+        return (exitCode, writer.ToString());
+    }
+
+    private string ArtifactRoot() => Path.Combine(root, ".intent-cli", "supervision");
+
+    private string TeamDirectory() => NotifySupervisionStore.ResolveDirectory(ArtifactRoot(), Domain, Team);
+
+    private static CliContext CreateContext(string repoRoot) => new()
+    {
+        RepoRoot = repoRoot,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = Domain,
+                ArtifactRoot = ".intent-cli",
+            },
+            Supervision = new SupervisionConfig
+            {
+                ArtifactRoot = ".intent-cli/supervision",
+            },
+        },
+    };
+
+    private static IReadOnlyDictionary<string, FileSnapshot> SnapshotDirectory(string directory) =>
+        Directory.Exists(directory)
+            ? Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToDictionary(
+                    path => Path.GetRelativePath(directory, path).Replace('\\', '/'),
+                    path => new FileSnapshot(
+                        Convert.ToBase64String(File.ReadAllBytes(path)),
+                        new FileInfo(path).Length,
+                        File.GetCreationTimeUtc(path),
+                        File.GetLastWriteTimeUtc(path)),
+                    StringComparer.Ordinal)
+            : new Dictionary<string, FileSnapshot>(StringComparer.Ordinal);
+
+    private sealed record FileSnapshot(
+        string Bytes,
+        long Length,
+        DateTime CreationTimeUtc,
+        DateTime LastWriteTimeUtc);
+}

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionRepairUnreadableG773Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionRepairUnreadableG773Tests.cs
@@ -30,6 +30,7 @@ public sealed class NotifySupervisionRepairUnreadableG773Tests : IDisposable
     {
         NotifyCommand.UtcNowFactory = null;
         NotifySupervisionStore.RepairUnreadableBeforeLengthRecheck = null;
+        NotifySupervisionStore.RepairUnreadableFaultInjector = null;
         if (Directory.Exists(root))
         {
             Directory.Delete(root, recursive: true);
@@ -200,6 +201,170 @@ public sealed class NotifySupervisionRepairUnreadableG773Tests : IDisposable
         {
             NotifySupervisionStore.RepairUnreadableBeforeLengthRecheck = null;
         }
+    }
+
+    [Fact]
+    public void FailureAfterQuarantinePublication_RetryMovesBytesExactlyOnceAndAppendsOneAudit_G773()
+    {
+        var cyclePath = WriteCycle("readable-cycle");
+        var readable = File.ReadAllBytes(cyclePath);
+        var unreadable = Encoding.UTF8.GetBytes("{bad-cycle-json}\n");
+        File.AppendAllBytes(cyclePath, unreadable);
+        var quarantinePath = Path.Combine(TeamDirectory(), "cycles.unreadable.jsonl");
+        var auditPath = Path.Combine(TeamDirectory(), "repair-unreadable-audit.jsonl");
+        NotifySupervisionStore.RepairUnreadableFaultInjector = point =>
+        {
+            if (point == NotifySupervisionRepairUnreadableFaultPoint.AfterQuarantinePublication)
+            {
+                throw new IOException("injected-after-quarantine-publication");
+            }
+        };
+
+        try
+        {
+            var (failedExit, failedOutput) = RunRepair("--write");
+
+            Assert.Equal(1, failedExit);
+            Assert.Contains("injected-after-quarantine-publication", failedOutput, StringComparison.Ordinal);
+            Assert.Equal(readable.Concat(unreadable).ToArray(), File.ReadAllBytes(cyclePath));
+            Assert.Equal(unreadable, File.ReadAllBytes(quarantinePath));
+            Assert.False(File.Exists(auditPath));
+        }
+        finally
+        {
+            NotifySupervisionStore.RepairUnreadableFaultInjector = null;
+        }
+
+        var (retryExit, _) = RunRepair("--write");
+
+        Assert.Equal(0, retryExit);
+        Assert.Equal(readable, File.ReadAllBytes(cyclePath));
+        Assert.Equal(unreadable, File.ReadAllBytes(quarantinePath));
+        var auditLine = Assert.Single(File.ReadAllLines(auditPath));
+        using var audit = JsonDocument.Parse(auditLine);
+        Assert.Equal("completed", audit.RootElement.GetProperty("outcome").GetString());
+        Assert.Equal(1, audit.RootElement.GetProperty("unreadable_record_count").GetInt32());
+        Assert.False(File.Exists(Path.Combine(
+            TeamDirectory(),
+            NotifySupervisionStore.RepairUnreadableTransactionFileName)));
+        var (livenessExit, livenessOutput) = RunLiveness(root);
+        Assert.Equal(0, livenessExit);
+        using var liveness = JsonDocument.Parse(livenessOutput);
+        Assert.Equal(0, liveness.RootElement.GetProperty("unreadable_record_count").GetInt32());
+    }
+
+    [Fact]
+    public void FailureAfterLaterQuarantinePublication_RecoversEveryFileWithoutDuplicateEvidence_G773()
+    {
+        var cyclePath = WriteCycle("readable-cycle");
+        var stallPath = NotifySupervisionStore.ResolveStallPath(ArtifactRoot(), Domain, Team);
+        Assert.True(NotifySupervisionStore.OpenStall(
+            stallPath,
+            new NotifySupervisionStallRecord
+            {
+                Key = "readable-stall",
+                Kind = "g773",
+                OwnerRole = "implementation",
+                Source = "g773-test",
+                Summary = "readable",
+                SurfacedAt = now,
+            },
+            write: true).Applied);
+        var readableCycles = File.ReadAllBytes(cyclePath);
+        var readableStalls = File.ReadAllBytes(stallPath);
+        var unreadableCycle = Encoding.UTF8.GetBytes("{bad-cycle-json}\n");
+        var unreadableStall = Encoding.UTF8.GetBytes("{bad-stall-json}\n");
+        File.AppendAllBytes(cyclePath, unreadableCycle);
+        File.AppendAllBytes(stallPath, unreadableStall);
+        var cyclesQuarantinePath = Path.Combine(TeamDirectory(), "cycles.unreadable.jsonl");
+        var stallsQuarantinePath = Path.Combine(TeamDirectory(), "stalls.unreadable.jsonl");
+        var auditPath = Path.Combine(TeamDirectory(), "repair-unreadable-audit.jsonl");
+        var publications = 0;
+        NotifySupervisionStore.RepairUnreadableFaultInjector = point =>
+        {
+            if (point == NotifySupervisionRepairUnreadableFaultPoint.AfterQuarantinePublication
+                && ++publications == 2)
+            {
+                throw new IOException("injected-after-later-quarantine-publication");
+            }
+        };
+
+        try
+        {
+            var (failedExit, failedOutput) = RunRepair("--write");
+
+            Assert.Equal(1, failedExit);
+            Assert.Contains("injected-after-later-quarantine-publication", failedOutput, StringComparison.Ordinal);
+            Assert.Equal(readableCycles, File.ReadAllBytes(cyclePath));
+            Assert.Equal(readableStalls.Concat(unreadableStall).ToArray(), File.ReadAllBytes(stallPath));
+            Assert.Equal(unreadableCycle, File.ReadAllBytes(cyclesQuarantinePath));
+            Assert.Equal(unreadableStall, File.ReadAllBytes(stallsQuarantinePath));
+            Assert.False(File.Exists(auditPath));
+        }
+        finally
+        {
+            NotifySupervisionStore.RepairUnreadableFaultInjector = null;
+        }
+
+        var (retryExit, _) = RunRepair("--write");
+
+        Assert.Equal(0, retryExit);
+        Assert.Equal(readableCycles, File.ReadAllBytes(cyclePath));
+        Assert.Equal(readableStalls, File.ReadAllBytes(stallPath));
+        Assert.Equal(unreadableCycle, File.ReadAllBytes(cyclesQuarantinePath));
+        Assert.Equal(unreadableStall, File.ReadAllBytes(stallsQuarantinePath));
+        var auditLine = Assert.Single(File.ReadAllLines(auditPath));
+        using var audit = JsonDocument.Parse(auditLine);
+        Assert.Equal(2, audit.RootElement.GetProperty("unreadable_record_count").GetInt32());
+        Assert.Equal(2, audit.RootElement.GetProperty("files").GetArrayLength());
+        Assert.False(File.Exists(Path.Combine(
+            TeamDirectory(),
+            NotifySupervisionStore.RepairUnreadableTransactionFileName)));
+    }
+
+    [Fact]
+    public void AuditFailure_LeavesNoCompletedAuditAndRetryAppendsExactlyOne_G773()
+    {
+        var cyclePath = WriteCycle("readable-cycle");
+        var readable = File.ReadAllBytes(cyclePath);
+        var unreadable = Encoding.UTF8.GetBytes("{bad-cycle-json}\n");
+        File.AppendAllBytes(cyclePath, unreadable);
+        var quarantinePath = Path.Combine(TeamDirectory(), "cycles.unreadable.jsonl");
+        var auditPath = Path.Combine(TeamDirectory(), "repair-unreadable-audit.jsonl");
+        NotifySupervisionStore.RepairUnreadableFaultInjector = point =>
+        {
+            if (point == NotifySupervisionRepairUnreadableFaultPoint.BeforeAuditAppend)
+            {
+                throw new IOException("injected-before-repair-audit");
+            }
+        };
+
+        try
+        {
+            var (failedExit, failedOutput) = RunRepair("--write");
+
+            Assert.Equal(1, failedExit);
+            Assert.Contains("injected-before-repair-audit", failedOutput, StringComparison.Ordinal);
+            Assert.Equal(readable, File.ReadAllBytes(cyclePath));
+            Assert.Equal(unreadable, File.ReadAllBytes(quarantinePath));
+            Assert.False(File.Exists(auditPath));
+        }
+        finally
+        {
+            NotifySupervisionStore.RepairUnreadableFaultInjector = null;
+        }
+
+        var (retryExit, _) = RunRepair("--write");
+
+        Assert.Equal(0, retryExit);
+        Assert.Equal(readable, File.ReadAllBytes(cyclePath));
+        Assert.Equal(unreadable, File.ReadAllBytes(quarantinePath));
+        var auditLine = Assert.Single(File.ReadAllLines(auditPath));
+        using var audit = JsonDocument.Parse(auditLine);
+        Assert.Equal("completed", audit.RootElement.GetProperty("outcome").GetString());
+        Assert.False(File.Exists(Path.Combine(
+            TeamDirectory(),
+            NotifySupervisionStore.RepairUnreadableTransactionFileName)));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds the explicit `notify supervise repair-unreadable` dry-run/write route.
- Quarantines unreadable JSONL bytes verbatim, rewrites only readable live bytes, records an atomic audit, and fails closed on concurrent growth.
- Documents the evidence-preserving/no-reconstruction boundary in both orchestration mirrors.

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~NotifySupervisionRepairUnreadableG773Tests --no-restore --nologo`
- `dotnet test IntentSystem.sln --configuration Release --no-restore --nologo` (5785 passed, 1 skipped, 0 failed)
- `git diff --check HEAD^ HEAD`

Closes #1685