### PR TITLE
feat: render declared external wake channels

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -290,6 +290,16 @@ intent-cli notify collect --domain <domain> --team <team> --role design --since 
 the durable record. A wake channel is a courtesy-only signal; dual-send is the
 practiced form.
 
+**Declare the courtesy wake explicitly (G776).** Only an operator may add a
+literal, one-line `--wake-command` template to an `external` topology record.
+The record and `session-layer topology show` preserve the declaration verbatim.
+At render time, `notify delegate` substitutes `{task_id}` and `{summary}` only;
+unknown placeholders such as `{foo}` remain literal. The canonical notify write
+always comes first. The resulting one-line wake is courtesy-only and never
+substitutes for the durable record. `intent-cli` renders this operator-supplied
+text only: it never executes, validates by shelling out, health-checks, launches,
+or manages the command.
+
 > **Non-normative Orca worked example.** A design operator may bind the
 > coordinator terminal before reading, then perform Orca's bounded blocking
 > check:
@@ -301,6 +311,13 @@ practiced form.
 >
 > Orca is only a courtesy wake receiver beside canonical `intent-cli notify`;
 > intent-cli neither launches nor manages Orca.
+>
+> An external design seat may also declare its durable run-addressed courtesy
+> wake template (not a routing input):
+>
+> ```text
+> orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}
+> ```
 
 ### Role-contract precedence (G672 — preview-through-1.x)
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -260,6 +260,15 @@ intent-cli notify collect --domain <domain> --team <team> --role design --since 
 **loop を確立してから dual-send。** canonical な `intent-cli notify` は永続的な record
 です。wake channel は `courtesy-only` の signal であり、`dual-send` が実践する形です。
 
+**courtesy wake を明示的に宣言（G776）。** `external` topology record に literal な
+一行の `--wake-command` template を追加できるのは operator だけです。record と
+`session-layer topology show` は宣言をそのまま保持して表示します。render 時にだけ
+`notify delegate` が `{task_id}` と `{summary}` を置換し、`{foo}` のような未知の
+placeholder は literal のまま残します。canonical notify write が必ず先であり、得られる
+一行の wake は `courtesy-only` で、永続的な record の代わりにはなりません。intent-cli は
+operator が渡した text を render するだけで、shell を起動して実行・検証・`health-check` を
+行ったり、command を起動・管理したりしません。
+
 > **非規範的な Orca の例。** design operator は読む前に coordinator terminal を接続し、
 > Orca の bounded blocking check を実行できます。
 >
@@ -270,6 +279,13 @@ intent-cli notify collect --domain <domain> --team <team> --role design --since 
 >
 > Orca は canonical な `intent-cli notify` に添える courtesy wake receiver だけです。
 > intent-cli は Orca を起動も管理もしません。
+>
+> external design seat は永続的な run address 向けの courtesy wake template も
+> 宣言できます（routing input ではありません）。
+>
+> ```text
+> orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}
+> ```
 
 ### role contract の precedence（G672 — preview-through-1.x）
 

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -201,6 +201,7 @@ internal static class GuideDesignThreadCommand
                 RoutingRootMust = "Routing-root MUST: every notify send and receive uses the canonical routing root. A wrong root strands notify records outside canonical state while the sender still returns `delivered: true`.",
                 CollectLoop = $"Collect loop: `intent-cli notify collect --domain {domainArg} --team {teamArg} --role design --since <cursor> --wait --timeout-ms <timeout-ms> --routing-root {root} --format json`; the caller holds the cursor, consumes the returned next cursor, and omits `--since` only for the first receive.",
                 WakeChannelPattern = "Wake-channel pattern: canonical `intent-cli notify` is the durable record; a wake channel is a courtesy-only signal; dual-send is the practiced form. Bind durable wake addresses before reading and never substitute a terminal-only address for a durable bound address.",
+                WakeChannelDeclaration = "Declared external wake: an operator may record one literal one-line `--wake-command` template on an external role, for example `orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}`. `notify delegate` renders `{task_id}` and `{summary}` only as text, leaves unknown placeholders untouched, and never executes, validates, health-checks, launches, or manages the command. The canonical notify write always comes first; the rendered declared wake is courtesy-only and never substitutes for that durable record.",
                 OrcaWorkedExample = "Non-normative Orca example: bind the design coordinator terminal before reading with `orca orchestration run-use --id <run-id>`, then use the blocking check `orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json`. Orca is only a courtesy wake receiver alongside canonical `intent-cli notify`; intent-cli neither launches nor manages Orca.",
                 ResidenceTransition = $"A herdr↔external residence change is a different operation from an external-to-external frontend relabel: `intent-cli session-layer topology update-residence --domain {domainArg} --team {teamArg} --role design --current-resident <herdr|external> --new-resident <herdr|external> [destination fields] --confirm-update-residence --write --format json`.",
             },
@@ -293,6 +294,7 @@ internal static class GuideDesignThreadCommand
         writer.WriteLine($"- **routing-root law:** {result.ExternalResidenceOperatingContract.RoutingRootMust}");
         writer.WriteLine($"- **collect:** {result.ExternalResidenceOperatingContract.CollectLoop}");
         writer.WriteLine($"- **wake channel:** {result.ExternalResidenceOperatingContract.WakeChannelPattern}");
+        writer.WriteLine($"- **declared wake:** {result.ExternalResidenceOperatingContract.WakeChannelDeclaration}");
         writer.WriteLine($"- **worked example:** {result.ExternalResidenceOperatingContract.OrcaWorkedExample}");
         writer.WriteLine($"- **different transition:** {result.ExternalResidenceOperatingContract.ResidenceTransition}");
         WriteList(writer, "## Negative invariants", result.NegativeInvariants);
@@ -423,6 +425,7 @@ internal sealed record DesignThreadExternalResidenceOperatingContract
     public required string RoutingRootMust { get; init; }
     public required string CollectLoop { get; init; }
     public required string WakeChannelPattern { get; init; }
+    public required string WakeChannelDeclaration { get; init; }
     public required string OrcaWorkedExample { get; init; }
     public required string ResidenceTransition { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -2226,6 +2226,7 @@ internal static class GuideOrchestratorThreadCommand
                     "Implementation/review threads finish a delegation with exactly one canonical `intent-cli notify report` call using the command embedded by `notify delegate`. "
                     + "The reply is a SIGNAL; the orchestrator re-verifies every claim against intent-cli / GitHub "
                     + "before acting on it.",
+                WakeChannelDeclaration = "Declared external wake: when an external recipient topology record declares a literal `--wake-command`, `notify delegate` renders that text only. The canonical notify write is the durable record and always comes first; after it succeeds, the rendered wake is a courtesy-only signal that never substitutes for the record. intent-cli never executes, validates, health-checks, launches, or manages the declaration.",
                 Accepted = "{\"status\":\"accepted\",\"thread\":\"implementation\",\"ref\":\"issue#<n>\",\"note\":\"claimed; starting\"}",
                 Progress = "{\"status\":\"progress\",\"thread\":\"implementation\",\"ref\":\"issue#<n>\",\"note\":\"branch pushed; CI running\"}",
                 Completed = "{\"status\":\"completed\",\"thread\":\"implementation\",\"ref\":\"pr#<n>\",\"note\":\"PR opened, Closes #<n>, CI green\"}",
@@ -5201,6 +5202,8 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine();
         writer.WriteLine(guide.AgmsgReplyContract.Description);
         writer.WriteLine();
+        writer.WriteLine($"- **declared external wake:** {guide.AgmsgReplyContract.WakeChannelDeclaration}");
+        writer.WriteLine();
         writer.WriteLine("```json");
         writer.WriteLine(guide.AgmsgReplyContract.Accepted);
         writer.WriteLine(guide.AgmsgReplyContract.Progress);
@@ -7187,6 +7190,9 @@ internal sealed record OrchestratorReplyContract
 {
     [JsonPropertyName("description")]
     public required string Description { get; init; }
+
+    [JsonPropertyName("wake_channel_declaration")]
+    public required string WakeChannelDeclaration { get; init; }
 
     [JsonPropertyName("accepted")]
     public required string Accepted { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -1743,8 +1743,14 @@ internal static class NotifyCommand
         var reportCommand = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
             ? BuildReportCommand(options)
             : null;
+        var recipientWakeCommand = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? ResolveDeclaredCourtesyWakeCommand(options, options.ToRole!, options.Objective!)
+            : null;
+        var reportWakeCommand = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? ResolveDeclaredCourtesyWakeCommand(options, options.ReportToRole!, "<one-line-summary>")
+            : null;
         var payload = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
-            ? BuildDelegatePayload(options, reportCommand!)
+            ? BuildDelegatePayload(options, reportCommand!, reportWakeCommand)
             : BuildReportPayload(options);
         NotifyPendingDelegation? reportPendingRecord = null;
         if (isReport)
@@ -2155,7 +2161,8 @@ internal static class NotifyCommand
             pendingRecordPath: pendingRecordPath,
             advisory: reportAdvisory,
             outboxEntryPath: outboxEntryPath,
-            continuationChain: continuationChain));
+            continuationChain: continuationChain,
+            courtesyWakeCommand: recipientWakeCommand));
         return 0;
     }
 
@@ -2401,7 +2408,10 @@ internal static class NotifyCommand
         return 0;
     }
 
-    private static string BuildDelegatePayload(NotifyOptions options, string reportCommand)
+    private static string BuildDelegatePayload(
+        NotifyOptions options,
+        string reportCommand,
+        string? reportWakeCommand)
     {
         var builder = new StringBuilder();
         builder.AppendLine($"TASK {options.TaskId}");
@@ -2421,7 +2431,17 @@ internal static class NotifyCommand
         builder.AppendLine($"  task-id: {options.TaskId}");
         builder.AppendLine($"  expected-artifact: {string.Join("; ", options.ExpectedArtifacts)}");
         builder.AppendLine($"  canonical-report-command: {reportCommand}");
-        builder.AppendLine("  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.");
+        if (reportWakeCommand is null)
+        {
+            // G776: the undeclared installed base retains every original byte,
+            // including this strict no-hand-written-transport instruction.
+            builder.AppendLine("  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.");
+        }
+        else
+        {
+            builder.AppendLine($"  courtesy-wake-command: {reportWakeCommand}");
+            builder.AppendLine("  required-final-step: Run canonical-report-command after all other work; after it succeeds, send the rendered courtesy-wake-command as a courtesy-only signal. It never substitutes for the durable canonical record. Do not hand-write any other transport invocation.");
+        }
         builder.AppendLine("result-prefix: ORCH_RESULT");
         builder.AppendLine($"result-nonce: {options.ResultNonce}");
         builder.Append("completion-marker: When the artifact is ready, concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Do not precompose the marker in this task block.");
@@ -2449,6 +2469,35 @@ internal static class NotifyCommand
         return string.IsNullOrWhiteSpace(cwd)
             ? MissingRecipientWorkRootPlaceholder
             : ShellQuote(Path.GetFullPath(cwd));
+    }
+
+    /// <summary>
+    /// G776: reads an operator-declared external wake template only so it can
+    /// be rendered into the caller-facing contract. It deliberately does not
+    /// participate in delivery resolution and never reaches a process runner.
+    /// </summary>
+    private static string? ResolveDeclaredCourtesyWakeCommand(
+        NotifyOptions options,
+        string role,
+        string summary)
+    {
+        var topology = NotifyRoleTopologyStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!);
+        var roleResolution = topology.Resolved && topology.Topology is { } teamTopology
+            ? NotifyRoleTopologyStore.ResolveRecordedRole(teamTopology, role)
+            : null;
+        var record = roleResolution?.Resolved == true
+            ? roleResolution.Record
+            : null;
+        if (record is null
+            || !string.Equals(record.Resident, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal)
+            || record.WakeCommand is null)
+        {
+            return null;
+        }
+
+        return record.WakeCommand
+            .Replace("{task_id}", options.TaskId!, StringComparison.Ordinal)
+            .Replace("{summary}", summary, StringComparison.Ordinal);
     }
 
     private static string? BuildReconciliationCommand(string operation, NotifyOptions options) =>
@@ -2519,7 +2568,8 @@ internal static class NotifyCommand
         string? advisory = null,
         string? outboxEntryPath = null,
         string? deliveryBasis = null,
-        ContinuationChainRecord? continuationChain = null) => new()
+        ContinuationChainRecord? continuationChain = null,
+        string? courtesyWakeCommand = null) => new()
         {
             Operation = operation,
             RoutingRoot = options.RoutingRoot!,
@@ -2557,6 +2607,7 @@ internal static class NotifyCommand
             Cause = null,
             Payload = payload,
             ReportCommand = reportCommand,
+            CourtesyWakeCommand = courtesyWakeCommand,
             ReconciliationCommand = BuildReconciliationCommand(operation, options),
             ContinuationChain = continuationChain,
             Summary = summary,
@@ -2720,6 +2771,11 @@ internal static class NotifyCommand
         if (result.ReportCommand is not null)
         {
             writer.WriteLine($"- report command: `{result.ReportCommand}`");
+        }
+        if (result.CourtesyWakeCommand is not null)
+        {
+            writer.WriteLine($"- courtesy wake command: `{result.CourtesyWakeCommand}`");
+            writer.WriteLine($"- courtesy wake instruction: {result.CourtesyWakeInstruction}");
         }
         if (result.ReconciliationCommand is not null)
         {
@@ -3592,6 +3648,14 @@ internal sealed record NotifyResult
     [JsonPropertyName("cause")] public string? Cause { get; init; }
     [JsonPropertyName("payload")] public string? Payload { get; init; }
     [JsonPropertyName("report_command")] public string? ReportCommand { get; init; }
+    [JsonPropertyName("courtesy_wake_command")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CourtesyWakeCommand { get; init; }
+    [JsonPropertyName("courtesy_wake_instruction")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CourtesyWakeInstruction => CourtesyWakeCommand is null
+        ? null
+        : "After the canonical notify write succeeds, send this declared command as a courtesy-only wake; it never substitutes for the durable canonical record.";
     [JsonPropertyName("reconciliation_command")] public string? ReconciliationCommand { get; init; }
     [JsonPropertyName("continuation_chain")] public ContinuationChainRecord? ContinuationChain { get; init; }
     [JsonPropertyName("completion_signal_id")]

--- a/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
@@ -16,7 +16,8 @@ internal sealed record NotifyRecordedRole(
     string? EnvelopeProfileReference = null,
     AgentLaunchEnvelopeProfile? EnvelopeProfileOverride = null,
     string? Model = null,
-    string? ReasoningEffort = null)
+    string? ReasoningEffort = null,
+    string? WakeCommand = null)
 {
     public const string HerdrResident = "herdr";
     public const string ExternalResident = "external";
@@ -105,6 +106,62 @@ internal static class SessionLayerTopologyDeclaredValueRules
         if (value.Length > MaxLength)
         {
             error = $"{field} must be at most {MaxLength} characters when supplied.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    public static bool TryRead(
+        JsonElement role,
+        string property,
+        out string? value,
+        out string error)
+    {
+        value = null;
+        if (!role.TryGetProperty(property, out var element)
+            || element.ValueKind == JsonValueKind.Null)
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        if (element.ValueKind != JsonValueKind.String)
+        {
+            error = $"Topology field '{property}' must be a string or null when present.";
+            return false;
+        }
+
+        value = element.GetString();
+        return TryValidate(value, $"Topology field '{property}'", out error);
+    }
+}
+
+/// <summary>
+/// G776: an external role may declare one literal, one-line courtesy wake
+/// template. This is syntax-only validation: intent-cli neither parses shell
+/// syntax nor attempts to execute, look up, validate, or health-check it.
+/// </summary>
+internal static class SessionLayerTopologyWakeCommandRules
+{
+    public static bool TryValidate(string? value, string field, out string error)
+    {
+        if (value is null)
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            error = $"{field} must be non-empty when supplied.";
+            return false;
+        }
+
+        if (value.IndexOfAny(['\r', '\n']) >= 0)
+        {
+            error = $"{field} must be a one-line literal command template.";
             return false;
         }
 
@@ -374,6 +431,25 @@ internal static class NotifyRoleTopologyStore
                         $"Role '{property.Name}' has an invalid declared reasoning effort: {reasoningEffortError}");
                 }
 
+                if (!SessionLayerTopologyWakeCommandRules.TryRead(
+                        property.Value,
+                        "wake_command",
+                        out var wakeCommand,
+                        out var wakeCommandError))
+                {
+                    return Failure(
+                        "topology-invalid",
+                        $"Role '{property.Name}' has an invalid declared wake command: {wakeCommandError}");
+                }
+
+                if (wakeCommand is not null
+                    && !string.Equals(resident, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal))
+                {
+                    return Failure(
+                        "topology-invalid",
+                        $"Role '{property.Name}' declares wake_command but only an external resident may declare a courtesy wake command.");
+                }
+
                 if (profileReference is not null)
                 {
                     if (!envelopeProfiles.TryGetValue(profileReference, out var referencedProfile))
@@ -414,7 +490,8 @@ internal static class NotifyRoleTopologyStore
                     profileReference,
                     profileOverride,
                     model,
-                    reasoningEffort));
+                    reasoningEffort,
+                    wakeCommand));
             }
 
             if (roles.Count == 0)

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -24,7 +24,7 @@ internal static class SessionLayerTopologyCommand
         + "[--model <text>] [--reasoning-effort <text>] [--dry-run|--write] "
         + "[--format markdown|json]\n"
         + "   or: intent-cli session-layer topology record --domain <name> --team <name> --role <name> --resident external "
-        + "--reader <routing-root-relative-path> [--frontend <name>] [--model <text>] [--reasoning-effort <text>] "
+        + "--reader <routing-root-relative-path> [--frontend <name>] [--wake-command <literal-template>] [--model <text>] [--reasoning-effort <text>] "
         + "[--dry-run|--write] "
         + "[--format markdown|json]\n"
         + "   Heartbeat coordination accepts recorded role 'orchestration' or the alias 'orchestrator'; existing "
@@ -347,6 +347,7 @@ internal static class SessionLayerTopologyCommand
                 EffectiveReader = readerReport.EffectivePaths.TryGetValue(role, out var effectiveReader)
                     ? effectiveReader
                     : null,
+                WakeCommand = record.Resident == NotifyRecordedRole.ExternalResident ? record.WakeCommand : null,
             });
         }
 
@@ -987,6 +988,7 @@ internal static class SessionLayerTopologyCommand
         string? deliveryMethod = null;
         string? reader = null;
         string? frontend = null;
+        string? wakeCommand = null;
         string? model = null;
         string? reasoningEffort = null;
         var write = false;
@@ -1030,6 +1032,9 @@ internal static class SessionLayerTopologyCommand
                 case "--frontend":
                     if (!TryReadValue(args, ref index, option, out frontend, out error)) return false;
                     break;
+                case "--wake-command":
+                    if (!TryReadValue(args, ref index, option, out wakeCommand, out error)) return false;
+                    break;
                 case "--model":
                     if (!TryReadValue(args, ref index, option, out model, out error)) return false;
                     break;
@@ -1067,7 +1072,8 @@ internal static class SessionLayerTopologyCommand
         }
 
         if (!SessionLayerTopologyDeclaredValueRules.TryValidate(model, "--model", out error)
-            || !SessionLayerTopologyDeclaredValueRules.TryValidate(reasoningEffort, "--reasoning-effort", out error))
+            || !SessionLayerTopologyDeclaredValueRules.TryValidate(reasoningEffort, "--reasoning-effort", out error)
+            || !SessionLayerTopologyWakeCommandRules.TryValidate(wakeCommand, "--wake-command", out error))
         {
             return false;
         }
@@ -1088,9 +1094,9 @@ internal static class SessionLayerTopologyCommand
                 return false;
             }
 
-            if (reader is not null || frontend is not null)
+            if (reader is not null || frontend is not null || wakeCommand is not null)
             {
-                error = "A herdr resident does not accept --reader or --frontend.";
+                error = "A herdr resident does not accept --reader, --frontend, or --wake-command.";
                 return false;
             }
 
@@ -1137,6 +1143,7 @@ internal static class SessionLayerTopologyCommand
             DeliveryMethod = deliveryMethod,
             Reader = reader,
             Frontend = frontend,
+            WakeCommand = wakeCommand,
             Model = model,
             ReasoningEffort = reasoningEffort,
             Write = write,
@@ -1570,9 +1577,12 @@ internal static class SessionLayerTopologyCommand
             var readerDetails = role.Reader is null
                 ? string.Empty
                 : $" reader={role.Reader}; effective_reader={role.EffectiveReader};";
+            var wakeDetails = role.WakeCommand is null
+                ? string.Empty
+                : $" wake_command={role.WakeCommand};";
             writer.WriteLine($"- {role.Role}: resident={role.Resident}; delivery_target={role.DeliveryTargetKind}:"
                 + $"{role.DeliveryTarget}; model={role.Model ?? "absent"}; "
-                + $"reasoning_effort={role.ReasoningEffort ?? "absent"};{readerDetails}");
+                + $"reasoning_effort={role.ReasoningEffort ?? "absent"};{readerDetails}{wakeDetails}");
         }
         foreach (var profile in result.EnvelopeProfiles)
         {
@@ -1615,7 +1625,7 @@ internal static class SessionLayerTopologyWriter
     private static readonly string[] KnownRoleFields =
     [
         "resident", "workspace_id", "pane_id", "cwd", "kind", "delivery_method", "reader", "frontend",
-        "model", "reasoning_effort",
+        "wake_command", "model", "reasoning_effort",
     ];
 
     public static SessionLayerTopologyRecordResult Record(
@@ -1627,9 +1637,22 @@ internal static class SessionLayerTopologyWriter
             || !SessionLayerTopologyDeclaredValueRules.TryValidate(
                 request.ReasoningEffort,
                 "--reasoning-effort",
+                out declaredValueError)
+            || !SessionLayerTopologyWakeCommandRules.TryValidate(
+                request.WakeCommand,
+                "--wake-command",
                 out declaredValueError))
         {
             return Conflict(request, path, declaredValueError);
+        }
+
+        if (request.WakeCommand is not null
+            && !string.Equals(request.Resident, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal))
+        {
+            return Conflict(
+                request,
+                path,
+                "Only an external resident may declare --wake-command.");
         }
 
         if (string.Equals(request.Resident, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal)
@@ -2787,6 +2810,7 @@ internal static class SessionLayerTopologyWriter
         Add(role, "delivery_method", request.DeliveryMethod);
         Add(role, "reader", request.Reader);
         Add(role, "frontend", request.Frontend);
+        Add(role, "wake_command", request.WakeCommand);
         Add(role, "model", request.Model);
         Add(role, "reasoning_effort", request.ReasoningEffort);
         return role;
@@ -3046,6 +3070,7 @@ internal sealed record SessionLayerTopologyRecordRequest
     public string? DeliveryMethod { get; init; }
     public string? Reader { get; init; }
     public string? Frontend { get; init; }
+    public string? WakeCommand { get; init; }
     public string? Model { get; init; }
     public string? ReasoningEffort { get; init; }
     public required bool Write { get; init; }
@@ -3249,4 +3274,5 @@ internal sealed record SessionLayerTopologyShownRole
     public string? ReasoningEffort { get; init; }
     public string? Reader { get; init; }
     public string? EffectiveReader { get; init; }
+    public string? WakeCommand { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/Fixtures/G776/parent-undeclared-delegate-result.json
+++ b/tests/IntentSystem.Cli.Tests/Fixtures/G776/parent-undeclared-delegate-result.json
@@ -1,0 +1,66 @@
+{
+  "operation": "delegate",
+  "routing_root": "<workspace-root>",
+  "domain": "intent-cli",
+  "team": "g776-team",
+  "mode": "herdr-only",
+  "mode_source": "recorded",
+  "command_mode": "write",
+  "from_role": "orchestration",
+  "to_role": "implementation",
+  "task_id": "G776-task",
+  "delivered": true,
+  "event_appended": false,
+  "session_layer_preflight": {
+    "verdict": "ready",
+    "ready": true,
+    "expected_team_declared": true,
+    "cross_domain_teams_elided": [],
+    "scopes": [
+      {
+        "domain": "intent-cli",
+        "team": "g776-team",
+        "verdict": "ready",
+        "ready": true,
+        "mode": "herdr-only",
+        "mode_source": "recorded",
+        "topology_mode": "herdr-only",
+        "findings": [
+          {
+            "team": "g776-team",
+            "role": "\u003Cmarker\u003E",
+            "field": "marker",
+            "cause": "marker-not-generated",
+            "message": "No managed marker has been generated for team \u0027g776-team\u0027 in domain \u0027intent-cli\u0027. This is informational; generate it with \u0060intent-cli session-layer marker generate --domain intent-cli --team g776-team --file \u003CAGENTS.md|CLAUDE.md\u003E --write\u0060.",
+            "recorded_mode": "herdr-only"
+          }
+        ],
+        "summary": "Passive session-layer structure is ready for team \u0027g776-team\u0027 in recorded mode \u0027herdr-only\u0027. Only that recorded transport may be probed; active receiver readiness is reported separately."
+      }
+    ],
+    "passive_phase": {
+      "status": "ready",
+      "checked": true,
+      "contacted_receiver": false,
+      "summary": "Session-layer passive preflight passed for 1 named team scope(s)."
+    },
+    "active_phase": {
+      "status": "observed",
+      "checked": true,
+      "contacted_receiver": true,
+      "summary": "Bounded herdr prompt-wait observed the settled recipient enter unattended work; a second bounded agent wait then observed its fresh settled acknowledgement state."
+    },
+    "summary": "Session-layer passive preflight passed for 1 named team scope(s)."
+  },
+  "receiver_state_outcome": "idle-transitions",
+  "working_transition": "observed",
+  "settle_outcome": "observed",
+  "resend_permitted": false,
+  "delivery_method": "file-backed",
+  "task_file": "<workspace-root>/.intent-cli/tasks/intent-cli/g776-team/G776-task-g776-nonce.md",
+  "delivery_pointer": "Read and execute task envelope: <workspace-root>/.intent-cli/tasks/intent-cli/g776-team/G776-task-g776-nonce.md",
+  "pending_record_path": "<workspace-root>/.intent-cli/notify/intent-cli/g776-team/pending.jsonl",
+  "payload": "TASK G776-task\nrole: implementation\nobjective: Implement wake contract\ninputs:\n  - issue #1689\nexpected-artifacts:\n  - ready PR\nreporting-contract:\n  task-id: G776-task\n  expected-artifact: ready PR\n  canonical-report-command: intent-cli notify report --domain intent-cli --team g776-team --from implementation --to orchestration --task-id G776-task --status \u003Ccompleted|blocked|question\u003E --artifact \u003Cartifact\u003E --summary \u003Cone-line-summary\u003E --routing-root \u0027<workspace-root>\u0027 --report-root \u003Crole-work-root\u003E --write --format json\n  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.\nresult-prefix: ORCH_RESULT\nresult-nonce: g776-nonce\ncompletion-marker: When the artifact is ready, concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Do not precompose the marker in this task block.",
+  "report_command": "intent-cli notify report --domain intent-cli --team g776-team --from implementation --to orchestration --task-id G776-task --status \u003Ccompleted|blocked|question\u003E --artifact \u003Cartifact\u003E --summary \u003Cone-line-summary\u003E --routing-root \u0027<workspace-root>\u0027 --report-root \u003Crole-work-root\u003E --write --format json",
+  "summary": "Delivered notification to herdr logical role \u0027implementation\u0027 in team \u0027g776-team\u0027 workspace \u0027w-g776\u0027 at recorded pane \u0027w-g776:p2\u0027 after a bounded observed unattended working transition and fresh settled acknowledgement."
+}

--- a/tests/IntentSystem.Cli.Tests/Fixtures/G776/parent-undeclared-envelope.md
+++ b/tests/IntentSystem.Cli.Tests/Fixtures/G776/parent-undeclared-envelope.md
@@ -1,0 +1,15 @@
+TASK G776-task
+role: implementation
+objective: Implement wake contract
+inputs:
+  - issue #1689
+expected-artifacts:
+  - ready PR
+reporting-contract:
+  task-id: G776-task
+  expected-artifact: ready PR
+  canonical-report-command: intent-cli notify report --domain intent-cli --team g776-team --from implementation --to orchestration --task-id G776-task --status <completed|blocked|question> --artifact <artifact> --summary <one-line-summary> --routing-root '<workspace-root>' --report-root <role-work-root> --write --format json
+  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.
+result-prefix: ORCH_RESULT
+result-nonce: g776-nonce
+completion-marker: When the artifact is ready, concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Do not precompose the marker in this task block.

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadCommandTests.cs
@@ -92,7 +92,7 @@ public sealed class GuideDesignThreadCommandTests
                     writer));
 
             var hash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(writer.ToString())));
-            Assert.Equal("cb18bd2786f4eb295f5c603f9d6ab7d2564724f3d5ea554ab2820bff80ffb008", hash);
+            Assert.Equal("12c26fdd6891c5536d1eb13e215b36296cb71654b33a870048735864cd99caa4", hash);
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
@@ -41,6 +41,9 @@ public sealed class GuideDesignThreadG654Tests
     private static readonly string[] G774BaselinePayloadFieldNames =
         ParentPayloadFieldNames.Append("packet_authoring_check").ToArray();
     private const string G774BaselinePayloadOracleHash = "8110a6150605810aaa609fc2c34668341b939e58bc0dc35085c7290e6c72b136";
+    // G776 may append exactly one declaration field. The existing G775
+    // operating-contract fields remain a raw-value and rendered-order oracle.
+    private const string G775ExternalResidenceContractOracleHash = "192178832e068e7651fc09fa9377059f1b3298cc91da263e428aa31a397bcd03";
 
     [Theory]
     [InlineData("agmsg", false)]
@@ -196,10 +199,31 @@ public sealed class GuideDesignThreadG654Tests
                 "routing_root_must",
                 "collect_loop",
                 "wake_channel_pattern",
+                "wake_channel_declaration",
                 "orca_worked_example",
                 "residence_transition",
             },
             contract.EnumerateObject().Select(field => field.Name));
+
+        var g775Fields = contract
+            .EnumerateObject()
+            .Where(field => field.Name != "wake_channel_declaration")
+            .ToArray();
+        Assert.Equal(
+            new[]
+            {
+                "frontend_relabel",
+                "routing_root_must",
+                "collect_loop",
+                "wake_channel_pattern",
+                "orca_worked_example",
+                "residence_transition",
+            },
+            g775Fields.Select(field => field.Name));
+        var g775Oracle = ComputePayloadOracle(g775Fields);
+        Assert.True(
+            string.Equals(G775ExternalResidenceContractOracleHash, g775Oracle, StringComparison.Ordinal),
+            $"G775 operating-contract oracle changed. Expected '{G775ExternalResidenceContractOracleHash}', actual '{g775Oracle}'.");
 
         var frontendRelabel = contract.GetProperty("frontend_relabel").GetString()!;
         Assert.StartsWith("External-to-external frontend relabel:", frontendRelabel);
@@ -224,6 +248,13 @@ public sealed class GuideDesignThreadG654Tests
         Assert.Contains("courtesy-only", wakeChannel, StringComparison.Ordinal);
         Assert.Contains("dual-send", wakeChannel, StringComparison.Ordinal);
         Assert.Contains("durable wake addresses", wakeChannel, StringComparison.Ordinal);
+
+        var wakeDeclaration = contract.GetProperty("wake_channel_declaration").GetString()!;
+        Assert.Contains("--wake-command", wakeDeclaration, StringComparison.Ordinal);
+        Assert.Contains("{task_id}", wakeDeclaration, StringComparison.Ordinal);
+        Assert.Contains("{summary}", wakeDeclaration, StringComparison.Ordinal);
+        Assert.Contains("unknown placeholders", wakeDeclaration, StringComparison.Ordinal);
+        Assert.Contains("never executes", wakeDeclaration, StringComparison.Ordinal);
 
         var orcaExample = contract.GetProperty("orca_worked_example").GetString()!;
         Assert.Contains("Non-normative Orca example", orcaExample, StringComparison.Ordinal);
@@ -282,6 +313,8 @@ public sealed class GuideDesignThreadG654Tests
         Assert.Contains("--routing-root /g775-routing-root", section, StringComparison.Ordinal);
         Assert.Contains("courtesy-only", section, StringComparison.Ordinal);
         Assert.Contains("dual-send", section, StringComparison.Ordinal);
+        Assert.Contains("--wake-command", section, StringComparison.Ordinal);
+        Assert.Contains("never executes", section, StringComparison.Ordinal);
         Assert.Contains("Non-normative Orca example", section, StringComparison.Ordinal);
         Assert.Contains("intent-cli neither launches nor manages Orca", section, StringComparison.Ordinal);
         Assert.Contains("A herdr↔external residence change is a different operation", section, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -15,9 +15,9 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     // G655/G673/G683 extend the shared guide; keep the deterministic baseline aligned
     // with the rendered guidance while preserving the hash guard.
     // G684 extends shared orchestrator guidance with envelope-only recipe drift.
-    // G685/G686/G690/G699/G707/G708/G719 intentionally extend the shared guide while preserving
+    // G685/G686/G690/G699/G707/G708/G719/G776 intentionally extend the shared guide while preserving
     // the G594 preflight contract. G696/G697/G700 add structured role-facing routes.
-    private const string G594AgmsgBaselineSha256 = "cb18bd2786f4eb295f5c603f9d6ab7d2564724f3d5ea554ab2820bff80ffb008";
+    private const string G594AgmsgBaselineSha256 = "12c26fdd6891c5536d1eb13e215b36296cb71654b33a870048735864cd99caa4";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -9,11 +9,11 @@ namespace IntentSystem.Cli.Tests;
 
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
-    // G685/G686/G690/G698/G699/G700/G707/G708/G719 extend the shared orchestrator guidance; keep the snapshot
+    // G685/G686/G690/G698/G699/G700/G707/G708/G719/G776 extend the shared orchestrator guidance; keep the snapshot
     // assertion explicit so a future wake-source or route change remains
     // intentional.
     private const string G594AgmsgGuideSha256 =
-        "4357D08439FCC3CCEB2060E0FABF8FDA3C3BBDCB91C9012E04EC4FD88503A75E";
+        "1B24888D61CF71C7F4B0BC31B62A1544C47B432219C92AE7C3CC6EA26C03F268";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/WakeChannelG776Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/WakeChannelG776Tests.cs
@@ -1,0 +1,478 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G776: operator-declared external wake templates are rendered as text in
+/// the existing dispatch/reporting surfaces. These tests deliberately use an
+/// unavailable-looking command name so a process-start regression is visible.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class WakeChannelG776Tests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "g776-team";
+    private const string TaskId = "G776-task";
+    private const string Objective = "Implement wake contract";
+    private const string Nonce = "g776-nonce";
+    private readonly string root = Directory.CreateTempSubdirectory("wake-channel-g776-").FullName;
+    private readonly string agmsgScriptsPath;
+    private readonly CliContext context;
+
+    public WakeChannelG776Tests()
+    {
+        agmsgScriptsPath = Path.Combine(root, "agmsg-scripts");
+        Directory.CreateDirectory(agmsgScriptsPath);
+        File.WriteAllText(Path.Combine(agmsgScriptsPath, "team.sh"), "fixture");
+        File.WriteAllText(Path.Combine(agmsgScriptsPath, "send.sh"), "fixture");
+        context = new CliContext
+        {
+            RepoRoot = root,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = Domain,
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                },
+            },
+        };
+        NotifyCommand.AgmsgScriptsDirectoryFactory = () => agmsgScriptsPath;
+        NotifyCommand.HerdrExecutableFactory = () => "fake-herdr";
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.AgmsgScriptsDirectoryFactory = null;
+        NotifyCommand.HerdrExecutableFactory = null;
+        NotifyTaskEnvelopeStore.WriteOverride = null;
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RecordAndShow_ExternalWakeCommandRoundTripsVerbatim_G776()
+    {
+        const string template = "wake-sentinel --task {task_id} --summary {summary} --unknown {foo}";
+        var (recordExit, record) = RunJson(
+            "session-layer", "topology", "record",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--resident", "external",
+            "--reader", $".intent-cli/events/{Domain}/{Team}.jsonl",
+            "--frontend", "orca",
+            "--wake-command", template,
+            "--write",
+            "--format", "json");
+
+        Assert.True(recordExit == 0, record.GetRawText());
+        Assert.True(record.GetProperty("applied").GetBoolean());
+
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(root, Domain, Team);
+        using var topology = JsonDocument.Parse(File.ReadAllText(topologyPath));
+        Assert.Equal(
+            template,
+            topology.RootElement.GetProperty("roles").GetProperty("design").GetProperty("wake_command").GetString());
+
+        var (herdrRecordExit, herdrRecord) = RunJson(
+            "session-layer", "topology", "record",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "orchestration",
+            "--resident", "herdr",
+            "--workspace-id", "w-g776",
+            "--pane-id", "w-g776:p1",
+            "--cwd", "/workspace",
+            "--write",
+            "--format", "json");
+        Assert.True(herdrRecordExit == 0, herdrRecord.GetRawText());
+
+        var (showExit, showRaw) = RunRaw(
+            "session-layer", "topology", "show",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "json");
+        Assert.True(showExit == 0, showRaw);
+        using var show = JsonDocument.Parse(showRaw);
+        var design = Assert.Single(show.RootElement.GetProperty("roles").EnumerateArray(), role =>
+            role.GetProperty("role").GetString() == "design");
+        Assert.Equal(template, design.GetProperty("wake_command").GetString());
+
+        var (markdownExit, markdown) = RunRaw(
+            "session-layer", "topology", "show",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "markdown");
+        Assert.True(markdownExit == 0, markdown);
+        Assert.Contains("wake_command=" + template, markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Record_HerdrRejectsWakeCommandWithoutWriting_G776()
+    {
+        var (exitCode, output) = RunRaw(
+            "session-layer", "topology", "record",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "implementation",
+            "--resident", "herdr",
+            "--workspace-id", "w-g776",
+            "--pane-id", "w-g776:p1",
+            "--cwd", "/workspace",
+            "--wake-command", "wake-sentinel {task_id}",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("does not accept --reader, --frontend, or --wake-command", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(NotifyRoleTopologyStore.ResolvePath(root, Domain, Team)));
+    }
+
+    [Fact]
+    public void Record_RejectsMultilineWakeCommandWithoutWriting_G776()
+    {
+        var (exitCode, output) = RunRaw(
+            "session-layer", "topology", "record",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--resident", "external",
+            "--reader", ".intent-cli/events/intent-cli/g776-team-design.jsonl",
+            "--wake-command", "wake-sentinel {task_id}\nsecond-line",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be a one-line literal command template", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(NotifyRoleTopologyStore.ResolvePath(root, Domain, Team)));
+    }
+
+    [Fact]
+    public void Delegate_DeclaredRecipientRendersWakeAfterCanonicalWrite_AndNeverExecutesIt_G776()
+    {
+        const string recipientTemplate = "wake-sentinel --task {task_id} --summary {summary} --unknown {foo}";
+        const string reportTemplate = "report-wake --task {task_id} --summary {summary} --unknown {foo}";
+        WriteTopology(
+            implementationExternal: true,
+            implementationWakeCommand: recipientTemplate,
+            orchestrationWakeCommand: reportTemplate);
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, output) = RunRaw(DelegateArgs());
+
+        Assert.True(exitCode == 0, output);
+        using var result = JsonDocument.Parse(output);
+        var rootElement = result.RootElement;
+        Assert.Equal(
+            "wake-sentinel --task G776-task --summary Implement wake contract --unknown {foo}",
+            rootElement.GetProperty("courtesy_wake_command").GetString());
+        Assert.Contains(
+            "After the canonical notify write succeeds",
+            rootElement.GetProperty("courtesy_wake_instruction").GetString(),
+            StringComparison.Ordinal);
+        Assert.True(
+            output.IndexOf("\"report_command\"", StringComparison.Ordinal)
+            < output.IndexOf("\"courtesy_wake_command\"", StringComparison.Ordinal));
+
+        var envelope = rootElement.GetProperty("payload").GetString()!;
+        var canonicalIndex = envelope.IndexOf("  canonical-report-command: ", StringComparison.Ordinal);
+        var wakeIndex = envelope.IndexOf("  courtesy-wake-command: ", StringComparison.Ordinal);
+        Assert.True(canonicalIndex >= 0 && wakeIndex > canonicalIndex, envelope);
+        Assert.Contains(
+            "report-wake --task G776-task --summary <one-line-summary> --unknown {foo}",
+            envelope,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "after it succeeds, send the rendered courtesy-wake-command as a courtesy-only signal",
+            envelope,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "never hand-write a transport invocation.",
+            envelope,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Do not hand-write any other transport invocation.",
+            envelope,
+            StringComparison.Ordinal);
+
+        Assert.DoesNotContain(runner.Calls, call =>
+            string.Equals(call.FileName, "wake-sentinel", StringComparison.Ordinal)
+            || call.Arguments.FirstOrDefault() == "wake-sentinel"
+            || string.Equals(call.FileName, "report-wake", StringComparison.Ordinal)
+            || call.Arguments.FirstOrDefault() == "report-wake");
+        Assert.Empty(runner.Calls);
+    }
+
+    [Fact]
+    public void Delegate_FileBackedEnvelope_RendersReportRecipientWakeAfterCanonicalCommand_G776()
+    {
+        const string reportTemplate = "report-wake --task {task_id} --summary {summary} --unknown {foo}";
+        WriteTopology(
+            implementationExternal: false,
+            implementationWakeCommand: null,
+            orchestrationWakeCommand: reportTemplate);
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, output) = RunRaw(DelegateArgs());
+
+        Assert.True(exitCode == 0, output);
+        using var result = JsonDocument.Parse(output);
+        Assert.False(result.RootElement.TryGetProperty("courtesy_wake_command", out _));
+        Assert.Equal("file-backed", result.RootElement.GetProperty("delivery_method").GetString());
+        var payload = result.RootElement.GetProperty("payload").GetString()!;
+        var taskFile = result.RootElement.GetProperty("task_file").GetString()!;
+        Assert.Equal(Encoding.UTF8.GetBytes(payload), File.ReadAllBytes(taskFile));
+        var canonicalIndex = payload.IndexOf("  canonical-report-command: ", StringComparison.Ordinal);
+        var wakeIndex = payload.IndexOf("  courtesy-wake-command: ", StringComparison.Ordinal);
+        Assert.True(canonicalIndex >= 0 && wakeIndex > canonicalIndex, payload);
+        Assert.Contains(
+            "report-wake --task G776-task --summary <one-line-summary> --unknown {foo}",
+            payload,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(runner.Calls, call =>
+            string.Equals(call.FileName, "report-wake", StringComparison.Ordinal)
+            || call.Arguments.FirstOrDefault() == "report-wake");
+        Assert.Contains(runner.Calls, call =>
+            call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "w-g776:p2"]));
+    }
+
+    [Fact]
+    public void Delegate_UndeclaredTeamRetainsParentResultAndEnvelopeBytes_G776()
+    {
+        WriteTopology(
+            implementationExternal: false,
+            implementationWakeCommand: null,
+            orchestrationWakeCommand: null);
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, output) = RunRaw(DelegateArgs());
+
+        Assert.True(exitCode == 0, output);
+        using var result = JsonDocument.Parse(output);
+        Assert.False(result.RootElement.TryGetProperty("courtesy_wake_command", out _));
+        Assert.False(result.RootElement.TryGetProperty("courtesy_wake_instruction", out _));
+        var payload = result.RootElement.GetProperty("payload").GetString()!;
+        Assert.Contains(
+            "  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.",
+            payload,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("courtesy-wake-command", payload, StringComparison.Ordinal);
+
+        var taskFile = result.RootElement.GetProperty("task_file").GetString()!;
+        Assert.Equal(Encoding.UTF8.GetBytes(payload), File.ReadAllBytes(taskFile));
+        Assert.Equal(ParentUndeclaredEnvelope, NormalizeRoot(payload));
+        Assert.Equal(ParentUndeclaredDelegateResult, NormalizeRoot(output));
+    }
+
+    [Fact]
+    public void Guides_RenderOneDeclaredWakeRule_WithoutReplacingTheCanonicalRecord_G776()
+    {
+        using var designWriter = new StringWriter();
+        Assert.Equal(
+            0,
+            GuideDesignThreadCommand.Execute(
+                context,
+                ["--domain", Domain, "--team", Team, "--routing-root", root, "--format", "markdown"],
+                designWriter));
+        var design = designWriter.ToString();
+        Assert.Equal(1, Count(design, "**declared wake:**"));
+        Assert.Contains("--wake-command", design, StringComparison.Ordinal);
+        Assert.Contains("{task_id}", design, StringComparison.Ordinal);
+        Assert.Contains("{summary}", design, StringComparison.Ordinal);
+        Assert.Contains("unknown placeholders untouched", design, StringComparison.Ordinal);
+        Assert.Contains("never executes, validates, health-checks, launches, or manages", design, StringComparison.Ordinal);
+
+        using var orchestratorWriter = new StringWriter();
+        Assert.Equal(
+            0,
+            GuideOrchestratorThreadCommand.Execute(
+                context,
+                ["--domain", Domain, "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex"],
+                orchestratorWriter));
+        var orchestrator = orchestratorWriter.ToString();
+        Assert.Equal(1, Count(orchestrator, "**declared external wake:**"));
+        Assert.Contains("canonical notify write is the durable record and always comes first", orchestrator, StringComparison.Ordinal);
+        Assert.Contains("never executes, validates, health-checks, launches, or manages", orchestrator, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DocumentationMirrors_DescribeLiteralDeclarationPlaceholdersAndNonExecution_G776()
+    {
+        var en = ReadRepoFile("docs/en/12-agent-message-orchestration.md");
+        var ja = ReadRepoFile("docs/ja/12-agent-message-orchestration.md");
+
+        foreach (var document in new[] { en, ja })
+        {
+            Assert.Contains("--wake-command", document, StringComparison.Ordinal);
+            Assert.Contains("{task_id}", document, StringComparison.Ordinal);
+            Assert.Contains("{summary}", document, StringComparison.Ordinal);
+            Assert.Contains("{foo}", document, StringComparison.Ordinal);
+            Assert.Contains("orca orchestration send --run <run-id> --to run:<run-id>", document, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("never executes, validates by shelling out, health-checks, launches,", en, StringComparison.Ordinal);
+        Assert.Contains("`health-check` を", ja, StringComparison.Ordinal);
+        Assert.Contains("command を起動・管理", ja, StringComparison.Ordinal);
+        Assert.Equal(1, Count(en, "Declare the courtesy wake explicitly (G776)."));
+        Assert.Equal(1, Count(ja, "courtesy wake を明示的に宣言（G776）。"));
+    }
+
+    // Captured from the exact G775 parent 75216283875b08ade3d100de7ddabe3fad0bd21c
+    // with this fixture. The sole substitution makes the test's temporary
+    // routing root deterministic; no field-level projection is used.
+    private static readonly string ParentUndeclaredEnvelope =
+        ReadFixture("parent-undeclared-envelope.md").TrimEnd('\r', '\n');
+    private static readonly string ParentUndeclaredDelegateResult =
+        ReadFixture("parent-undeclared-delegate-result.json");
+
+    private void WriteTopology(
+        bool implementationExternal,
+        string? implementationWakeCommand,
+        string? orchestrationWakeCommand)
+    {
+        var roles = new Dictionary<string, object>
+        {
+            ["orchestration"] = ExternalRole("orchestration", orchestrationWakeCommand),
+            ["implementation"] = implementationExternal
+                ? ExternalRole("implementation", implementationWakeCommand)
+                : new
+                {
+                    resident = "herdr",
+                    workspace_id = "w-g776",
+                    pane_id = "w-g776:p2",
+                    kind = "codex",
+                    delivery_method = "file-backed",
+                },
+            ["review"] = new
+            {
+                resident = "herdr",
+                workspace_id = "w-g776",
+                pane_id = "w-g776:p3",
+            },
+        };
+        var topology = new
+        {
+            domain = Domain,
+            team = Team,
+            workspace_id = "w-g776",
+            roles,
+            host_state = new
+            {
+                role = "orchestration",
+                envelope = "test-owned-host-state",
+            },
+        };
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(root, Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(topologyPath)!);
+        File.WriteAllText(topologyPath, JsonSerializer.Serialize(topology));
+        SetHerdrOnlyMode();
+    }
+
+    private void SetHerdrOnlyMode()
+    {
+        using var writer = new StringWriter();
+        var exitCode = SessionLayerCommand.ExecuteSet(
+            context,
+            ["--domain", Domain, "--team", Team, "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+            writer);
+        Assert.True(exitCode == 0, writer.ToString());
+    }
+
+    private object ExternalRole(string role, string? wakeCommand)
+    {
+        var record = new Dictionary<string, object>
+        {
+            ["resident"] = "external",
+            ["reader"] = $".intent-cli/events/{Domain}/{Team}-{role}.jsonl",
+            ["frontend"] = "orca",
+        };
+        if (wakeCommand is not null)
+        {
+            record["wake_command"] = wakeCommand;
+        }
+
+        return record;
+    }
+
+    private (int ExitCode, JsonElement Result) RunJson(params string[] args)
+    {
+        var (exitCode, output) = RunRaw(args);
+        Assert.True(exitCode == 0, output);
+        return (exitCode, JsonDocument.Parse(output).RootElement.Clone());
+    }
+
+    private (int ExitCode, string Output) RunRaw(params string[] args)
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(args, context, writer);
+        return (exitCode, writer.ToString());
+    }
+
+    private static string[] DelegateArgs() =>
+    [
+        "notify", "delegate", "--domain", Domain, "--team", Team,
+        "--from", "orchestration", "--to", "implementation", "--report-to", "orchestration",
+        "--task-id", TaskId, "--objective", Objective,
+        "--input", "issue #1689", "--expected-artifact", "ready PR", "--result-nonce", Nonce,
+        "--write", "--format", "json",
+    ];
+
+    private static FakeNotifyProcessRunner SuccessfulRunner() => new((_, arguments) =>
+        arguments.SequenceEqual(["agent", "list"])
+            ? new NotifyProcessResult(
+                0,
+                "{\"result\":{\"agents\":[{\"name\":\"implementation\",\"workspace_id\":\"w-g776\",\"pane_id\":\"w-g776:p2\",\"agent\":\"codex\",\"agent_session\":{\"id\":\"implementation\"},\"agent_status\":\"idle\",\"interactive_ready\":true},{\"name\":\"review\",\"workspace_id\":\"w-g776\",\"pane_id\":\"w-g776:p3\",\"agent\":\"codex\",\"agent_session\":{\"id\":\"review\"},\"agent_status\":\"idle\",\"interactive_ready\":true}]}}",
+                string.Empty)
+            : new NotifyProcessResult(0, string.Empty, string.Empty));
+
+    private static int Count(string text, string value) =>
+        text.Split(value, StringSplitOptions.None).Length - 1;
+
+    private string NormalizeRoot(string value) =>
+        value.Replace(root, "<workspace-root>", StringComparison.Ordinal);
+
+    private static string ReadRepoFile(string relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate)) return File.ReadAllText(candidate);
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException(relativePath);
+    }
+
+    private static string ReadFixture(string name) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(),
+        "tests",
+        "IntentSystem.Cli.Tests",
+        "Fixtures",
+        "G776",
+        name));
+
+    private sealed class FakeNotifyProcessRunner(
+        Func<string, IReadOnlyList<string>, NotifyProcessResult> handler) : INotifyProcessRunner
+    {
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            return handler(fileName, arguments);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1689

## Summary
- Adds optional literal one-line `--wake-command` declarations for external topology roles, with verbatim record/show round-tripping.
- Renders declared wakes only after the canonical write into delegate results and report-envelope contracts; unknown placeholders remain literal.
- Preserves byte-identical undeclared delegate/envelope output, extends the existing G775 guide block once per guide, and documents the non-executing boundary in EN/JA.

## Verification
- Focused/adjacent: 216 passed, 0 failed, 0 skipped.
- Release build: succeeded, 0 warnings, 0 errors.
- Full Release tests: 5,473 passed, 0 failed, 1 skipped, 5,474 total.
- `git diff --check origin/main...HEAD`: clean.

## Safety boundary
`--wake-command` remains topology metadata rendered through string replacement only; it is never executed, validated by shelling out, health-checked, launched, or managed. The canonical `intent-cli notify` write remains the durable record.