### PR TITLE
G774: add packet-authoring self-check to design guide

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -229,6 +229,31 @@ role. Its wording is the same in `agmsg` and `herdr-only`, with or without a
 named team. Re-read installed guides after a CLI version or session-layer
 configuration change, not on every wake.
 
+### Packet-authoring self-check (G774)
+
+Before publishing a packet, the design seat performs this guidance-only check;
+it adds no semantic lint to `packet draft`.
+
+- **Per-criterion satisfiability.** Verify every criterion can be satisfied
+  under the packet's own constraints.
+- **Negative-criterion scoping.** Check every negative criterion against every
+  positive one. Scope the negative with a limiting word that names the one
+  thing it protects.
+- **Request-update condition.** Request an update before publication when a
+  criterion conflicts with a required positive criterion, a negative lacks a
+  limiting word, or the requested evidence is unobtainable under the packet's
+  own constraints.
+- **Discriminating pair.** Name at least one named discriminating pair: a
+  compliant case and a near case that proves the scoped rule catches the
+  intended difference.
+
+Recognition examples are G765 AC4/AC6 (unobtainable evidence: live scheduler
+state versus the no-OS-lifecycle-query boundary), G767 AC1/AC6 (status versus
+the full clean-payload oracle), and G769 AC3/AC4 (a broad negative forbids the
+needed change). Apply the G770 resolution rule: scope the negative with a
+limiting word naming exactly what it protects — for example, `root resolution`
+— instead of broadening it to forbid the needed change.
+
 ### Role-contract precedence (G672 — preview-through-1.x)
 
 When `guide next` or `guide onboarding` is invoked with `--role`, the role's

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -204,6 +204,27 @@ agent kind に依存しない contract は `intent-cli guide design-thread` で�
 内容は `agmsg` / `herdr-only` と team 指定の有無で変わりません。guide を再読するのは
 CLI version または session-layer configuration が変わったときで、wake ごとではありません。
 
+### packet authoring の事前自己点検（G774）
+
+`packet` を公開する前に、設計担当者はこの guidance-only の点検を行います。これは
+`packet draft` に semantic lint を追加しません。
+
+- **criterion ごとの充足可能性。** 各 criterion が、その packet 自身の制約の下で満たせることを
+  確認します。
+- **negative criterion の限定。** 各 negative criterion を各 positive criterion と照合します。
+  negative は、保護する一つの対象を名前で示す限定語で範囲を絞ります。
+- **更新を要求する条件。** criterion が必要な positive criterion と衝突するとき、negative に
+  限定語がないとき、または packet 自身の制約の下で必要な evidence を取得できないときは、
+  公開前に更新を要求します。
+- **判別対。** 少なくとも一つの名前付き判別対、すなわち適合する事例と、限定した rule が意図した
+  差を捕捉することを示す近接事例を示します。
+
+認識例は G765 AC4/AC6（取得不能な evidence: live scheduler state と no-OS-lifecycle-query
+boundary の衝突）、G767 AC1/AC6（status と full clean-payload oracle の衝突）、G769 AC3/AC4
+（広すぎる negative が必要な変更を禁じる形）です。G770 の解決則は、negative を
+必要な変更まで禁じるほど広げず、保護する対象を正確に名前で示す限定語、たとえば
+`root resolution`、で範囲を絞ることです。
+
 ### role contract の precedence（G672 — preview-through-1.x）
 
 `guide next` または `guide onboarding` を `--role` 付きで呼ぶと、contract を持つ role の

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -180,6 +180,21 @@ internal static class GuideDesignThreadCommand
                 "No canonical identity inferred from prose, transport state, or an unaccepted candidate.",
                 "No publication, contract, priority, release, destructive, permission, security, or credential decision is silently broadened.",
             },
+            PacketAuthoringCheck = new DesignThreadPacketAuthoringCheck
+            {
+                BeforePublish = "Before publishing any packet, perform this authoring self-check; it is guidance for the design seat and does not add semantic lint to `packet draft`.",
+                PerCriterionSatisfiability = "Per-criterion satisfiability: verify every criterion can be satisfied under the packet's own constraints.",
+                NegativeCriterionScoping = "Negative-criterion scoping: check every negative criterion against every positive criterion, and scope the negative with a limiting word that names the one thing it protects.",
+                RequestUpdateCondition = "Request an update before publication if any criterion conflicts with a required positive criterion, if a negative is not scoped with a limiting word, or if the requested evidence is unobtainable under the packet's own constraints.",
+                DiscriminatingPair = "Name at least one named discriminating pair: a compliant case and a near case that proves the scoped rule catches the intended difference.",
+                RecognitionExamples = new[]
+                {
+                    "G765 AC4/AC6 — unobtainable evidence: a live scheduler-state requirement conflicts with a no-OS-lifecycle-query boundary.",
+                    "G767 AC1/AC6 — status versus oracle: a success-status interpretation conflicts with the full clean-payload oracle.",
+                    "G769 AC3/AC4 — broad negative forbids the needed change: cwd independence needs a routing-root behavior that an unscoped negative would prohibit.",
+                },
+                G770ResolutionRule = "G770 resolution rule: scope the negative with a limiting word naming exactly what it protects — for example, `root resolution` — rather than broadening it to forbid the required change.",
+            },
         };
     }
 
@@ -254,6 +269,15 @@ internal static class GuideDesignThreadCommand
         writer.WriteLine("## 7. Outcome-shaped reporting");
         writer.WriteLine($"- {result.Reporting.Rule}");
         writer.WriteLine($"- {result.Reporting.HumanActionRule}");
+        writer.WriteLine();
+        writer.WriteLine("## 8. Packet-authoring self-check (G774)");
+        writer.WriteLine($"- **before publish:** {result.PacketAuthoringCheck.BeforePublish}");
+        writer.WriteLine($"- **per-criterion satisfiability:** {result.PacketAuthoringCheck.PerCriterionSatisfiability}");
+        writer.WriteLine($"- **negative-criterion scoping:** {result.PacketAuthoringCheck.NegativeCriterionScoping}");
+        writer.WriteLine($"- **request-update condition:** {result.PacketAuthoringCheck.RequestUpdateCondition}");
+        writer.WriteLine($"- **discriminating pair:** {result.PacketAuthoringCheck.DiscriminatingPair}");
+        foreach (var example in result.PacketAuthoringCheck.RecognitionExamples) writer.WriteLine($"- **recognition example:** {example}");
+        writer.WriteLine($"- **G770 resolution:** {result.PacketAuthoringCheck.G770ResolutionRule}");
         WriteList(writer, "## Negative invariants", result.NegativeInvariants);
     }
 
@@ -331,6 +355,7 @@ internal sealed record DesignThreadGuideResult
     public required DesignThreadMonitoring Monitoring { get; init; }
     public required DesignThreadReporting Reporting { get; init; }
     public required IReadOnlyList<string> NegativeInvariants { get; init; }
+    public required DesignThreadPacketAuthoringCheck PacketAuthoringCheck { get; init; }
 }
 
 internal sealed record DesignThreadReachability
@@ -363,3 +388,13 @@ internal sealed record DesignThreadObservationBoundary
 internal sealed record DesignThreadTeamAndDutySplit { public required string Formula { get; init; } public required string MonitoringRule { get; init; } public required string OrchestrationOwnership { get; init; } public required string DesignMode { get; init; } public required IReadOnlyList<string> DesignEscalations { get; init; } }
 internal sealed record DesignThreadMonitoring { public required string Separation { get; init; } public required string ResidualDesignCheck { get; init; } public required string BoundRule { get; init; } public required string GuideRefreshRule { get; init; } public required string DeploymentRule { get; init; } }
 internal sealed record DesignThreadReporting { public required string Rule { get; init; } public required string HumanActionRule { get; init; } }
+internal sealed record DesignThreadPacketAuthoringCheck
+{
+    public required string BeforePublish { get; init; }
+    public required string PerCriterionSatisfiability { get; init; }
+    public required string NegativeCriterionScoping { get; init; }
+    public required string RequestUpdateCondition { get; init; }
+    public required string DiscriminatingPair { get; init; }
+    public required IReadOnlyList<string> RecognitionExamples { get; init; }
+    public required string G770ResolutionRule { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
@@ -7,6 +9,36 @@ namespace IntentSystem.Cli.Tests;
 
 public sealed class GuideDesignThreadG654Tests
 {
+    private static readonly string[] ParentPayloadFieldNames =
+    [
+        "process",
+        "preview_status",
+        "agent_kind_neutral",
+        "session_layer_rule",
+        "domain",
+        "team",
+        "routing_root",
+        "reachability",
+        "wake_rule",
+        "provenance",
+        "approval",
+        "dialog_answering_rule",
+        "residual_approval",
+        "merge_authority",
+        "delegation_verification",
+        "observation_boundary",
+        "team_and_duty_split",
+        "monitoring",
+        "reporting",
+        "negative_invariants",
+    ];
+
+    // G774 captures every parent field name and raw JSON value in rendered
+    // order. Only the separately asserted packet_authoring_check block may
+    // differ; changing any parent value, nesting, or field order changes this
+    // oracle rather than weakening a full-payload assertion.
+    private const string ParentPayloadOracleHash = "c43e27f362c39d9c737fc2269b1979bdf8ad9b7ecb07f3dd0491ba1325d0c54f";
+
     [Theory]
     [InlineData("agmsg", false)]
     [InlineData("agmsg", true)]
@@ -79,6 +111,70 @@ public sealed class GuideDesignThreadG654Tests
     }
 
     [Fact]
+    public void Json_PacketAuthoringCheckIsTheOnlyAdditivePayloadDelta_G774()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            GuideDesignThreadCommand.Execute(
+                CreateContext(),
+                ["--domain", "intent-cli", "--team", "intent-cli-dev", "--routing-root", "/g774-parent", "--format", "json"],
+                writer));
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var fields = root.EnumerateObject().ToArray();
+
+        Assert.Equal(
+            ParentPayloadFieldNames.Append("packet_authoring_check"),
+            fields.Select(field => field.Name));
+        var parentPayloadOracle = ComputePayloadOracle(fields.Where(field => field.Name != "packet_authoring_check"));
+        Assert.True(
+            string.Equals(ParentPayloadOracleHash, parentPayloadOracle, StringComparison.Ordinal),
+            $"Parent payload oracle changed. Expected '{ParentPayloadOracleHash}', actual '{parentPayloadOracle}'.");
+
+        var check = root.GetProperty("packet_authoring_check");
+        Assert.Equal(
+            new[]
+            {
+                "before_publish",
+                "per_criterion_satisfiability",
+                "negative_criterion_scoping",
+                "request_update_condition",
+                "discriminating_pair",
+                "recognition_examples",
+                "g770_resolution_rule",
+            },
+            check.EnumerateObject().Select(field => field.Name));
+        Assert.Contains("packet's own constraints", check.GetProperty("per_criterion_satisfiability").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("every negative criterion", check.GetProperty("negative_criterion_scoping").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("limiting word", check.GetProperty("negative_criterion_scoping").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("Request an update", check.GetProperty("request_update_condition").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("named discriminating pair", check.GetProperty("discriminating_pair").GetString()!, StringComparison.Ordinal);
+
+        var examples = Join(check.GetProperty("recognition_examples"));
+        Assert.Contains("G765 AC4/AC6", examples, StringComparison.Ordinal);
+        Assert.Contains("G767 AC1/AC6", examples, StringComparison.Ordinal);
+        Assert.Contains("G769 AC3/AC4", examples, StringComparison.Ordinal);
+        Assert.Contains("root resolution", check.GetProperty("g770_resolution_rule").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Markdown_RendersPacketAuthoringCheckWithAllRecognitionExamples_G774()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(CreateContext(), [], writer));
+        var output = writer.ToString();
+
+        Assert.Contains("## 8. Packet-authoring self-check (G774)", output, StringComparison.Ordinal);
+        Assert.Contains("per-criterion satisfiability", output, StringComparison.Ordinal);
+        Assert.Contains("limiting word", output, StringComparison.Ordinal);
+        Assert.Contains("Request an update", output, StringComparison.Ordinal);
+        Assert.Contains("named discriminating pair", output, StringComparison.Ordinal);
+        foreach (var recognitionExample in new[] { "G765 AC4/AC6", "G767 AC1/AC6", "G769 AC3/AC4", "root resolution" })
+            Assert.Contains(recognitionExample, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Markdown_IsAgentKindNeutral_AndContainsNoNormativeProviderNames()
     {
         using var writer = new StringWriter();
@@ -131,7 +227,38 @@ public sealed class GuideDesignThreadG654Tests
         }
     }
 
+    [Fact]
+    public void EnglishAndJapaneseDocs_SemanticallyMirrorPacketAuthoringCheck_G774()
+    {
+        var en = ReadRepoFile("docs/en/12-agent-message-orchestration.md");
+        var ja = ReadRepoFile("docs/ja/12-agent-message-orchestration.md");
+
+        foreach (var recognitionExample in new[] { "G765 AC4/AC6", "G767 AC1/AC6", "G769 AC3/AC4", "root resolution" })
+        {
+            Assert.Contains(recognitionExample, en, StringComparison.Ordinal);
+            Assert.Contains(recognitionExample, ja, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("per-criterion satisfiability", en, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("limiting word", en, StringComparison.Ordinal);
+        Assert.Contains("request an update", en, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("discriminating pair", en, StringComparison.Ordinal);
+
+        Assert.Contains("criterion ごとの充足可能性", ja, StringComparison.Ordinal);
+        Assert.Contains("限定語", ja, StringComparison.Ordinal);
+        Assert.Contains("更新を要求", ja, StringComparison.Ordinal);
+        Assert.Contains("判別対", ja, StringComparison.Ordinal);
+    }
+
     private static string Join(JsonElement array) => string.Join('\n', array.EnumerateArray().Select(item => item.GetString()));
+
+    private static string ComputePayloadOracle(IEnumerable<JsonProperty> fields)
+    {
+        var payload = string.Join(
+            "\u001E",
+            fields.Select(field => field.Name + "\u001F" + field.Value.GetRawText()));
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+    }
 
     private static CliContext CreateContext() => new()
     {


### PR DESCRIPTION
Adds the additive packet_authoring_check guide payload and Markdown/docs coverage, with a full parent-payload oracle. Closes #1687