### PR TITLE
G775: render external residence operating contract

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -254,6 +254,54 @@ needed change). Apply the G770 resolution rule: scope the negative with a
 limiting word naming exactly what it protects — for example, `root resolution`
 — instead of broadening it to forbid the needed change.
 
+### External-residence operating contract (G775)
+
+**Frontend relabel first.** An already-external seat may change its frontend
+application freely: residence, reader, and routing root are unchanged. Do not
+use `session-layer topology update-residence` for that external-to-external
+relabel. No transition command is involved. `frontend` is an operator label,
+never a routing input; re-record at most with `intent-cli session-layer topology
+record` when the operator wants to change that label.
+
+**Routing-root MUST.** Every `notify` send and receive uses the canonical
+`--routing-root <routing-root>`. A wrong root strands notify records outside
+the state canonical readers see while the sender still returns
+`delivered: true`.
+
+A herdr↔external residence transition is a **different operation** from a
+frontend relabel. When the human answer changes residence, use the guarded
+`session-layer topology update-residence` route; do not let that route imply a
+transition for an external-to-external frontend change. The human-selected
+external branch of `guide bootstrap` names this distinct route so the rendered
+bootstrap reaches the residence transition without conflating it with relabel.
+
+**Bind the wake address.** Bind durable wake addresses before the first read,
+and never substitute a terminal-only address for a durable bound address.
+
+**Collect after binding.** The external receive is an explicit pull loop; the
+caller retains the opaque cursor, supplies the returned next cursor on the next
+receive, and omits `--since` only for the first receive:
+
+```text
+intent-cli notify collect --domain <domain> --team <team> --role design --since <cursor> --wait --timeout-ms <timeout-ms> --routing-root <routing-root> --format json
+```
+
+**Dual-send after the loop is established.** Canonical `intent-cli notify` is
+the durable record. A wake channel is a courtesy-only signal; dual-send is the
+practiced form.
+
+> **Non-normative Orca worked example.** A design operator may bind the
+> coordinator terminal before reading, then perform Orca's bounded blocking
+> check:
+>
+> ```text
+> orca orchestration run-use --id <run-id>
+> orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json
+> ```
+>
+> Orca is only a courtesy wake receiver beside canonical `intent-cli notify`;
+> intent-cli neither launches nor manages Orca.
+
 ### Role-contract precedence (G672 — preview-through-1.x)
 
 When `guide next` or `guide onboarding` is invoked with `--role`, the role's

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -225,6 +225,52 @@ boundary の衝突）、G767 AC1/AC6（status と full clean-payload oracle の�
 必要な変更まで禁じるほど広げず、保護する対象を正確に名前で示す限定語、たとえば
 `root resolution`、で範囲を絞ることです。
 
+### external residence の運用契約（G775）
+
+**最初にフロントエンドの表示名変更。** すでに `external` である seat は、frontend
+application を自由に変更できます。residence、reader、routing root は変わりません。
+この external-to-external の表示名変更で
+`session-layer topology update-residence` を使いません。`frontend` は operator label であり
+routing input ではありません。transition command は関与しません。operator がこの label を
+変えたいときだけ、最大でも `intent-cli session-layer topology record` で再記録します。
+
+**routing-root MUST。** すべての `notify` の send / receive は正本の
+`--routing-root <routing-root>` を使います。root を誤ると、sender が
+`delivered: true` を返しても、notify record は canonical reader から見えない場所に
+取り残されます。
+
+herdr↔external の residence transition は、frontend の表示名変更とは**別の操作**です。
+human answer が residence を変えるときは、guarded な
+`session-layer topology update-residence` route を使います。この route が
+external-to-external の表示名変更にも必要だとは読まないでください。human-selected
+external branch の `guide bootstrap` がこの別の route を示すため、rendered bootstrap は
+表示名変更と residence transition を混同しません。
+
+**wake address を接続。** 最初に読む前に永続的な wake address を接続し、terminal-only
+address を永続的に接続済みの address の代わりにはしません。
+
+**接続後に collect。** external receive は明示的な pull loop です。caller は opaque cursor
+を保持し、返された next cursor を次の receive に渡します。最初の receive だけ `--since` を
+省略します。
+
+```text
+intent-cli notify collect --domain <domain> --team <team> --role design --since <cursor> --wait --timeout-ms <timeout-ms> --routing-root <routing-root> --format json
+```
+
+**loop を確立してから dual-send。** canonical な `intent-cli notify` は永続的な record
+です。wake channel は `courtesy-only` の signal であり、`dual-send` が実践する形です。
+
+> **非規範的な Orca の例。** design operator は読む前に coordinator terminal を接続し、
+> Orca の bounded blocking check を実行できます。
+>
+> ```text
+> orca orchestration run-use --id <run-id>
+> orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json
+> ```
+>
+> Orca は canonical な `intent-cli notify` に添える courtesy wake receiver だけです。
+> intent-cli は Orca を起動も管理もしません。
+
 ### role contract の precedence（G672 — preview-through-1.x）
 
 `guide next` または `guide onboarding` を `--role` 付きで呼ぶと、contract を持つ role の

--- a/src/IntentSystem.Cli/Commands/GuideBootstrapCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideBootstrapCommand.cs
@@ -163,11 +163,12 @@ internal static class GuideBootstrapCommand
                 {
                     Number = 5,
                     Id = "ask-app-kind-and-place-design",
-                    Instruction = $"Ask the human which agent kind this application conversation uses and whether that kind has an inbound application monitor. Never infer or default either answer. With a monitor, design may be the recorded external reader; at the human-selected external branch, follow the rendered `intent-cli guide design-thread --domain {domainArg} --team {teamArg} --routing-root {routingRoot} --format markdown` guidance for its canonical role-scoped `intent-cli notify collect --role design` receive, caller-held cursor, and bounded wait. Without one, design must be a recorded herdr seat at the routing-root cwd. This placement rule does not move recovery authority from orchestration.",
+                    Instruction = $"Ask the human which agent kind this application conversation uses and whether that kind has an inbound application monitor. Never infer or default either answer. With a monitor, design may be the recorded external reader; at the human-selected external branch, follow the rendered `intent-cli guide design-thread --domain {domainArg} --team {teamArg} --routing-root {routingRoot} --format markdown` guidance for its canonical role-scoped `intent-cli notify collect --role design` receive, caller-held cursor, bounded wait, frontend relabel, routing-root law, and wake-channel pattern. A later herdr↔external residence change is a different operation from an external-to-external frontend relabel and uses `session-layer topology update-residence`. Without a monitor, design must be a recorded herdr seat at the routing-root cwd. This placement rule does not move recovery authority from orchestration.",
                     EmittedCommands =
                     [
                         $"intent-cli session-layer topology record --domain {domainArg} --team {teamArg} --role design --resident <external-or-herdr-from-human-answer> <reader-or-workspace-pane-and-cwd-fields> --write --format json",
                         $"intent-cli guide design-thread --domain {domainArg} --team {teamArg} --routing-root {routingRoot} --format markdown",
+                        $"intent-cli session-layer topology update-residence --domain {domainArg} --team {teamArg} --role design --current-resident <herdr|external> --new-resident <herdr|external> [destination fields] --confirm-update-residence --write --format json",
                     ],
                 },
                 new BootstrapStep

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -195,6 +195,15 @@ internal static class GuideDesignThreadCommand
                 },
                 G770ResolutionRule = "G770 resolution rule: scope the negative with a limiting word naming exactly what it protects — for example, `root resolution` — rather than broadening it to forbid the required change.",
             },
+            ExternalResidenceOperatingContract = new DesignThreadExternalResidenceOperatingContract
+            {
+                FrontendRelabel = "External-to-external frontend relabel: an external seat may change its frontend application freely; residence, reader, and routing root stay unchanged; no transition command is involved; do not use `session-layer topology update-residence`; frontend is an operator label, never a routing input; re-record at most with `intent-cli session-layer topology record` when the operator wants to change the frontend label.",
+                RoutingRootMust = "Routing-root MUST: every notify send and receive uses the canonical routing root. A wrong root strands notify records outside canonical state while the sender still returns `delivered: true`.",
+                CollectLoop = $"Collect loop: `intent-cli notify collect --domain {domainArg} --team {teamArg} --role design --since <cursor> --wait --timeout-ms <timeout-ms> --routing-root {root} --format json`; the caller holds the cursor, consumes the returned next cursor, and omits `--since` only for the first receive.",
+                WakeChannelPattern = "Wake-channel pattern: canonical `intent-cli notify` is the durable record; a wake channel is a courtesy-only signal; dual-send is the practiced form. Bind durable wake addresses before reading and never substitute a terminal-only address for a durable bound address.",
+                OrcaWorkedExample = "Non-normative Orca example: bind the design coordinator terminal before reading with `orca orchestration run-use --id <run-id>`, then use the blocking check `orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json`. Orca is only a courtesy wake receiver alongside canonical `intent-cli notify`; intent-cli neither launches nor manages Orca.",
+                ResidenceTransition = $"A herdr↔external residence change is a different operation from an external-to-external frontend relabel: `intent-cli session-layer topology update-residence --domain {domainArg} --team {teamArg} --role design --current-resident <herdr|external> --new-resident <herdr|external> [destination fields] --confirm-update-residence --write --format json`.",
+            },
         };
     }
 
@@ -278,6 +287,14 @@ internal static class GuideDesignThreadCommand
         writer.WriteLine($"- **discriminating pair:** {result.PacketAuthoringCheck.DiscriminatingPair}");
         foreach (var example in result.PacketAuthoringCheck.RecognitionExamples) writer.WriteLine($"- **recognition example:** {example}");
         writer.WriteLine($"- **G770 resolution:** {result.PacketAuthoringCheck.G770ResolutionRule}");
+        writer.WriteLine();
+        writer.WriteLine("## 9. External-residence operating contract (G775)");
+        writer.WriteLine($"- **frontend relabel first:** {result.ExternalResidenceOperatingContract.FrontendRelabel}");
+        writer.WriteLine($"- **routing-root law:** {result.ExternalResidenceOperatingContract.RoutingRootMust}");
+        writer.WriteLine($"- **collect:** {result.ExternalResidenceOperatingContract.CollectLoop}");
+        writer.WriteLine($"- **wake channel:** {result.ExternalResidenceOperatingContract.WakeChannelPattern}");
+        writer.WriteLine($"- **worked example:** {result.ExternalResidenceOperatingContract.OrcaWorkedExample}");
+        writer.WriteLine($"- **different transition:** {result.ExternalResidenceOperatingContract.ResidenceTransition}");
         WriteList(writer, "## Negative invariants", result.NegativeInvariants);
     }
 
@@ -356,6 +373,7 @@ internal sealed record DesignThreadGuideResult
     public required DesignThreadReporting Reporting { get; init; }
     public required IReadOnlyList<string> NegativeInvariants { get; init; }
     public required DesignThreadPacketAuthoringCheck PacketAuthoringCheck { get; init; }
+    public required DesignThreadExternalResidenceOperatingContract ExternalResidenceOperatingContract { get; init; }
 }
 
 internal sealed record DesignThreadReachability
@@ -397,4 +415,14 @@ internal sealed record DesignThreadPacketAuthoringCheck
     public required string DiscriminatingPair { get; init; }
     public required IReadOnlyList<string> RecognitionExamples { get; init; }
     public required string G770ResolutionRule { get; init; }
+}
+
+internal sealed record DesignThreadExternalResidenceOperatingContract
+{
+    public required string FrontendRelabel { get; init; }
+    public required string RoutingRootMust { get; init; }
+    public required string CollectLoop { get; init; }
+    public required string WakeChannelPattern { get; init; }
+    public required string OrcaWorkedExample { get; init; }
+    public required string ResidenceTransition { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
@@ -38,6 +38,9 @@ public sealed class GuideDesignThreadG654Tests
     // differ; changing any parent value, nesting, or field order changes this
     // oracle rather than weakening a full-payload assertion.
     private const string ParentPayloadOracleHash = "c43e27f362c39d9c737fc2269b1979bdf8ad9b7ecb07f3dd0491ba1325d0c54f";
+    private static readonly string[] G774BaselinePayloadFieldNames =
+        ParentPayloadFieldNames.Append("packet_authoring_check").ToArray();
+    private const string G774BaselinePayloadOracleHash = "8110a6150605810aaa609fc2c34668341b939e58bc0dc35085c7290e6c72b136";
 
     [Theory]
     [InlineData("agmsg", false)]
@@ -111,7 +114,7 @@ public sealed class GuideDesignThreadG654Tests
     }
 
     [Fact]
-    public void Json_PacketAuthoringCheckIsTheOnlyAdditivePayloadDelta_G774()
+    public void Json_PacketAuthoringCheckRemainsTheG774Baseline_G774()
     {
         using var writer = new StringWriter();
         Assert.Equal(
@@ -124,13 +127,18 @@ public sealed class GuideDesignThreadG654Tests
         var root = document.RootElement;
         var fields = root.EnumerateObject().ToArray();
 
-        Assert.Equal(
-            ParentPayloadFieldNames.Append("packet_authoring_check"),
-            fields.Select(field => field.Name));
-        var parentPayloadOracle = ComputePayloadOracle(fields.Where(field => field.Name != "packet_authoring_check"));
+        var g774BaselineFields = fields
+            .Where(field => field.Name != "external_residence_operating_contract")
+            .ToArray();
+        Assert.Equal(G774BaselinePayloadFieldNames, g774BaselineFields.Select(field => field.Name));
+        var g774BaselineOracle = ComputePayloadOracle(g774BaselineFields);
+        Assert.True(
+            string.Equals(G774BaselinePayloadOracleHash, g774BaselineOracle, StringComparison.Ordinal),
+            $"G774 baseline payload oracle changed. Expected '{G774BaselinePayloadOracleHash}', actual '{g774BaselineOracle}'.");
+        var parentPayloadOracle = ComputePayloadOracle(fields.Where(field => field.Name is not "packet_authoring_check" and not "external_residence_operating_contract"));
         Assert.True(
             string.Equals(ParentPayloadOracleHash, parentPayloadOracle, StringComparison.Ordinal),
-            $"Parent payload oracle changed. Expected '{ParentPayloadOracleHash}', actual '{parentPayloadOracle}'.");
+            $"G654 parent payload oracle changed. Expected '{ParentPayloadOracleHash}', actual '{parentPayloadOracle}'.");
 
         var check = root.GetProperty("packet_authoring_check");
         Assert.Equal(
@@ -159,6 +167,81 @@ public sealed class GuideDesignThreadG654Tests
     }
 
     [Fact]
+    public void Json_ExternalResidenceOperatingContractIsTheOnlyAdditivePayloadDelta_G775()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            GuideDesignThreadCommand.Execute(
+                CreateContext(),
+                ["--domain", "intent-cli", "--team", "intent-cli-dev", "--routing-root", "/g774-parent", "--format", "json"],
+                writer));
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var fields = root.EnumerateObject().ToArray();
+
+        Assert.Equal(
+            G774BaselinePayloadFieldNames.Append("external_residence_operating_contract"),
+            fields.Select(field => field.Name));
+        var g774BaselineOracle = ComputePayloadOracle(fields.Where(field => field.Name != "external_residence_operating_contract"));
+        Assert.True(
+            string.Equals(G774BaselinePayloadOracleHash, g774BaselineOracle, StringComparison.Ordinal),
+            $"G774 baseline payload oracle changed. Expected '{G774BaselinePayloadOracleHash}', actual '{g774BaselineOracle}'.");
+
+        var contract = root.GetProperty("external_residence_operating_contract");
+        Assert.Equal(
+            new[]
+            {
+                "frontend_relabel",
+                "routing_root_must",
+                "collect_loop",
+                "wake_channel_pattern",
+                "orca_worked_example",
+                "residence_transition",
+            },
+            contract.EnumerateObject().Select(field => field.Name));
+
+        var frontendRelabel = contract.GetProperty("frontend_relabel").GetString()!;
+        Assert.StartsWith("External-to-external frontend relabel:", frontendRelabel);
+        Assert.Contains("residence, reader, and routing root stay unchanged", frontendRelabel, StringComparison.Ordinal);
+        Assert.Contains("no transition command is involved", frontendRelabel, StringComparison.Ordinal);
+        Assert.Contains("do not use `session-layer topology update-residence`", frontendRelabel, StringComparison.Ordinal);
+        Assert.Contains("frontend is an operator label, never a routing input", frontendRelabel, StringComparison.Ordinal);
+        Assert.Contains("re-record at most", frontendRelabel, StringComparison.Ordinal);
+
+        var routingRootMust = contract.GetProperty("routing_root_must").GetString()!;
+        Assert.Contains("MUST", routingRootMust, StringComparison.Ordinal);
+        Assert.Contains("strands notify records", routingRootMust, StringComparison.Ordinal);
+        Assert.Contains("delivered: true", routingRootMust, StringComparison.Ordinal);
+
+        var collectLoop = contract.GetProperty("collect_loop").GetString()!;
+        Assert.Contains("--role design", collectLoop, StringComparison.Ordinal);
+        Assert.Contains("--wait --timeout-ms", collectLoop, StringComparison.Ordinal);
+        Assert.Contains("--routing-root /g774-parent", collectLoop, StringComparison.Ordinal);
+        Assert.Contains("caller holds the cursor", collectLoop, StringComparison.Ordinal);
+
+        var wakeChannel = contract.GetProperty("wake_channel_pattern").GetString()!;
+        Assert.Contains("courtesy-only", wakeChannel, StringComparison.Ordinal);
+        Assert.Contains("dual-send", wakeChannel, StringComparison.Ordinal);
+        Assert.Contains("durable wake addresses", wakeChannel, StringComparison.Ordinal);
+
+        var orcaExample = contract.GetProperty("orca_worked_example").GetString()!;
+        Assert.Contains("Non-normative Orca example", orcaExample, StringComparison.Ordinal);
+        Assert.Contains("orca orchestration run-use --id <run-id>", orcaExample, StringComparison.Ordinal);
+        Assert.Contains("orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json", orcaExample, StringComparison.Ordinal);
+        Assert.Contains("intent-cli neither launches nor manages Orca", orcaExample, StringComparison.Ordinal);
+
+        var residenceTransition = contract.GetProperty("residence_transition").GetString()!;
+        Assert.Contains("different operation", residenceTransition, StringComparison.Ordinal);
+        Assert.Contains("herdr↔external", residenceTransition, StringComparison.Ordinal);
+        Assert.Contains("session-layer topology update-residence", residenceTransition, StringComparison.Ordinal);
+
+        using var unknownArgumentWriter = new StringWriter();
+        Assert.Equal(1, GuideDesignThreadCommand.Execute(CreateContext(), ["--frontend", "orca"], unknownArgumentWriter));
+        Assert.Contains("Unknown argument '--frontend'.", unknownArgumentWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Markdown_RendersPacketAuthoringCheckWithAllRecognitionExamples_G774()
     {
         using var writer = new StringWriter();
@@ -172,6 +255,59 @@ public sealed class GuideDesignThreadG654Tests
         Assert.Contains("named discriminating pair", output, StringComparison.Ordinal);
         foreach (var recognitionExample in new[] { "G765 AC4/AC6", "G767 AC1/AC6", "G769 AC3/AC4", "root resolution" })
             Assert.Contains(recognitionExample, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Markdown_RendersExternalResidenceOperatingContractInIncidentOrder_G775()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(CreateContext(), ["--domain", "intent-cli", "--team", "intent-cli-dev", "--routing-root", "/g775-routing-root"], writer));
+        var output = writer.ToString();
+        var sectionStart = output.IndexOf("## 9. External-residence operating contract (G775)", StringComparison.Ordinal);
+        var sectionEnd = output.IndexOf("## Negative invariants", sectionStart, StringComparison.Ordinal);
+        Assert.True(sectionStart >= 0 && sectionEnd > sectionStart, output);
+        var section = output[sectionStart..sectionEnd];
+
+        Assert.StartsWith(
+            "## 9. External-residence operating contract (G775)\n- **frontend relabel first:** External-to-external frontend relabel:",
+            section);
+        Assert.Contains("residence, reader, and routing root stay unchanged", section, StringComparison.Ordinal);
+        Assert.Contains("no transition command is involved", section, StringComparison.Ordinal);
+        Assert.Contains("do not use `session-layer topology update-residence`", section, StringComparison.Ordinal);
+        Assert.Contains("frontend is an operator label, never a routing input", section, StringComparison.Ordinal);
+        Assert.Contains("Routing-root MUST", section, StringComparison.Ordinal);
+        Assert.Contains("delivered: true", section, StringComparison.Ordinal);
+        Assert.Contains("--role design", section, StringComparison.Ordinal);
+        Assert.Contains("--wait --timeout-ms", section, StringComparison.Ordinal);
+        Assert.Contains("--routing-root /g775-routing-root", section, StringComparison.Ordinal);
+        Assert.Contains("courtesy-only", section, StringComparison.Ordinal);
+        Assert.Contains("dual-send", section, StringComparison.Ordinal);
+        Assert.Contains("Non-normative Orca example", section, StringComparison.Ordinal);
+        Assert.Contains("intent-cli neither launches nor manages Orca", section, StringComparison.Ordinal);
+        Assert.Contains("A herdr↔external residence change is a different operation", section, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BootstrapExternalBranchNamesDistinctUpdateResidenceRoute_G775()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            GuideBootstrapCommand.Execute(
+                CreateContext(),
+                ["--domain", "intent-cli", "--team", "intent-cli-dev", "--target-repo", "example/repo", "--routing-root", "/g775-routing-root", "--format", "markdown"],
+                writer));
+        var output = writer.ToString();
+        var stepStart = output.IndexOf("### 5. ask-app-kind-and-place-design", StringComparison.Ordinal);
+        var stepEnd = output.IndexOf("### 6. delegate-first-task", stepStart, StringComparison.Ordinal);
+        Assert.True(stepStart >= 0 && stepEnd > stepStart, output);
+        var externalBranch = output[stepStart..stepEnd];
+
+        var relabelIndex = externalBranch.IndexOf("external-to-external frontend relabel", StringComparison.Ordinal);
+        var transitionIndex = externalBranch.IndexOf("session-layer topology update-residence", StringComparison.Ordinal);
+        Assert.True(relabelIndex >= 0 && transitionIndex > relabelIndex, externalBranch);
+        Assert.Contains("different operation", externalBranch, StringComparison.Ordinal);
+        Assert.Contains("--current-resident <herdr|external>", externalBranch, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -250,7 +386,67 @@ public sealed class GuideDesignThreadG654Tests
         Assert.Contains("判別対", ja, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void EnglishAndJapaneseDocs_SemanticallyMirrorExternalResidenceOperatingContract_G775()
+    {
+        var en = ReadRepoFile("docs/en/12-agent-message-orchestration.md");
+        var ja = ReadRepoFile("docs/ja/12-agent-message-orchestration.md");
+        var enSection = Section(en, "### External-residence operating contract (G775)", "### Role-contract precedence");
+        var jaSection = Section(ja, "### external residence の運用契約（G775）", "### role contract の precedence");
+
+        Assert.StartsWith("### External-residence operating contract (G775)\n\n**Frontend relabel first.", enSection);
+        Assert.Contains("residence, reader, and routing root are unchanged", enSection, StringComparison.Ordinal);
+        Assert.Contains("No transition command is involved", enSection, StringComparison.Ordinal);
+        Assert.Contains("delivered: true", enSection, StringComparison.Ordinal);
+        Assert.Contains("--wait --timeout-ms", enSection, StringComparison.Ordinal);
+        Assert.Contains("courtesy-only", enSection, StringComparison.Ordinal);
+        Assert.Contains("dual-send", enSection, StringComparison.Ordinal);
+        Assert.Contains("Non-normative Orca worked example", enSection, StringComparison.Ordinal);
+        Assert.Contains("intent-cli neither launches nor manages Orca", enSection, StringComparison.Ordinal);
+        Assert.Contains("different operation", enSection, StringComparison.Ordinal);
+        Assert.Contains("guide bootstrap", enSection, StringComparison.Ordinal);
+        Assert.True(
+            enSection.IndexOf("A herdr↔external residence transition", StringComparison.Ordinal)
+            < enSection.IndexOf("**Bind the wake address.**", StringComparison.Ordinal));
+        Assert.True(
+            enSection.IndexOf("**Bind the wake address.**", StringComparison.Ordinal)
+            < enSection.IndexOf("**Collect after binding.**", StringComparison.Ordinal));
+        Assert.True(
+            enSection.IndexOf("**Collect after binding.**", StringComparison.Ordinal)
+            < enSection.IndexOf("**Dual-send after the loop is established.**", StringComparison.Ordinal));
+
+        Assert.StartsWith("### external residence の運用契約（G775）\n\n**最初にフロントエンドの表示名変更。", jaSection);
+        Assert.Contains("residence、reader、routing root は変わりません", jaSection, StringComparison.Ordinal);
+        Assert.Contains("transition command は関与しません", jaSection, StringComparison.Ordinal);
+        Assert.Contains("delivered: true", jaSection, StringComparison.Ordinal);
+        Assert.Contains("--wait --timeout-ms", jaSection, StringComparison.Ordinal);
+        Assert.Contains("courtesy-only", jaSection, StringComparison.Ordinal);
+        Assert.Contains("dual-send", jaSection, StringComparison.Ordinal);
+        Assert.Contains("非規範的な Orca の例", jaSection, StringComparison.Ordinal);
+        Assert.Contains("intent-cli は Orca を起動も管理もしません", jaSection, StringComparison.Ordinal);
+        Assert.Contains("別の操作", jaSection, StringComparison.Ordinal);
+        Assert.Contains("guide bootstrap", jaSection, StringComparison.Ordinal);
+        Assert.True(
+            jaSection.IndexOf("herdr↔external の residence transition", StringComparison.Ordinal)
+            < jaSection.IndexOf("**wake address を接続。**", StringComparison.Ordinal));
+        Assert.True(
+            jaSection.IndexOf("**wake address を接続。**", StringComparison.Ordinal)
+            < jaSection.IndexOf("**接続後に collect。**", StringComparison.Ordinal));
+        Assert.True(
+            jaSection.IndexOf("**接続後に collect。**", StringComparison.Ordinal)
+            < jaSection.IndexOf("**loop を確立してから dual-send。**", StringComparison.Ordinal));
+    }
+
     private static string Join(JsonElement array) => string.Join('\n', array.EnumerateArray().Select(item => item.GetString()));
+
+    private static string Section(string document, string start, string end)
+    {
+        var startIndex = document.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(startIndex >= 0, $"Missing section '{start}'.");
+        var endIndex = document.IndexOf(end, startIndex, StringComparison.Ordinal);
+        Assert.True(endIndex > startIndex, $"Missing section terminator '{end}'.");
+        return document[startIndex..endIndex];
+    }
 
     private static string ComputePayloadOracle(IEnumerable<JsonProperty> fields)
     {


### PR DESCRIPTION
## Summary

- Render the additive external-residence operating block: frontend relabel first, routing-root law, collect/wake/dual-send contract, non-normative Orca example, and distinct residence transition.
- Make `guide bootstrap` name the distinct `update-residence` route from its external branch.
- Pin the G774 baseline/full payload plus G775 rendered JSON, Markdown, documentation, and no-new-routing-input coverage.

## Verification

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~GuideDesignThreadG654Tests|FullyQualifiedName~GuideBootstrapG664Tests|FullyQualifiedName~GuideDesignThreadCommandTests|FullyQualifiedName~NotifyCollectCommandTests|FullyQualifiedName~SessionLayerTopologyCommandTests|FullyQualifiedName~JapaneseTerminologyGuardG613Tests|FullyQualifiedName~AgentMessageOrchestrationDocsTests"`
- `dotnet build IntentSystem.sln --configuration Release --no-restore`
- `dotnet test IntentSystem.sln --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"`
- `git diff --check`

Closes #1688