### PR TITLE
docs: prepare intent-cli v0.29.0

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2763,7 +2763,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0281)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0291)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2969,7 +2969,55 @@ rotated by this command; the result and `shrink-audit.jsonl` say so explicitly.
 out of scope. Use `--dry-run` to inspect the measured plan without writing the
 manifest, JSONL files, or audit.
 
-### Next release readiness (v0.28.1)
+### Next release readiness (v0.29.1)
+
+**RELEASE PREPARED / NOT PUBLISHED.**
+
+G778 measured the v0.29.0 preparation from the exact named base
+`65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf`. Its normal clean Release build
+reports `intent-cli 0.28.1-65e02d8-G772`; it is the old `nextVersion`
+placeholder identity, not v0.29.0. The same base built with explicit
+`-p:Version=0.29.0` reports `intent-cli 0.29.0-65e02d8-G772`. Published
+v0.29.0 derives `VERSION` from the release tag's `RAW` value in `release.yml`;
+`eng/version.json` governs local builds and dry runs only.
+
+The prepared files are `release-notes-v0.29.0.md` and the
+`release-notes-v0.29.1.md` DRAFT stub. The current policy is:
+
+```json
+{
+  "stableVersion": "0.29.0",
+  "nextVersion": "0.29.1"
+}
+```
+
+`0.29.1` is a replaceable development placeholder, not the next real release
+number. No tag, GitHub Release, package publish, workflow change, or product
+source change belongs to this prepare-only slice.
+
+The active package-policy evidence is `stableVersion 0.29.0`, `nextVersion 0.29.1`,
+and local candidate `JTechJapan.IntentSystem.Cli.0.29.1.nupkg`.
+The host-only release-prep claim boundary is `release-prep:<owner/repo>:0.29.1`;
+this child release-prep uses supplied authority and does not inspect or mutate host state.
+
+The tagged v0.28.0 CLI returned `invalid-notification: Unknown argument
+'repair-unreadable'.`; the named base renders
+`notify supervise repair-unreadable`. That one command-route addition is the
+minor-bump evidence. The v0.28.0 rule does not count option-level additions:
+G776's `--wake-command` is explicitly not a second command route.
+
+The v0.29.0 notes enumerate the exact G773–G777 first-parent range, all five
+unit/PR/issue/merge tuples, and their operator-observable outcomes. The EN/JA
+tuple parity is compared directly by `ReleaseNotesV0290DocsTests`; a one-field
+mirror mutation must fail. The same guard pins these truthfulness boundaries:
+repair-unreadable quarantines unreadable lines verbatim with no reconstruction,
+never automatically or on read; undeclared wake-channel teams receive zero
+changed bytes; and the observed 9-record transaction `6279ad14` is path
+evidence, not a fleet-cleanliness claim. `ReleasePackageMetadataTests`,
+`VersionSourcePolicyGuardTests`, and `JapaneseTerminologyGuardG613Tests` remain
+the release-policy, source, and terminology guards.
+
+### Previous v0.28.0 release-prep evidence (retained in history only)
 
 **RELEASE PREPARED / NOT PUBLISHED.**
 

--- a/docs/en/release-notes-v0.29.0.md
+++ b/docs/en/release-notes-v0.29.0.md
@@ -1,0 +1,127 @@
+# Release Notes — intent-cli v0.29.0
+
+> **PREPARED / NOT PUBLISHED.** This is the prepare-only release-note set for
+> the independently measured G773–G777 corrective chain. This unit does not
+> create a tag or GitHub Release, publish packages, change a workflow trigger
+> or configuration, or change product source.
+
+No GitHub Release exists yet for v0.29.0; these notes are preparation evidence
+only. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.29.0`.
+
+The policy after this preparation is:
+
+```json
+{
+  "stableVersion": "0.29.0",
+  "nextVersion": "0.29.1"
+}
+```
+
+`0.29.1` is a replaceable development placeholder only. It is not a choice of
+the next real release number; a later release-prep packet must measure and
+decide that number. The EN and JA v0.29.1 files are DRAFT planning scaffolds,
+not changelogs.
+
+## Independently measured minor justification
+
+The version decision comes from Release builds and tagged behavior, not from an
+inference from `eng/version.json`. The named base revision is
+`65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf`.
+
+```bash
+# normal clean Release build of the named base revision
+dotnet build IntentSystem.sln --configuration Release
+dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+# intent-cli 0.28.1-65e02d8-G772
+
+# explicit release-prep identity on the same named base revision
+dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.29.0
+dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+# intent-cli 0.29.0-65e02d8-G772
+```
+
+The first banner is the current `nextVersion` placeholder identity and is
+**not** v0.29.0. The second banner is only the explicit `-p:Version=0.29.0`
+measurement. A published v0.29.0 release derives its version in `release.yml`:
+on a release event `RAW` is the `v0.29.0` tag and `VERSION="${RAW#v}"` is
+`0.29.0`; `eng/version.json` governs local builds and dry runs. No v0.29.0 tag
+was created by this preparation.
+
+The tagged v0.28.0 Release build rejects the new G773 route:
+
+```text
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll notify supervise repair-unreadable --format json
+invalid-notification: Unknown argument 'repair-unreadable'.
+```
+
+The named base provides the route:
+
+```text
+Usage: intent-cli notify supervise repair-unreadable --domain <d> --team <t> [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
+```
+
+The v0.28.0 release policy's auditable rule is **a command-route addition is a
+minor bump; option-level additions do not count as command routes**. G773 adds
+this one route, so the operator chose v0.29.0. G776's `--wake-command` is an
+option-level declaration, explicitly not counted as a second route.
+
+## Release inventory: exactly five units
+
+The exact first-parent range is
+`v0.28.0..65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf`. Git measured five
+commits, and every one is listed below with an operator-observable outcome.
+
+- G773 — PR #1686 / issue #1685; merge commit `370cfd3ad6b008503fc38d11822a31617949c372`.
+  **Operator-observable outcome:** `notify supervise repair-unreadable` first
+  previews and then quarantines unreadable supervision evidence without
+  reconstructing it.
+- G774 — PR #1690 / issue #1687; merge commit `9f124d86b0cc76366d2bb8cfcdcffed17a9eca66`.
+  **Operator-observable outcome:** rendered design guidance exposes a bounded
+  `packet_authoring_check` before a packet is handed to implementation.
+- G775 — PR #1691 / issue #1688; merge commit `75216283875b08ade3d100de7ddabe3fad0bd21c`.
+  **Operator-observable outcome:** external frontend relabel guidance keeps
+  residence, reader, and routing root distinct from an update-residence move.
+- G776 — PR #1692 / issue #1689; merge commit `b766f2d0961c665a2d6216c7ed24755556560626`.
+  **Operator-observable outcome:** a declared external wake command is shown
+  as a courtesy after the durable canonical report, while intent-cli never
+  executes or manages it and undeclared output remains unchanged.
+- G777 — PR #1694 / issue #1693; merge commit `65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf`.
+  **Operator-observable outcome:** a non-zero unreadable count routes an
+  operator to repair-unreadable dry-run first and `--write` second.
+
+## First-parent accounting
+
+```bash
+git rev-list --first-parent --reverse v0.28.0..65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf
+git rev-list --first-parent --count v0.28.0..65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf
+# 5
+```
+
+| first-parent commit | classification | release inventory |
+| --- | --- | --- |
+| `370cfd3ad6b008503fc38d11822a31617949c372` | G773 / PR #1686 / issue #1685 | included |
+| `9f124d86b0cc76366d2bb8cfcdcffed17a9eca66` | G774 / PR #1690 / issue #1687 | included |
+| `75216283875b08ade3d100de7ddabe3fad0bd21c` | G775 / PR #1691 / issue #1688 | included |
+| `b766f2d0961c665a2d6216c7ed24755556560626` | G776 / PR #1692 / issue #1689 | included |
+| `65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf` | G777 / PR #1694 / issue #1693 | included |
+
+## Truthfulness boundaries
+
+- `repair-unreadable` quarantines unreadable lines **verbatim** as evidence. It
+  makes no reconstruction claim, is never automatic, and is never performed on
+  read.
+- Teams without a declared wake channel receive **zero changed bytes** in
+  delegate results and task envelopes. A declared wake remains courtesy-only
+  and never replaces the durable canonical record.
+- The real-host repair of **9 records** with audit transaction `6279ad14` is
+  evidence that the repair path worked in that observed transaction. It is not
+  a fleet-cleanliness claim.
+
+## Prepare-only verification
+
+The PR records the exact parent-absence, focused, adjacent, G613, full Release,
+build, `git diff --check`, and CI evidence. This change is restricted to
+release notes, version policy, readiness documentation, and test guards; it
+does not include a tag, GitHub Release, package publish, workflow change, or
+product-source change.

--- a/docs/en/release-notes-v0.29.1.md
+++ b/docs/en/release-notes-v0.29.1.md
@@ -1,0 +1,9 @@
+# Release Notes — intent-cli v0.29.1
+
+> **DRAFT / UNRELEASED.** This is a replaceable planning scaffold, not a changelog.
+> The next release-prep packet will replace this placeholder after measuring
+> and deciding the next real release number. Do not treat this file as a changelog.
+
+This placeholder intentionally contains no release entries. No tag, GitHub
+Release, or package publish exists for v0.29.1. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.29.1`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3009,7 +3009,56 @@ result は literal bytes の削減、追加した reference bytes、record の n
 `shrink-audit.jsonl` に明記します。`.intent-cli/runs/*.provider.jsonl` は別の provider-run state なので
 scope 外です。`--dry-run` なら manifest、JSONL、audit を書き込まずに測定済み plan だけを確認できます。
 
-### 次リリース準備(v0.28.1)
+### 次リリース準備(v0.29.1)
+
+**RELEASE PREPARED / NOT PUBLISHED。**
+
+G778 は exact named base
+`65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf` から v0.29.0 preparation を測定しました。
+normal clean Release build は `intent-cli 0.28.1-65e02d8-G772` を返します。これは
+旧 `nextVersion` placeholder identity であり、v0.29.0 ではありません。同じ base を
+explicit `-p:Version=0.29.0` で build すると
+`intent-cli 0.29.0-65e02d8-G772` を返します。published v0.29.0 は `release.yml` の
+release tag `RAW` から `VERSION` を導出し、`eng/version.json` は local builds と
+dry runs だけを管理します。
+
+prepared files は `release-notes-v0.29.0.md` と
+`release-notes-v0.29.1.md` の DRAFT stub です。current policy は次のとおりです:
+
+```json
+{
+  "stableVersion": "0.29.0",
+  "nextVersion": "0.29.1"
+}
+```
+
+`0.29.1` は replaceable development placeholder であり、次の real release number
+ではありません。tag、GitHub Release、package publish、workflow change、product source
+change はこの prepare-only slice に含みません。
+
+active package-policy evidence は `stableVersion 0.29.0`、`nextVersion 0.29.1`、local
+candidate `JTechJapan.IntentSystem.Cli.0.29.1.nupkg` です。
+host-only release-prep claim boundary は `release-prep:<owner/repo>:0.29.1` です。この child
+release-prep は事前に確認済みの所有情報を使い、host state を inspect/mutate しません。
+
+tagged v0.28.0 CLI は `invalid-notification: Unknown argument
+'repair-unreadable'.` を返し、named base は `notify supervise repair-unreadable` を
+render します。この一つの command-route addition が minor-bump evidence です。
+v0.28.0 の rule は option-level addition を数えません。G776 の `--wake-command` は
+二つ目の command route ではないことを明示します。
+
+v0.29.0 notes は G773–G777 の exact first-parent range、五つすべての
+unit/PR/issue/merge tuple、operator-observable outcome を記録します。EN/JA tuple parity
+は `ReleaseNotesV0290DocsTests` が直接比較し、one-field mirror mutation は fail
+しなければなりません。同じ guard は次の truthfulness boundary を pin します:
+repair-unreadable は unreadable line を verbatim に quarantine し reconstruction を
+claim せず、automatic でも read 時でもないこと、undeclared wake-channel team の bytes
+は zero changed bytes であること、観測した 9-record transaction `6279ad14` は path
+evidence で fleet-cleanliness claim ではないことです。`ReleasePackageMetadataTests`、
+`VersionSourcePolicyGuardTests`、`JapaneseTerminologyGuardG613Tests` は release-policy、
+source、terminology guard のままです。
+
+### previous v0.28.0 release-prep evidence (history のみ)
 
 **RELEASE PREPARED / NOT PUBLISHED。**
 

--- a/docs/ja/release-notes-v0.29.0.md
+++ b/docs/ja/release-notes-v0.29.0.md
@@ -1,0 +1,122 @@
+# リリースノート — intent-cli v0.29.0
+
+> **PREPARED / NOT PUBLISHED。** これは独自に測定した G773–G777 corrective chain の
+> prepare-only release-note set です。この unit は tag、GitHub Release、package
+> publish、workflow trigger/configuration change、product source change を行いません。
+
+v0.29.0 の GitHub Release はまだ存在せず、この notes は preparation evidence
+だけです。matching install query は
+`JTechJapan.IntentSystem.Cli --version 0.29.0` です。
+
+この preparation 後の policy は次のとおりです:
+
+```json
+{
+  "stableVersion": "0.29.0",
+  "nextVersion": "0.29.1"
+}
+```
+
+`0.29.1` は replaceable development placeholder だけです。次の real release
+number を決定したものではなく、後続の release-prep packet が測定して決めます。
+EN/JA の v0.29.1 file は DRAFT planning scaffold であり、changelog ではありません。
+
+## 独自に測定した minor justification
+
+version decision は `eng/version.json` から推測せず、Release build と tagged behavior
+から測定しました。named base revision は
+`65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf` です。
+
+```bash
+# normal clean Release build of the named base revision
+dotnet build IntentSystem.sln --configuration Release
+dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+# intent-cli 0.28.1-65e02d8-G772
+
+# explicit release-prep identity on the same named base revision
+dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.29.0
+dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+# intent-cli 0.29.0-65e02d8-G772
+```
+
+最初の banner は current `nextVersion` placeholder identity であり、**v0.29.0
+ではありません**。二つ目の banner は explicit `-p:Version=0.29.0` measurement
+だけです。published v0.29.0 release の version は `release.yml` が導出します:
+release event では `RAW` が `v0.29.0` tag、`VERSION="${RAW#v}"` が `0.29.0` です。
+`eng/version.json` は local builds と dry runs を管理します。この preparation は
+v0.29.0 tag を作成していません。
+
+tagged v0.28.0 Release build は新しい G773 route を reject しました:
+
+```text
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll notify supervise repair-unreadable --format json
+invalid-notification: Unknown argument 'repair-unreadable'.
+```
+
+named base はこの route を提供します:
+
+```text
+Usage: intent-cli notify supervise repair-unreadable --domain <d> --team <t> [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
+```
+
+v0.28.0 release policy の auditable rule は **command-route addition は minor bump、
+option-level addition は command route として数えない** です。G773 はこの一つの route
+を追加したため、operator は v0.29.0 を選びました。G776 の `--wake-command` は
+option-level declaration であり、二つ目の route として明示的に数えません。
+
+## Release inventory: 正確に五 units
+
+exact first-parent range は
+`v0.28.0..65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf` です。git は五 commit を
+測定し、そのすべてを operator-observable outcome とともに次に記録します。
+
+- G773 — PR #1686 / issue #1685; merge commit `370cfd3ad6b008503fc38d11822a31617949c372`。
+  **Operator-observable outcome:** `notify supervise repair-unreadable` がまず
+  preview し、read 不能な supervision evidence を reconstruction せず quarantine します。
+- G774 — PR #1690 / issue #1687; merge commit `9f124d86b0cc76366d2bb8cfcdcffed17a9eca66`。
+  **Operator-observable outcome:** rendered design guidance が implementation へ
+  packet を渡す前に bounded な `packet_authoring_check` を表示します。
+- G775 — PR #1691 / issue #1688; merge commit `75216283875b08ade3d100de7ddabe3fad0bd21c`。
+  **Operator-observable outcome:** external frontend relabel guidance が residence、
+  reader、routing root を update-residence move と区別します。
+- G776 — PR #1692 / issue #1689; merge commit `b766f2d0961c665a2d6216c7ed24755556560626`。
+  **Operator-observable outcome:** declared external wake command を durable canonical
+  report の後の courtesy として表示し、intent-cli は実行・管理せず、undeclared output は変えません。
+- G777 — PR #1694 / issue #1693; merge commit `65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf`。
+  **Operator-observable outcome:** non-zero unreadable count が operator を
+  repair-unreadable dry-run first、`--write` second へ導きます。
+
+## First-parent accounting
+
+```bash
+git rev-list --first-parent --reverse v0.28.0..65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf
+git rev-list --first-parent --count v0.28.0..65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf
+# 5
+```
+
+| first-parent commit | classification | release inventory |
+| --- | --- | --- |
+| `370cfd3ad6b008503fc38d11822a31617949c372` | G773 / PR #1686 / issue #1685 | included |
+| `9f124d86b0cc76366d2bb8cfcdcffed17a9eca66` | G774 / PR #1690 / issue #1687 | included |
+| `75216283875b08ade3d100de7ddabe3fad0bd21c` | G775 / PR #1691 / issue #1688 | included |
+| `b766f2d0961c665a2d6216c7ed24755556560626` | G776 / PR #1692 / issue #1689 | included |
+| `65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf` | G777 / PR #1694 / issue #1693 | included |
+
+## Truthfulness boundaries
+
+- `repair-unreadable` は read 不能な line を evidence として**verbatim** に
+  quarantine します。reconstruction を claim せず、automatic ではなく、read 時に
+  実行されることもありません。
+- declared wake channel がない team の delegate result と task envelope は
+  **zero changed bytes** です。declared wake は courtesy-only であり、durable
+  canonical record の代わりにはなりません。
+- audit transaction `6279ad14` で real host の **9 records** を repair した事実は、
+  観測した transaction で repair path が動いた evidence です。fleet-cleanliness
+  claim ではありません。
+
+## Prepare-only verification
+
+PR には exact parent-absence、focused、adjacent、G613、full Release、build、
+`git diff --check`、CI の evidence を記録します。この change は release notes、
+version policy、readiness documentation、test guard に限定し、tag、GitHub Release、
+package publish、workflow change、product-source change を含みません。

--- a/docs/ja/release-notes-v0.29.1.md
+++ b/docs/ja/release-notes-v0.29.1.md
@@ -1,0 +1,9 @@
+# リリースノート — intent-cli v0.29.1
+
+> **DRAFT / 未リリース。** これは replaceable planning scaffold であり、changelog ではありません。
+> 後続の release-prep packet が次の real release number を測定して決めた後、この
+> placeholder を replace します。この file を changelog として扱ってはいけません。
+
+この placeholder には release entry を記録しません。v0.29.1 の tag、GitHub
+Release、package publish はまだ存在しません。matching install query は
+`JTechJapan.IntentSystem.Cli --version 0.29.1` です。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.28.0",
-  "nextVersion": "0.28.1"
+  "stableVersion": "0.29.0",
+  "nextVersion": "0.29.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -287,11 +287,18 @@ public sealed class ReleaseNotesV0220DocsTests
         Assert.Contains($"release-notes-v{policy.NextVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains("RELEASE PREPARED / NOT PUBLISHED", section, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("placeholder", compact, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("104 usages", section, StringComparison.Ordinal);
-        Assert.Contains("106 usages", section, StringComparison.Ordinal);
-        Assert.Contains("canonical-unavailable", section, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("child", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("repair-unreadable", section, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--wake-command", section, StringComparison.Ordinal);
+        Assert.Contains("option-level", section, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("GitHub Release", section, StringComparison.Ordinal);
+
+        // Keep the v0.28 measured command-surface evidence frozen with the
+        // released v0.28 notes instead of copying historical counts into each
+        // later active readiness section.
+        var historicNotes = File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.28.0.md"));
+        Assert.Contains("104 usages", historicNotes, StringComparison.Ordinal);
+        Assert.Contains("106 usages", historicNotes, StringComparison.Ordinal);
     }
 
     private static string ReadinessSection(string language, string nextVersion)

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
@@ -165,12 +165,12 @@ public sealed class ReleaseNotesV0240DocsTests
     }
 
     [Fact]
-    public void ShippedV0240NotesAndReadinessPointAtTheCurrentV0281Line()
+    public void ShippedV0240NotesAndReadinessPointAtTheCurrentV0291Line()
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.28.0", policy.StableVersion);
-        Assert.Equal("0.28.1", policy.NextVersion);
+        Assert.Equal("0.29.0", policy.StableVersion);
+        Assert.Equal("0.29.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -184,6 +184,8 @@ public sealed class ReleaseNotesV0240DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.0.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.1.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.1.md")));
 
             var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
             Assert.Contains("0.24.0", reference, StringComparison.Ordinal);
@@ -191,13 +193,15 @@ public sealed class ReleaseNotesV0240DocsTests
             Assert.Contains("0.25.0", reference, StringComparison.Ordinal);
             Assert.Contains("release-notes-v0.28.0.md", reference, StringComparison.Ordinal);
             Assert.Contains("release-notes-v0.28.1.md", reference, StringComparison.Ordinal);
+            Assert.Contains("release-notes-v0.29.0.md", reference, StringComparison.Ordinal);
+            Assert.Contains("release-notes-v0.29.1.md", reference, StringComparison.Ordinal);
             Assert.DoesNotContain("release-notes-v0.27.0.md", reference, StringComparison.Ordinal);
             Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
             Assert.Contains(
-                language == "en" ? "Next release readiness (v0.28.1)" : "次リリース準備(v0.28.1)",
+                language == "en" ? "Next release readiness (v0.29.1)" : "次リリース準備(v0.29.1)",
                 reference,
                 StringComparison.Ordinal);
-            Assert.Contains("intent-cli 0.28.0-565530e-G769", reference, StringComparison.Ordinal);
+            Assert.Contains("intent-cli 0.29.0-65e02d8-G772", reference, StringComparison.Ordinal);
             Assert.Contains("ReleasePackageMetadataTests", reference, StringComparison.Ordinal);
             Assert.Contains("VersionSourcePolicyGuardTests", reference, StringComparison.Ordinal);
         }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
@@ -14,7 +14,7 @@ public sealed class ReleaseNotesV0250DocsTests
         "5c4af5d88ddcfa47335bad4df56ad3e40dae9140";
     private const string BuiltDisplayIdentity = "intent-cli 0.24.1-5c4af5d-G741";
     private const string InstalledDisplayIdentity = "intent-cli 0.24.0-df472fe-G737";
-    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.28.0-565530e-G769";
+    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.29.0-65e02d8-G772";
 
     private static readonly (string Unit, string Pr, string Merge)[] Units =
     [
@@ -165,8 +165,8 @@ public sealed class ReleaseNotesV0250DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
 
-        Assert.Equal("0.28.0", policy.StableVersion);
-        Assert.Equal("0.28.1", policy.NextVersion);
+        Assert.Equal("0.29.0", policy.StableVersion);
+        Assert.Equal("0.29.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -179,6 +179,8 @@ public sealed class ReleaseNotesV0250DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.0.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.1.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.1.md")));
         }
     }
 
@@ -191,13 +193,15 @@ public sealed class ReleaseNotesV0250DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.28.1)" : "次リリース準備(v0.28.1)",
+            language == "en" ? "Next release readiness (v0.29.1)" : "次リリース準備(v0.29.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(CurrentStableInstallDisplayIdentity, reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.26.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.28.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.28.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.29.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.29.1.md", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.27.0.md", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0250DocsTests", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
@@ -214,12 +214,12 @@ public sealed class ReleaseNotesV0260DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policyPath = Path.Combine(root, "eng", "version.json");
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.28.0\",\n  \"nextVersion\": \"0.28.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.28.0", policy.StableVersion);
-        Assert.Equal("0.28.1", policy.NextVersion);
+        Assert.Equal("0.29.0", policy.StableVersion);
+        Assert.Equal("0.29.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -231,6 +231,8 @@ public sealed class ReleaseNotesV0260DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.0.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.1.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.1.md")));
         }
     }
 
@@ -255,7 +257,9 @@ public sealed class ReleaseNotesV0260DocsTests
         var readiness = ReadCurrentReadiness(language);
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.28.1)" : "次リリース準備(v0.28.1)",
+            language == "en"
+                ? "Previous v0.28.0 release-prep evidence (retained in history only)"
+                : "previous v0.28.0 release-prep evidence (history のみ)",
             readiness,
             StringComparison.Ordinal);
         Assert.Contains("0.25.0", readiness, StringComparison.Ordinal);
@@ -370,7 +374,9 @@ public sealed class ReleaseNotesV0260DocsTests
     {
         var content = File.ReadAllText(Path.Combine(
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
-        var heading = language == "en" ? "### Next release readiness (v0.28.1)" : "### 次リリース準備(v0.28.1)";
+        var heading = language == "en"
+            ? "### Previous v0.28.0 release-prep evidence (retained in history only)"
+            : "### previous v0.28.0 release-prep evidence (history のみ)";
         var start = content.IndexOf(heading, StringComparison.Ordinal);
         Assert.True(start >= 0, $"Missing current readiness heading in {language}.");
         var end = content.IndexOf("**Previous v0.25.0 preparation evidence", start, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
@@ -155,12 +155,12 @@ public sealed class ReleaseNotesV0270DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.28.0\",\n  \"nextVersion\": \"0.28.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.28.0", policy.StableVersion);
-        Assert.Equal("0.28.1", policy.NextVersion);
+        Assert.Equal("0.29.0", policy.StableVersion);
+        Assert.Equal("0.29.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -171,6 +171,8 @@ public sealed class ReleaseNotesV0270DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.0.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.1.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.1.md")));
         }
     }
 
@@ -185,8 +187,8 @@ public sealed class ReleaseNotesV0270DocsTests
 
         Assert.Contains(
             language == "en"
-                ? "### Next release readiness (v0.28.1)"
-                : "### 次リリース準備(v0.28.1)",
+                ? "### Previous v0.28.0 release-prep evidence (retained in history only)"
+                : "### previous v0.28.0 release-prep evidence (history のみ)",
             reference,
             StringComparison.Ordinal);
         Assert.DoesNotContain(

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
@@ -18,12 +18,12 @@ public sealed class ReleaseNotesV0271DocsTests
         var policyPath = Path.Combine(root, "eng", "version.json");
 
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.28.0\",\n  \"nextVersion\": \"0.28.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.28.0", policy.StableVersion);
-        Assert.Equal("0.28.1", policy.NextVersion);
+        Assert.Equal("0.29.0", policy.StableVersion);
+        Assert.Equal("0.29.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -34,6 +34,8 @@ public sealed class ReleaseNotesV0271DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.0.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.1.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.1.md")));
             Assert.DoesNotContain("- G", stub, StringComparison.Ordinal);
 
             if (language == "en")
@@ -88,8 +90,8 @@ public sealed class ReleaseNotesV0271DocsTests
         var content = File.ReadAllText(Path.Combine(
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
         var heading = language == "en"
-            ? "### Next release readiness (v0.28.1)"
-            : "### 次リリース準備(v0.28.1)";
+            ? "### Previous v0.28.0 release-prep evidence (retained in history only)"
+            : "### previous v0.28.0 release-prep evidence (history のみ)";
         var endHeading = language == "en"
             ? "### Retired v0.27.0 release-prep evidence (retained in history only)"
             : "### retired v0.27.0 release-prep evidence (history のみ)";

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
@@ -156,17 +156,19 @@ public sealed class ReleaseNotesV0280DocsTests
         var policyPath = Path.Combine(root, "eng", "version.json");
 
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.28.0\",\n  \"nextVersion\": \"0.28.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.28.0", policy.StableVersion);
-        Assert.Equal("0.28.1", policy.NextVersion);
+        Assert.Equal("0.29.0", policy.StableVersion);
+        Assert.Equal("0.29.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.0.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.28.1.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.1.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.0.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
 
@@ -188,7 +190,9 @@ public sealed class ReleaseNotesV0280DocsTests
             root, "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.28.1)" : "次リリース準備(v0.28.1)",
+            language == "en"
+                ? "Previous v0.28.0 release-prep evidence (retained in history only)"
+                : "previous v0.28.0 release-prep evidence (history のみ)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains("0.28.0", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
@@ -1,0 +1,185 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G778: v0.29.0 is a measured, prepare-only release line. These guards keep
+/// its mirrored inventory and three identity statements auditable.
+/// </summary>
+public sealed class ReleaseNotesV0290DocsTests
+{
+    private const string Base = "65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf";
+    private const string NormalBaseIdentity = "intent-cli 0.28.1-65e02d8-G772";
+    private const string ExplicitReleaseIdentity = "intent-cli 0.29.0-65e02d8-G772";
+
+    private static readonly (string Unit, string Pr, string Issue, string Merge)[] Units =
+    [
+        ("G773", "#1686", "#1685", "370cfd3ad6b008503fc38d11822a31617949c372"),
+        ("G774", "#1690", "#1687", "9f124d86b0cc76366d2bb8cfcdcffed17a9eca66"),
+        ("G775", "#1691", "#1688", "75216283875b08ade3d100de7ddabe3fad0bd21c"),
+        ("G776", "#1692", "#1689", "b766f2d0961c665a2d6216c7ed24755556560626"),
+        ("G777", "#1694", "#1693", "65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf"),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyTheFiveGitDerivedUnits(string language)
+    {
+        var notes = ReadNotes(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(5, listed.Length);
+
+        foreach (var unit in Units)
+        {
+            var entry = FindEntry(notes, unit.Unit);
+            Assert.Contains($"PR {unit.Pr} / issue {unit.Issue};", entry, StringComparison.Ordinal);
+            Assert.Contains($"merge commit `{unit.Merge}`", entry, StringComparison.Ordinal);
+            Assert.Contains("Operator-observable outcome", entry, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseMirrorsHaveIdenticalUnitPrIssueAndMergeTuples()
+    {
+        var english = ParseInventory(ReadNotes("en"));
+        var japanese = ParseInventory(ReadNotes("ja"));
+
+        Assert.Equal(Units, english);
+        Assert.Equal(english, japanese);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinTheThreeMeasuredIdentitiesAndMinorDecision(string language)
+    {
+        var notes = ReadNotes(language);
+        var normalized = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Contains(Base, notes, StringComparison.Ordinal);
+        Assert.Contains("dotnet build IntentSystem.sln --configuration Release", notes, StringComparison.Ordinal);
+        Assert.Contains("-p:Version=0.29.0", notes, StringComparison.Ordinal);
+        Assert.Contains(NormalBaseIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains(ExplicitReleaseIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains("release.yml", notes, StringComparison.Ordinal);
+        Assert.Contains("RAW", notes, StringComparison.Ordinal);
+        Assert.Contains("VERSION", notes, StringComparison.Ordinal);
+        Assert.Contains("eng/version.json", notes, StringComparison.Ordinal);
+        Assert.Contains("local builds", notes, StringComparison.Ordinal);
+        Assert.Contains("dry runs", notes, StringComparison.Ordinal);
+        Assert.Contains("Unknown argument 'repair-unreadable'", notes, StringComparison.Ordinal);
+        Assert.Contains("notify supervise repair-unreadable", notes, StringComparison.Ordinal);
+        Assert.Contains("option-level", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--wake-command", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "not counted" : "数えません", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "**not** v0.29.0" : "**v0.29.0 ではありません**", normalized, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinEveryFirstParentCommitAndClassification(string language)
+    {
+        var notes = ReadNotes(language);
+        const string range = "v0.28.0..65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf";
+
+        Assert.Contains($"git rev-list --first-parent --reverse {range}", notes, StringComparison.Ordinal);
+        Assert.Contains($"git rev-list --first-parent --count {range}", notes, StringComparison.Ordinal);
+        Assert.Contains("# 5", notes, StringComparison.Ordinal);
+
+        foreach (var unit in Units)
+        {
+            Assert.Contains(unit.Merge, notes, StringComparison.Ordinal);
+            Assert.Contains($"{unit.Unit} / PR {unit.Pr} / issue {unit.Issue}", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinTheThreeTruthfulnessBoundaries(string language)
+    {
+        var notes = ReadNotes(language);
+        var normalized = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Contains("repair-unreadable", notes, StringComparison.Ordinal);
+        Assert.Contains("verbatim", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "no reconstruction claim" : "reconstruction を claim せず", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "never automatic" : "automatic ではなく", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "never performed on read" : "read 時に", normalized, StringComparison.Ordinal);
+        Assert.Contains("zero changed bytes", notes, StringComparison.Ordinal);
+        Assert.Contains("9 records", notes, StringComparison.Ordinal);
+        Assert.Contains("6279ad14", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "not a fleet-cleanliness claim" : "fleet-cleanliness claim ではありません", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VersionPolicyAndPreparedNotesAreExact()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        Assert.Equal(
+            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
+            File.ReadAllText(Path.Combine(root, "eng", "version.json")));
+
+        var policy = RepoVersionPolicySource.Read();
+        Assert.Equal("0.29.0", policy.StableVersion);
+        Assert.Equal("0.29.1", policy.NextVersion);
+
+        foreach (var language in new[] { "en", "ja" })
+        {
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.29.0.md")));
+            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.29.1.md"));
+            Assert.Contains("DRAFT", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(language == "en" ? "not a changelog" : "changelog ではありません", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("- G", stub, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReadinessMirrorsDocumentTheCurrentPreparedLine(string language)
+    {
+        var reference = File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
+
+        Assert.Contains(
+            language == "en" ? "### Next release readiness (v0.29.1)" : "### 次リリース準備(v0.29.1)",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(NormalBaseIdentity, reference, StringComparison.Ordinal);
+        Assert.Contains(ExplicitReleaseIdentity, reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.29.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.29.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0290DocsTests", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleasePackageMetadataTests", reference, StringComparison.Ordinal);
+        Assert.Contains("JapaneseTerminologyGuardG613Tests", reference, StringComparison.Ordinal);
+    }
+
+    private static string FindEntry(string notes, string unit)
+    {
+        var match = Regex.Match(notes, $@"(?ms)^- {Regex.Escape(unit)} —.*?(?=^- |^## |\z)");
+        return match.Success ? match.Value : string.Empty;
+    }
+
+    private static IReadOnlyList<(string Unit, string Pr, string Issue, string Merge)> ParseInventory(string notes) =>
+        Regex.Matches(
+                notes,
+                @"(?ms)^- (G\d+) — PR (#\d+) / issue (#\d+); merge commit `([0-9a-f]{40})`.*?(?=^- |^## |\z)")
+            .Select(match => (
+                match.Groups[1].Value,
+                match.Groups[2].Value,
+                match.Groups[3].Value,
+                match.Groups[4].Value))
+            .ToArray();
+
+    private static string ReadNotes(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.29.0.md"));
+}


### PR DESCRIPTION
Closes #1695

## Scope

Prepare-only v0.29.0 release work. This PR changes only release notes, the two
readiness mirrors, `eng/version.json`, and release-policy/document guards. It
does not create a tag or GitHub Release, publish a package, change a workflow,
or change product source.

Base: `65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf`  
Head: `2152ee71ad3b4f4ea7acb2f3259e01867a5c28ac`

## Measured version decision

These commands were run before drafting, from the named base.

```text
$ dotnet build IntentSystem.sln --configuration Release
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.28.1-65e02d8-G772

$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.29.0
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.29.0-65e02d8-G772
```

The normal clean named-base build is the existing `0.28.1` placeholder identity,
never `0.29.0`. The latter is only the explicit `-p:Version=0.29.0` measurement.
For publication, `.github/workflows/release.yml` reads the release-event tag
into `RAW` and uses `VERSION="${RAW#v}"`; `eng/version.json` governs local
builds and dry runs.

The tagged v0.28.0 check demonstrates the command-route delta:

```text
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll notify supervise repair-unreadable --format json
intent-cli 0.28.1-bb7e56d-G772
invalid-notification: Unknown argument 'repair-unreadable'.
Usage: intent-cli notify supervise ...

$ [named base] dotnet ... notify supervise repair-unreadable --help
Usage: intent-cli notify supervise repair-unreadable --domain <d> --team <t> [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
```

G773 adds that one route. Under the release rule, command-route additions are a
minor bump; option additions are not. G776 `--wake-command` is option-level and
is explicitly not counted as a second route.

## Git accounting

`git rev-list --first-parent --reverse v0.28.0..65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf`
and `--count` returned exactly these five commits / `5`:

| Unit | Issue | PR | Merge | Operator-observable outcome |
| --- | --- | --- | --- | --- |
| G773 | #1685 | #1686 | `370cfd3ad6b008503fc38d11822a31617949c372` | repairs unreadable supervision evidence by verbatim quarantine after dry-run |
| G774 | #1687 | #1690 | `9f124d86b0cc76366d2bb8cfcdcffed17a9eca66` | renders a bounded packet-authoring check |
| G775 | #1688 | #1691 | `75216283875b08ade3d100de7ddabe3fad0bd21c` | distinguishes external frontend relabel from residence transition |
| G776 | #1689 | #1692 | `b766f2d0961c665a2d6216c7ed24755556560626` | renders a declared courtesy wake without executing it |
| G777 | #1693 | #1694 | `65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf` | routes a non-zero unreadable count to dry-run then write repair guidance |

## Parent and parity evidence

All 12 new `ReleaseNotesV0290DocsTests` were absent on the parent:

```text
$ git switch --detach 65e02d86d5e9e415d1fe934b0d5e8bad87af9ccf
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore -p:IsTestProject=true --filter FullyQualifiedName~ReleaseNotesV0290DocsTests
No test matches the given testcase filter `FullyQualifiedName~ReleaseNotesV0290DocsTests` in .../IntentSystem.Cli.Tests.dll
```

The EN/JA guard parses tuples from both mirrors and directly compares them. I
changed only the JA G774 issue field to `#9999`, ran the guard, and restored it
before committing:

```text
$ dotnet test ... --filter FullyQualifiedName~ReleaseNotesV0290DocsTests.EnglishAndJapaneseMirrorsHaveIdenticalUnitPrIssueAndMergeTuples
Assert.Equal() Failure: Collections differ
Expected: ... Tuple ("G774", "#1690", "#1687", "9f124d86b0cc76366d2bb8cfcdcffed17a9eca66") ...
Actual:   ... Tuple ("G774", "#1690", "#9999", "9f124d86b0cc76366d2bb8cfcdcffed17a9eca66") ...
Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1
```

The new EN/JA notes and guards also pin: verbatim quarantine with no
reconstruction claim and no read-time/automatic repair; byte-identical
undeclared wake output; and the observed real-host repair of 9 records in audit
transaction `6279ad14` as one path-success observation, not a fleet-cleanliness
claim.

## Verification

```text
Release build: succeeded, 0 warnings, 0 errors
ReleaseNotesV0290DocsTests: Passed 12, Failed 0, Skipped 0
Adjacent release-policy guards: Passed 136, Failed 0, Skipped 0
JapaneseTerminologyGuardG613Tests: Passed 6, Failed 0, Skipped 0
IntentSystem.Cli.Tests: Passed 5488, Failed 0, Skipped 1, Total 5489
All Release test projects: Passed 5818, Failed 0, Skipped 1, Total 5819
git diff --check: clean
```

The five first-parent inventory and both v0.28.0 note blobs are unchanged:
EN `3a5baf01d1d1a9a8831f89101ff9611b65b504e9`; JA
`b4141a33e96f65cf820335b5b5bd4389f3b99752` before and after this PR.

## Claim visibility boundary

The child `guide start` had no local `.intent-cli/config.toml`; child
`worker next-action` selected #1695 but returned `wait` / `holder none` /
`unheld`, and child preflight returned `actionable=false`,
`classification=missing-target-declaration`, `missing Target paths:`. Per the
dispatch, I recorded that child/host contradiction and consumed the supplied
authoritative host ownership. No child execution-unit claim or host state was
created or mutated.
