### PR TITLE
docs: render unreadable-record repair guidance

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1167,6 +1167,12 @@ intent-cli notify supervise repair-unreadable --domain <domain> --team <team> \
   [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
 ```
 
+The rendered `intent-cli guide design-thread` liveness guidance points a seat to
+this command only when liveness reports a non-zero `unreadable_record_count`:
+run `intent-cli notify supervise repair-unreadable` with `--dry-run` first,
+inspect the evidence, and use `--write` only second. It repeats the boundary
+that quarantine preserves unreadable lines verbatim as evidence and makes no reconstruction claim; it is never automatic and never performed on read.
+
 `--dry-run` is the default. It lists every unreadable record with its relative
 file, one-based line number, G767 reason, and source-line byte length, while
 leaving the whole store byte-identical. A clean store is a strict no-op in

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -992,6 +992,13 @@ intent-cli notify supervise repair-unreadable --domain <domain> --team <team> \
   [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
 ```
 
+描画される `intent-cli guide design-thread` の liveness の案内は、liveness が 0 以外の
+`unreadable_record_count` を報告したときだけ、この操作を示します。まず
+`intent-cli notify supervise repair-unreadable` を `--dry-run` で実行して証拠を確認し、
+その後に限って二番目の操作として `--write` を使います。quarantine は読めない行を証拠として
+原文のバイト列のまま保存し、内容を再構成しないという境界を繰り返し示します。これは自動修復でも
+読み取り時の修復でもありません。
+
 default は `--dry-run` です。relative file、1-based line number、G767 の reason、source line の
 byte length をすべて列挙し、store 全体を byte-identical のまま残します。clean store は両 mode で
 strict no-op です。live file、quarantine sidecar、audit の作成・置換はなく、結果は completed repair

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -205,6 +205,7 @@ internal static class GuideDesignThreadCommand
                 OrcaWorkedExample = "Non-normative Orca example: bind the design coordinator terminal before reading with `orca orchestration run-use --id <run-id>`, then use the blocking check `orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json`. Orca is only a courtesy wake receiver alongside canonical `intent-cli notify`; intent-cli neither launches nor manages Orca.",
                 ResidenceTransition = $"A herdr↔external residence change is a different operation from an external-to-external frontend relabel: `intent-cli session-layer topology update-residence --domain {domainArg} --team {teamArg} --role design --current-resident <herdr|external> --new-resident <herdr|external> [destination fields] --confirm-update-residence --write --format json`.",
             },
+            UnreadableRepairResponse = "When liveness reports a non-zero `unreadable_record_count`, the sanctioned response is `intent-cli notify supervise repair-unreadable`: run `--dry-run` first, inspect the evidence, and use `--write` only second; it is never automatic and never performed on read. The repair quarantines unreadable lines verbatim as evidence and makes no reconstruction claim.",
         };
     }
 
@@ -272,6 +273,7 @@ internal static class GuideDesignThreadCommand
         foreach (var item in result.TeamAndDutySplit.DesignEscalations) writer.WriteLine($"  - {item}");
         writer.WriteLine($"- {result.Monitoring.Separation}");
         writer.WriteLine($"- {result.Monitoring.ResidualDesignCheck}");
+        writer.WriteLine($"- **unreadable-record response (G777):** {result.UnreadableRepairResponse}");
         writer.WriteLine($"- {result.Monitoring.BoundRule}");
         writer.WriteLine($"- {result.Monitoring.GuideRefreshRule}");
         writer.WriteLine($"- {result.Monitoring.DeploymentRule}");
@@ -376,6 +378,7 @@ internal sealed record DesignThreadGuideResult
     public required IReadOnlyList<string> NegativeInvariants { get; init; }
     public required DesignThreadPacketAuthoringCheck PacketAuthoringCheck { get; init; }
     public required DesignThreadExternalResidenceOperatingContract ExternalResidenceOperatingContract { get; init; }
+    public required string UnreadableRepairResponse { get; init; }
 }
 
 internal sealed record DesignThreadReachability

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
@@ -131,14 +131,14 @@ public sealed class GuideDesignThreadG654Tests
         var fields = root.EnumerateObject().ToArray();
 
         var g774BaselineFields = fields
-            .Where(field => field.Name != "external_residence_operating_contract")
+            .Where(field => field.Name is not "external_residence_operating_contract" and not "unreadable_repair_response")
             .ToArray();
         Assert.Equal(G774BaselinePayloadFieldNames, g774BaselineFields.Select(field => field.Name));
         var g774BaselineOracle = ComputePayloadOracle(g774BaselineFields);
         Assert.True(
             string.Equals(G774BaselinePayloadOracleHash, g774BaselineOracle, StringComparison.Ordinal),
             $"G774 baseline payload oracle changed. Expected '{G774BaselinePayloadOracleHash}', actual '{g774BaselineOracle}'.");
-        var parentPayloadOracle = ComputePayloadOracle(fields.Where(field => field.Name is not "packet_authoring_check" and not "external_residence_operating_contract"));
+        var parentPayloadOracle = ComputePayloadOracle(fields.Where(field => field.Name is not "packet_authoring_check" and not "external_residence_operating_contract" and not "unreadable_repair_response"));
         Assert.True(
             string.Equals(ParentPayloadOracleHash, parentPayloadOracle, StringComparison.Ordinal),
             $"G654 parent payload oracle changed. Expected '{ParentPayloadOracleHash}', actual '{parentPayloadOracle}'.");
@@ -183,10 +183,13 @@ public sealed class GuideDesignThreadG654Tests
         var root = document.RootElement;
         var fields = root.EnumerateObject().ToArray();
 
+        var g775BaselineFields = fields
+            .Where(field => field.Name != "unreadable_repair_response")
+            .ToArray();
         Assert.Equal(
             G774BaselinePayloadFieldNames.Append("external_residence_operating_contract"),
-            fields.Select(field => field.Name));
-        var g774BaselineOracle = ComputePayloadOracle(fields.Where(field => field.Name != "external_residence_operating_contract"));
+            g775BaselineFields.Select(field => field.Name));
+        var g774BaselineOracle = ComputePayloadOracle(g775BaselineFields.Where(field => field.Name != "external_residence_operating_contract"));
         Assert.True(
             string.Equals(G774BaselinePayloadOracleHash, g774BaselineOracle, StringComparison.Ordinal),
             $"G774 baseline payload oracle changed. Expected '{G774BaselinePayloadOracleHash}', actual '{g774BaselineOracle}'.");

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG777Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG777Tests.cs
@@ -1,0 +1,180 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G777: a liveness answer that names unreadable-record damage must render the
+/// existing G773 repair route without changing any reader or repair behavior.
+/// </summary>
+public sealed class GuideDesignThreadG777Tests
+{
+    private static readonly string[] G776BaselinePayloadFieldNames =
+    [
+        "process",
+        "preview_status",
+        "agent_kind_neutral",
+        "session_layer_rule",
+        "domain",
+        "team",
+        "routing_root",
+        "reachability",
+        "wake_rule",
+        "provenance",
+        "approval",
+        "dialog_answering_rule",
+        "residual_approval",
+        "merge_authority",
+        "delegation_verification",
+        "observation_boundary",
+        "team_and_duty_split",
+        "monitoring",
+        "reporting",
+        "negative_invariants",
+        "packet_authoring_check",
+        "external_residence_operating_contract",
+    ];
+
+    // The full b766f2d0 payload, including raw G774, G775, and G776 blocks,
+    // stays byte-for-byte stable when the one G777 sibling is excluded.
+    private const string G776BaselinePayloadOracleHash = "6cd7190c6e6ef168d738b00f10f3855357166a111ad42c4bbed2bf3e8a59b206";
+
+    [Fact]
+    public void RenderedLivenessGuidance_NamesTheSanctionedDryRunBeforeWriteResponse_G777()
+    {
+        using var document = JsonDocument.Parse(RenderJson());
+        var response = document.RootElement.GetProperty("unreadable_repair_response").GetString()!;
+
+        Assert.Contains("non-zero `unreadable_record_count`", response, StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify supervise repair-unreadable", response, StringComparison.Ordinal);
+        var dryRunIndex = response.IndexOf("`--dry-run`", StringComparison.Ordinal);
+        var writeIndex = response.IndexOf("`--write`", StringComparison.Ordinal);
+        Assert.True(dryRunIndex >= 0 && writeIndex > dryRunIndex, response);
+        Assert.Contains("verbatim as evidence", response, StringComparison.Ordinal);
+        Assert.Contains("no reconstruction claim", response, StringComparison.Ordinal);
+        Assert.Contains("never automatic and never performed on read", response, StringComparison.Ordinal);
+
+        var livenessGuidance = Section(RenderMarkdown(), "## 6. Team formula, duty split, and monitoring separation", "## 7. Outcome-shaped reporting");
+        Assert.Contains("**unreadable-record response (G777):**", livenessGuidance, StringComparison.Ordinal);
+        Assert.Contains(response, livenessGuidance, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Json_FieldDiffAddsOnlyG777Response_AndPreservesG774G775G776Baseline_G777()
+    {
+        using var document = JsonDocument.Parse(RenderJson());
+        var fields = document.RootElement.EnumerateObject().ToArray();
+
+        Assert.Equal(
+            G776BaselinePayloadFieldNames.Append("unreadable_repair_response"),
+            fields.Select(field => field.Name));
+
+        var addition = Assert.Single(fields, field => field.Name == "unreadable_repair_response");
+        Assert.Contains("repair-unreadable", addition.Value.GetString()!, StringComparison.Ordinal);
+
+        var baseline = fields.Where(field => field.Name != "unreadable_repair_response").ToArray();
+        var actualOracle = ComputePayloadOracle(baseline);
+        Assert.True(
+            string.Equals(G776BaselinePayloadOracleHash, actualOracle, StringComparison.Ordinal),
+            $"G776 sibling baseline changed. Expected '{G776BaselinePayloadOracleHash}', actual '{actualOracle}'.");
+    }
+
+    [Fact]
+    public void DocumentationMirrors_CrossReferenceTheRenderedLivenessResponse_G777()
+    {
+        var en = Section(
+            ReadRepoFile("docs/en/12-agent-message-orchestration.md"),
+            "### Evidence-preserving unreadable-record repair (G773 — preview-through-1.x)",
+            "### Atomic per-record supervision history appends");
+        var ja = Section(
+            ReadRepoFile("docs/ja/12-agent-message-orchestration.md"),
+            "### unreadable record を evidence として隔離する repair (G773 — preview-through-1.x)",
+            "### supervision history の record 単位 append");
+
+        Assert.Contains("The rendered `intent-cli guide design-thread` liveness guidance", en, StringComparison.Ordinal);
+        Assert.Contains("non-zero `unreadable_record_count`", en, StringComparison.Ordinal);
+        Assert.Contains("`--dry-run` first", en, StringComparison.Ordinal);
+        Assert.Contains("`--write` only second", en, StringComparison.Ordinal);
+        Assert.Contains("verbatim as evidence", en, StringComparison.Ordinal);
+        Assert.Contains("no reconstruction claim", en, StringComparison.Ordinal);
+
+        Assert.Contains("描画される `intent-cli guide design-thread` の liveness の案内", ja, StringComparison.Ordinal);
+        Assert.Contains("0 以外の\n`unreadable_record_count`", ja, StringComparison.Ordinal);
+        Assert.Contains("`--dry-run` で実行して証拠を確認", ja, StringComparison.Ordinal);
+        Assert.Contains("二番目の操作として `--write`", ja, StringComparison.Ordinal);
+        Assert.Contains("原文のバイト列のまま保存", ja, StringComparison.Ordinal);
+        Assert.Contains("内容を再構成しない", ja, StringComparison.Ordinal);
+    }
+
+    private static string RenderJson()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            GuideDesignThreadCommand.Execute(
+                CreateContext(),
+                ["--domain", "intent-cli", "--team", "intent-cli-dev", "--routing-root", "/g777-parent", "--format", "json"],
+                writer));
+        return writer.ToString();
+    }
+
+    private static string RenderMarkdown()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            GuideDesignThreadCommand.Execute(
+                CreateContext(),
+                ["--domain", "intent-cli", "--team", "intent-cli-dev", "--routing-root", "/g777-parent"],
+                writer));
+        return writer.ToString();
+    }
+
+    private static string Section(string document, string start, string end)
+    {
+        var startIndex = document.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(startIndex >= 0, $"Missing section '{start}'.");
+        var endIndex = document.IndexOf(end, startIndex, StringComparison.Ordinal);
+        Assert.True(endIndex > startIndex, $"Missing section terminator '{end}'.");
+        return document[startIndex..endIndex];
+    }
+
+    private static string ComputePayloadOracle(IEnumerable<JsonProperty> fields)
+    {
+        var payload = string.Join(
+            "\u001E",
+            fields.Select(field => field.Name + "\u001F" + field.Value.GetRawText()));
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+    }
+
+    private static CliContext CreateContext() => new()
+    {
+        RepoRoot = Path.GetTempPath(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private static string ReadRepoFile(string relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate)) return File.ReadAllText(candidate);
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException(relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds one rendered G777 liveness response that directs a non-zero `unreadable_record_count` to `intent-cli notify supervise repair-unreadable`: `--dry-run` first, then `--write` only second.
- States the non-automatic, never-on-read boundary plus verbatim quarantine evidence with no reconstruction claim.
- Adds an additive sibling field-diff guard that pins all raw G774/G775/G776 parent content, plus EN/JA repair-section cross-references.

Closes #1693

## Verification

- `dotnet build IntentSystem.sln --configuration Release --no-restore` — passed.
- Focused and adjacent: 40 passed, 0 failed, 0 skipped.
- Full Release suite, run as each actual `tests/*.csproj` project under Release because this SDK requires `-p:IsTestProject=true` per test project: 5806 passed, 1 skipped, 0 failed, 5807 total.
- `git diff --check` — passed.
- Head render contains exactly one response line: `repair-unreadable`, non-zero count, `--dry-run` before `--write`, verbatim evidence, and no reconstruction.

## Durable parent evidence: b766f2d0961c665a2d6216c7ed24755556560626

Guide-zero command and actual output:

```text
dotnet exec src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll guide design-thread --domain intent-cli --team intent-cli-dev --routing-root /g777-parent --format markdown | rg -n "repair-unreadable"
exit 1
stdout: <empty>
```

Every new G777 test is absent on that parent. Actual command outputs:

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release -p:IsTestProject=true --no-restore --filter "FullyQualifiedName=IntentSystem.Cli.Tests.GuideDesignThreadG777Tests.RenderedLivenessGuidance_NamesTheSanctionedDryRunBeforeWriteResponse_G777" --logger "console;verbosity=minimal"
Test run for .../IntentSystem.Cli.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.
No test matches the given testcase filter `FullyQualifiedName=IntentSystem.Cli.Tests.GuideDesignThreadG777Tests.RenderedLivenessGuidance_NamesTheSanctionedDryRunBeforeWriteResponse_G777` in .../IntentSystem.Cli.Tests.dll

dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-build -p:IsTestProject=true --filter "FullyQualifiedName=IntentSystem.Cli.Tests.GuideDesignThreadG777Tests.Json_FieldDiffAddsOnlyG777Response_AndPreservesG774G775G776Baseline_G777" --logger "console;verbosity=minimal"
Test run for .../IntentSystem.Cli.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.
No test matches the given testcase filter `FullyQualifiedName=IntentSystem.Cli.Tests.GuideDesignThreadG777Tests.Json_FieldDiffAddsOnlyG777Response_AndPreservesG774G775G776Baseline_G777` in .../IntentSystem.Cli.Tests.dll

dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-build -p:IsTestProject=true --filter "FullyQualifiedName=IntentSystem.Cli.Tests.GuideDesignThreadG777Tests.DocumentationMirrors_CrossReferenceTheRenderedLivenessResponse_G777" --logger "console;verbosity=minimal"
Test run for .../IntentSystem.Cli.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.
No test matches the given testcase filter `FullyQualifiedName=IntentSystem.Cli.Tests.GuideDesignThreadG777Tests.DocumentationMirrors_CrossReferenceTheRenderedLivenessResponse_G777` in .../IntentSystem.Cli.Tests.dll
```

## Boundary record

The child selector reported `execution-unit:G777` unheld and issue preflight reported `missing-target-declaration`; the supplied authoritative host claim is the ownership authority. I used the canonical GitHub-only issue claim and made no child execution-unit claim mutation.