### PR TITLE
G779: distinguish rejected claim pushes from remote races

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -200,6 +200,12 @@ reports `not-configured`, the keys above are not being resolved — check they a
 under `[project]` (not a different table) and spelled exactly
 `metadata_source_branch` / `metadata_write_branch`.
 
+Those metadata-branch keys do not change where a claim transaction writes. A
+metadata branch can be read as adoption evidence when the canonical claims tree
+is empty, but ownership remains canonical and a claim writer still targets the
+remote default branch. See [Remote default-branch targeting (G747)](#remote-default-branch-targeting-g747)
+for the target-ref and rejected-push contract.
+
 Host vs child bootstrap (G514): the host-side automation commands
 (`automation summary`, `automation same-repo-metadata-preflight`,
 `automation queue-seed-from-packet`) load `.intent-cli/config.toml` from the
@@ -2719,6 +2725,25 @@ is never used as the claim target or advanced by the refresh. If the symref is
 missing, ambiguous, unsafe, or cannot be queried, the command fails closed; it
 never falls back to the current branch. Successful transaction results include
 the resolved `target_ref`.
+
+### Rejected default-branch pushes (G779)
+
+A non-zero claim push is not automatically a race. After a rejected push, the
+command first checks whether origin already contains the transaction commit or
+the scope record; those remain the existing committed and held outcomes. If it
+contains neither and the post-rejection `origin/<default>` head still equals the
+transaction `base_commit`, the result is `push-rejected` with exit code 1. It
+includes `target_ref`, `base_commit`, `remote_advanced: false`, and
+`git_push_error` (Git's trimmed stderr), and does not create a second transaction
+workspace or retry.
+
+If the remote default ref did move, the command keeps the existing fresh-base,
+bounded reapply behavior. A final `retry-exhausted` result identifies the
+`target_ref`, `base_commit`, last `remote_head`, `remote_advanced: true`, and
+last `git_push_error`; its detail calls the condition an unrelated remote
+advance only in that case. In practical terms, a protected default branch now
+surfaces as `push-rejected` with the server's message: the claim writer needs
+ordinary plain-push access to the resolved remote default branch.
 
 An acquire whose active record already has the same actor and team is an
 intentional no-op. Its result says that the scope is already held and that no

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -187,6 +187,13 @@ metadata_write_branch  = "main-metadata"   # host loop がメタデータを WRI
 配下にあること、`metadata_source_branch` / `metadata_write_branch` の綴りが正確であることを
 確認してください。
 
+これらの metadata-branch key は claim transaction の書き込み先を変更しません。canonical
+claims tree が空のときメタデータ用ブランチは adoption evidence として読まれる場合がありますが、
+ownership は canonical のままであり、claim writer は引き続き remote の default branch を対象に
+します。target ref と rejected-push 契約は
+[remote の default branch を対象にする場合 (G747)](#remote-の-default-branch-を対象にする場合-g747)
+を参照してください。
+
 host と child の bootstrap（G514）: host 側 automation コマンド（`automation summary`、
 `automation same-repo-metadata-preflight`、`automation queue-seed-from-packet`）は解決された
 repo root の `.intent-cli/config.toml` をロードするため、他の host コマンドと同じ effective な
@@ -2777,6 +2784,22 @@ commit を `refs/heads/<resolved-default-branch>` へ明示的に push します
 checkout の current branch は claim の target にせず、refresh でも進めません。symref が
 無い、曖昧、安全に扱えない、または query できない場合は fail closed とし、current branch
 へは fallback しません。成功した transaction result には解決した `target_ref` が含まれます。
+
+### default branch への push 拒否 (G779)
+
+claim push が nonzero を返しても、それだけで race とはみなしません。拒否後に command はまず
+origin が transaction commit または scope record をすでに持つかを確認し、それらは従来どおり
+committed / held outcome です。どちらもなく、post-rejection の `origin/<default>` head が
+transaction の `base_commit` と同じなら、exit code 1 の `push-rejected` を返します。この
+result には `target_ref`、`base_commit`、`remote_advanced: false`、および Git の trim 済み
+stderr である `git_push_error` が含まれ、2 個目の transaction workspace を作らず retry もしません。
+
+remote default ref が移動していた場合は、既存の fresh-base による bounded reapply を維持します。
+最後の `retry-exhausted` result には `target_ref`、`base_commit`、最後の `remote_head`、
+`remote_advanced: true`、最後の `git_push_error` が入り、detail で unrelated remote advance
+と呼ぶのはこの場合だけです。実務上、protected default branch は server message を伴う
+`push-rejected` として表面化します。claim writer には解決済み remote default branch への
+通常の plain-push 権限が必要です。
 
 active record の actor と team が同じ acquire は意図した no-op です。result は scope が
 すでに保持され、claim commit は不要 (`nothing to commit`) であることを示します。teardown

--- a/src/IntentSystem.Cli/Commands/ClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimCommand.cs
@@ -252,18 +252,18 @@ internal static class ClaimCommand
                 var now = DateTimeOffset.UtcNow;
                 var head = RunGit(transactionRoot, ["rev-parse", "HEAD"]);
                 EnsureSuccess(head, "resolve claim base commit");
+                var baseCommit = head.StandardOutput.Trim();
                 string? historyPath = null;
 
                 if (request.Operation == ClaimOperation.Acquire)
                 {
                     WriteClaim(absoluteClaimPath, new ClaimRecord(
                         "1", request.Scope, request.Actor, request.Team, now,
-                        head.StandardOutput.Trim()));
+                        baseCommit));
                 }
                 else
                 {
-                    historyPath = WriteHistory(
-                        transactionRoot, request, current!, now, head.StandardOutput.Trim());
+                    historyPath = WriteHistory(transactionRoot, request, current!, now, baseCommit);
                     if (request.Operation == ClaimOperation.Release)
                     {
                         File.Delete(absoluteClaimPath);
@@ -272,7 +272,7 @@ internal static class ClaimCommand
                     {
                         WriteClaim(absoluteClaimPath, new ClaimRecord(
                             "1", request.Scope, request.Actor, request.Team, now,
-                            head.StandardOutput.Trim()));
+                            baseCommit));
                     }
                 }
 
@@ -337,23 +337,36 @@ internal static class ClaimCommand
                     };
                 }
 
+                var gitPushError = push.StandardError.Trim();
                 var fetch = RunGit(transactionRoot, ["fetch", "origin", defaultBranch]);
                 EnsureSuccess(fetch, "inspect rejected claim push");
                 var remoteDefaultHead = RunGit(transactionRoot, ["rev-parse", $"origin/{defaultBranch}"]);
-                var remoteCommitMatches = remoteDefaultHead.ExitCode == 0
-                    && string.Equals(remoteDefaultHead.StandardOutput.Trim(), transactionCommitSha, StringComparison.Ordinal);
+                EnsureSuccess(remoteDefaultHead, "resolve rejected claim push target head");
+                var remoteHead = remoteDefaultHead.StandardOutput.Trim();
+                var remoteCommitMatches = string.Equals(
+                    remoteHead,
+                    transactionCommitSha,
+                    StringComparison.Ordinal);
+                var remoteAdvanced = !string.Equals(remoteHead, baseCommit, StringComparison.Ordinal);
 
-                var remoteClaim = RunGit(transactionRoot,
-                    ["show", $"origin/{defaultBranch}:{relativeClaimPath}"]);
-                if (remoteClaim.ExitCode == 0)
+                var remoteClaimTree = RunGit(transactionRoot,
+                    ["ls-tree", "-r", "--name-only", $"origin/{defaultBranch}", "--", relativeClaimPath]);
+                EnsureSuccess(remoteClaimTree, "inspect rejected claim push scope");
+                var remoteClaimExists = remoteClaimTree.StandardOutput
+                    .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Contains(relativeClaimPath, StringComparer.Ordinal);
+                if (remoteClaimExists)
                 {
+                    var remoteClaim = RunGit(transactionRoot,
+                        ["show", $"origin/{defaultBranch}:{relativeClaimPath}"]);
+                    EnsureSuccess(remoteClaim, "read rejected claim push scope");
                     var holder = JsonSerializer.Deserialize<ClaimRecord>(remoteClaim.StandardOutput, JsonOptions)
                         ?? throw new InvalidOperationException("remote claim record was empty");
                     if (remoteCommitMatches
                         && request.Operation != ClaimOperation.Release
                         && string.Equals(holder.Actor, request.Actor, StringComparison.Ordinal)
                         && string.Equals(holder.Team, request.Team, StringComparison.Ordinal)
-                        && string.Equals(holder.BaseCommit, head.StandardOutput.Trim(), StringComparison.Ordinal))
+                        && string.Equals(holder.BaseCommit, baseCommit, StringComparison.Ordinal))
                     {
                         // A receive-side failure can be reported after the
                         // remote ref has advanced. The fetched commit and
@@ -398,7 +411,7 @@ internal static class ClaimCommand
 
                 if (remoteCommitMatches
                     && request.Operation == ClaimOperation.Release
-                    && remoteClaim.ExitCode != 0)
+                    && !remoteClaimExists)
                 {
                     committed = true;
                     var status = "released";
@@ -416,16 +429,39 @@ internal static class ClaimCommand
                     };
                 }
 
-                // Unrelated remote advance: discard this isolated workspace and
+                if (!remoteAdvanced)
+                {
+                    return new ClaimTransactionResult(
+                        "push-rejected", request.Scope, relativeClaimPath, false, attempt,
+                        lastObserved?.Actor, null, null,
+                        $"Push to '{targetRef}' was rejected without advancing the remote target; "
+                        + $"origin remained at base commit '{baseCommit}'.")
+                    {
+                        GitWriteRetry = lastGitWriteRetry,
+                        TargetRef = targetRef,
+                        BaseCommit = baseCommit,
+                        RemoteHead = remoteHead,
+                        RemoteAdvanced = false,
+                        GitPushError = gitPushError,
+                    };
+                }
+
+                // A genuine remote advance: discard this isolated workspace and
                 // reapply from a fresh ff-only base. No force, rebase, or merge.
                 if (attempt == request.MaxAttempts)
                 {
                     return new ClaimTransactionResult(
                         "retry-exhausted", request.Scope, relativeClaimPath, false, attempt,
                         lastObserved?.Actor, null, null,
-                        $"Push was rejected by unrelated remote advance after {attempt} bounded attempt(s).")
+                        $"Push to '{targetRef}' was rejected by unrelated remote advance from base commit "
+                        + $"'{baseCommit}' to remote head '{remoteHead}' after {attempt} bounded attempt(s).")
                     {
                         GitWriteRetry = lastGitWriteRetry,
+                        TargetRef = targetRef,
+                        BaseCommit = baseCommit,
+                        RemoteHead = remoteHead,
+                        RemoteAdvanced = true,
+                        GitPushError = gitPushError,
                     };
                 }
             }
@@ -1974,6 +2010,10 @@ internal static class ClaimCommand
         writer.WriteLine($"- claim_path: `{result.ClaimPath}`");
         writer.WriteLine($"- push_succeeded: {(result.PushSucceeded ? "true" : "false")}");
         if (result.TargetRef is not null) writer.WriteLine($"- target_ref: `{result.TargetRef}`");
+        if (result.BaseCommit is not null) writer.WriteLine($"- base_commit: `{result.BaseCommit}`");
+        if (result.RemoteHead is not null) writer.WriteLine($"- remote_head: `{result.RemoteHead}`");
+        if (result.RemoteAdvanced is not null) writer.WriteLine($"- remote_advanced: {result.RemoteAdvanced.Value.ToString().ToLowerInvariant()}");
+        if (result.GitPushError is not null) writer.WriteLine($"- git_push_error: {result.GitPushError}");
         if (result.Holder is not null) writer.WriteLine($"- holder: {result.Holder}");
         if (result.HolderTeam is not null) writer.WriteLine($"- holder_team: {result.HolderTeam}");
         if (result.DisplacedHolder is not null) writer.WriteLine($"- displaced_holder: {result.DisplacedHolder}");
@@ -2111,6 +2151,22 @@ internal sealed record ClaimTransactionResult(
     [JsonPropertyName("target_ref")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? TargetRef { get; init; }
+
+    [JsonPropertyName("base_commit")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BaseCommit { get; init; }
+
+    [JsonPropertyName("remote_head")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RemoteHead { get; init; }
+
+    [JsonPropertyName("remote_advanced")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? RemoteAdvanced { get; init; }
+
+    [JsonPropertyName("git_push_error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? GitPushError { get; init; }
 
     [JsonPropertyName("git_write_retry")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/IntentSystem.Cli/Commands/ClaimOwnershipVerifier.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimOwnershipVerifier.cs
@@ -98,7 +98,7 @@ internal static class ClaimOwnershipVerifier
                 invokingTeam,
                 null,
                 null,
-                $"claim verification refused scope '{scope}': holder is none (unheld); acquire the scope before starting work.");
+                $"claim verification refused scope '{scope}': holder is none (unheld); acquire the scope before starting work. {evidence.Detail}");
         }
 
         ClaimRecord? record;
@@ -189,9 +189,9 @@ internal static class ClaimOwnershipVerifier
     /// </summary>
     private static CanonicalClaimEvidence ReadCanonicalEvidence(string repoRoot, string scope)
     {
-        // G763: ordinary verification is deliberately canonical-only. The
-        // explicit `claim stranded` surface is the only claim command that
-        // reads a configured metadata branch for migration diagnostics.
+        // Ordinary verification reads the canonical branch for ownership.
+        // A configured metadata branch is adoption evidence only: it can
+        // prove that claims were adopted, but it never supplies ownership.
         var inside = RunGit(repoRoot, ["rev-parse", "--is-inside-work-tree"]);
         if (inside.ExitCode != 0
             || !string.Equals(inside.StandardOutput.Trim(), "true", StringComparison.Ordinal))
@@ -309,14 +309,19 @@ internal static class ClaimOwnershipVerifier
                     : tree.StandardError.Trim());
         }
 
-        var claimCount = tree.StandardOutput
+        var claimPaths = tree.StandardOutput
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Count(IsActiveClaimPath);
-        return claimCount == 0
-            ? CanonicalClaimEvidence.NoStore
-            : CanonicalClaimEvidence.MetadataOnly(
-                metadataBranch,
-                claimCount);
+            .Where(path => path.StartsWith(ClaimCommand.ClaimsDirectory + "/", StringComparison.Ordinal))
+            .ToArray();
+        if (claimPaths.Length == 0)
+        {
+            return CanonicalClaimEvidence.NoStore;
+        }
+
+        var activeClaimCount = claimPaths.Count(IsActiveClaimPath);
+        return activeClaimCount == 0
+            ? CanonicalClaimEvidence.MetadataHistoryOnly(metadataBranch, claimPaths.Length)
+            : CanonicalClaimEvidence.MetadataOnly(metadataBranch, activeClaimCount);
     }
 
     private static (string? Branch, string? Error) ReadConfiguredMetadataBranch(string repoRoot)
@@ -457,6 +462,13 @@ internal static class ClaimOwnershipVerifier
                 true,
                 null,
                 $"Claims store is configured on metadata branch '{metadataBranch}' with {claimCount} active record(s), but the canonical branch has no claim records; refusing to treat every scope as unconfigured.");
+        public static CanonicalClaimEvidence MetadataHistoryOnly(string metadataBranch, int claimPathCount) =>
+            new(
+                true,
+                true,
+                false,
+                null,
+                $"Claims store is adopted on metadata branch '{metadataBranch}' with {claimPathCount} claim history path(s), but no active record exists on that branch or the canonical branch.");
     }
 
     private sealed record GitResult(int ExitCode, string StandardOutput, string StandardError);

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandG779Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandG779Tests.cs
@@ -1,0 +1,524 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class ClaimCommandG779Tests : IDisposable
+{
+    public ClaimCommandG779Tests()
+    {
+        WorkerClaimCommand.MutatorFactory = null;
+        WorkerClaimCommand.IssueLookupFactory = null;
+        WorkerClaimCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerClaimCommand.MutatorFactory = null;
+        WorkerClaimCommand.IssueLookupFactory = null;
+        WorkerClaimCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void RejectedPushWithoutRemoteAdvance_ReportsPushRejectedWithoutRetry_AndRendersDiagnostics_G779()
+    {
+        using var repos = new ClaimRepositories();
+        repos.RejectEveryPushWithoutAdvancingTarget();
+        const string scope = "execution-unit:G779-rejected";
+        var baseCommit = repos.ReadRef("main");
+
+        using var json = new StringWriter();
+        var jsonExit = ClaimCommand.ExecuteAcquire(
+            Context(repos.FirstClone),
+            [
+                "--scope", scope,
+                "--actor", "alice",
+                "--team", "implementation",
+                "--max-attempts", "5",
+                "--write",
+                "--format", "json",
+            ],
+            json);
+
+        Assert.Equal(1, jsonExit);
+        using (var emitted = JsonDocument.Parse(json.ToString()))
+        {
+            var result = emitted.RootElement;
+            Assert.Equal("push-rejected", result.GetProperty("status").GetString());
+            Assert.False(result.GetProperty("push_succeeded").GetBoolean());
+            Assert.Equal(1, result.GetProperty("attempts").GetInt32());
+            Assert.Equal("refs/heads/main", result.GetProperty("target_ref").GetString());
+            Assert.Equal(baseCommit, result.GetProperty("base_commit").GetString());
+            Assert.Equal(baseCommit, result.GetProperty("remote_head").GetString());
+            Assert.False(result.GetProperty("remote_advanced").GetBoolean());
+            Assert.Contains(
+                "G779 test: protected default branch",
+                result.GetProperty("git_push_error").GetString(),
+                StringComparison.Ordinal);
+        }
+
+        Assert.Equal(1, repos.HookInvocations);
+        Assert.Equal(baseCommit, repos.ReadRef("main"));
+        var inspection = repos.CloneForInspection();
+        Assert.False(File.Exists(Path.Combine(inspection, ClaimCommand.ClaimPath(scope))));
+
+        using var markdown = new StringWriter();
+        var markdownExit = ClaimCommand.ExecuteAcquire(
+            Context(repos.FirstClone),
+            [
+                "--scope", scope,
+                "--actor", "alice",
+                "--team", "implementation",
+                "--max-attempts", "5",
+                "--write",
+                "--format", "markdown",
+            ],
+            markdown);
+
+        Assert.Equal(1, markdownExit);
+        Assert.Contains($"- base_commit: `{baseCommit}`", markdown.ToString(), StringComparison.Ordinal);
+        Assert.Contains("- remote_advanced: false", markdown.ToString(), StringComparison.Ordinal);
+        Assert.Contains(
+            "- git_push_error: remote: G779 test: protected default branch",
+            markdown.ToString(),
+            StringComparison.Ordinal);
+        Assert.Equal(2, repos.HookInvocations);
+    }
+
+    [Fact]
+    public void RejectedPushWithOneRemoteAdvance_ReappliesAndAcquiresOnSecondAttempt_G779()
+    {
+        using var repos = new ClaimRepositories();
+        repos.AdvanceTargetThenRejectOnlyTheFirstPush();
+        const string scope = "execution-unit:G779-advance-once";
+        var before = repos.ReadRef("main");
+
+        var result = ClaimCommand.RunTransaction(
+            repos.FirstClone,
+            Request(scope, maxAttempts: 5));
+
+        Assert.Equal("acquired", result.Status);
+        Assert.True(result.PushSucceeded);
+        Assert.Equal(2, result.Attempts);
+        Assert.Equal("refs/heads/main", result.TargetRef);
+        Assert.Equal(2, repos.HookInvocations);
+        Assert.NotEqual(before, repos.ReadRef("main"));
+        var inspection = repos.CloneForInspection();
+        Assert.True(File.Exists(Path.Combine(inspection, ClaimCommand.ClaimPath(scope))));
+    }
+
+    [Fact]
+    public void RejectedPushWithRemoteAdvanceOnEveryAttempt_ReportsTruthfulRetryExhausted_G779()
+    {
+        using var repos = new ClaimRepositories();
+        repos.AdvanceTargetThenRejectEveryPush();
+        const string scope = "execution-unit:G779-retry-exhausted";
+
+        var result = ClaimCommand.RunTransaction(
+            repos.FirstClone,
+            Request(scope, maxAttempts: 3));
+
+        Assert.Equal("retry-exhausted", result.Status);
+        Assert.False(result.PushSucceeded);
+        Assert.Equal(3, result.Attempts);
+        Assert.Equal("refs/heads/main", result.TargetRef);
+        Assert.True(result.RemoteAdvanced);
+        Assert.NotNull(result.BaseCommit);
+        Assert.NotNull(result.RemoteHead);
+        Assert.NotEqual(result.BaseCommit, result.RemoteHead);
+        Assert.Equal(repos.ReadRef("main"), result.RemoteHead);
+        Assert.Contains("G779 test: advanced default branch", result.GitPushError, StringComparison.Ordinal);
+        Assert.Contains("refs/heads/main", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("unrelated remote advance", result.Detail, StringComparison.Ordinal);
+        Assert.Equal(3, repos.HookInvocations);
+    }
+
+    [Fact]
+    public void MetadataBranchHistoryOnly_IsAdoptedStoreForVerifyTriple_G779()
+    {
+        const string scope = "execution-unit:G779-history-only";
+        using var historyOnly = new ClaimMetadataRepositories(MetadataFixture.HistoryOnly);
+        using var absentEverywhere = new ClaimMetadataRepositories(MetadataFixture.AbsentEverywhere);
+        using var activeMetadataOnly = new ClaimMetadataRepositories(MetadataFixture.ActiveOnly);
+
+        var historyVerification = ClaimOwnershipVerifier.Verify(
+            historyOnly.FirstClone,
+            scope,
+            "implementation");
+        Assert.False(historyVerification.Passed);
+        Assert.Equal(ClaimOwnershipVerification.StatusUnheld, historyVerification.Status);
+        Assert.True(historyVerification.StoreConfigured);
+        Assert.Contains("intent-metadata", historyVerification.Detail, StringComparison.Ordinal);
+        Assert.Contains("no active record exists", historyVerification.Detail, StringComparison.Ordinal);
+
+        var absentVerification = ClaimOwnershipVerifier.Verify(
+            absentEverywhere.FirstClone,
+            scope,
+            "implementation");
+        Assert.True(absentVerification.Passed);
+        Assert.Equal(ClaimOwnershipVerification.StatusNotConfigured, absentVerification.Status);
+        Assert.False(absentVerification.StoreConfigured);
+
+        var activeVerification = ClaimOwnershipVerifier.Verify(
+            activeMetadataOnly.FirstClone,
+            scope,
+            "implementation");
+        Assert.False(activeVerification.Passed);
+        Assert.Equal(ClaimOwnershipVerification.StatusMetadataBranchOnly, activeVerification.Status);
+        Assert.True(activeVerification.StoreConfigured);
+
+        var historyOutput = ExecuteVerification(historyOnly.FirstClone, scope, out var historyExit);
+        var absentOutput = ExecuteVerification(absentEverywhere.FirstClone, scope, out var absentExit);
+        var activeOutput = ExecuteVerification(activeMetadataOnly.FirstClone, scope, out var activeExit);
+
+        Assert.Equal(1, historyExit);
+        Assert.Equal(0, absentExit);
+        Assert.Equal(1, activeExit);
+        using var historyJson = JsonDocument.Parse(historyOutput);
+        using var absentJson = JsonDocument.Parse(absentOutput);
+        using var activeJson = JsonDocument.Parse(activeOutput);
+        Assert.Equal("unheld", historyJson.RootElement.GetProperty("status").GetString());
+        Assert.False(historyJson.RootElement.GetProperty("passed").GetBoolean());
+        Assert.True(historyJson.RootElement.GetProperty("store_configured").GetBoolean());
+        Assert.Equal("not-configured", absentJson.RootElement.GetProperty("status").GetString());
+        Assert.True(absentJson.RootElement.GetProperty("passed").GetBoolean());
+        Assert.False(absentJson.RootElement.GetProperty("store_configured").GetBoolean());
+        Assert.Equal("metadata-branch-only", activeJson.RootElement.GetProperty("status").GetString());
+        Assert.False(activeJson.RootElement.GetProperty("passed").GetBoolean());
+        Assert.True(activeJson.RootElement.GetProperty("store_configured").GetBoolean());
+    }
+
+    [Fact]
+    public void WorkerClaimHistoryOnlyStoreProbe_RefusesInsteadOfBypassing_G779()
+    {
+        using var repos = new ClaimMetadataRepositories(MetadataFixture.HistoryOnly);
+        var mutator = new FakeLabelMutator(["intent-target"]);
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+        WorkerClaimCommand.IssueLookupFactory = () => new FakeIssueLookup("claim history fixture");
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            Context(repos.FirstClone),
+            [
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "1779",
+                "--github-only",
+                "--write",
+                "--format", "json",
+            ],
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Empty(mutator.Transitions);
+        Assert.Contains(
+            result.Errors,
+            error => error.Contains("could not resolve a leading execution-unit token", StringComparison.Ordinal));
+    }
+
+    private static ClaimRequest Request(string scope, int maxAttempts) =>
+        new(
+            ClaimOperation.Acquire,
+            scope,
+            "alice",
+            "implementation",
+            null,
+            null,
+            true,
+            "json",
+            maxAttempts);
+
+    private static string ExecuteVerification(string root, string scope, out int exitCode)
+    {
+        using var writer = new StringWriter();
+        exitCode = ClaimVerificationCommand.Execute(
+            Context(root),
+            ["--scope", scope, "--team", "implementation", "--format", "json"],
+            writer);
+        return writer.ToString();
+    }
+
+    private static CliContext Context(string root) => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private sealed class ClaimRepositories : IDisposable
+    {
+        private readonly TempDirectory temp = new("claim-g779-repos-");
+        private readonly string hookCountPath;
+
+        public ClaimRepositories()
+        {
+            Bare = Path.Combine(temp.Path, "origin.git");
+            var seed = Path.Combine(temp.Path, "seed");
+            FirstClone = Path.Combine(temp.Path, "first");
+            Directory.CreateDirectory(Bare);
+            Run(Bare, "git", "init", "--bare", "--quiet");
+            Directory.CreateDirectory(seed);
+            Run(seed, "git", "init", "--quiet", "--initial-branch=main");
+            Run(seed, "git", "config", "user.name", "g779-fixture");
+            Run(seed, "git", "config", "user.email", "g779-fixture@example.invalid");
+            File.WriteAllText(Path.Combine(seed, "README.md"), "g779 fixture\n");
+            Run(seed, "git", "add", "README.md");
+            Run(seed, "git", "commit", "--quiet", "-m", "seed");
+            Run(seed, "git", "remote", "add", "origin", Bare);
+            Run(seed, "git", "push", "--quiet", "-u", "origin", "main");
+            Run(Bare, "git", "symbolic-ref", "HEAD", "refs/heads/main");
+            Run(temp.Path, "git", "clone", "--quiet", Bare, FirstClone);
+            hookCountPath = Path.Combine(Bare, "hooks", "g779-push-count");
+        }
+
+        public string Bare { get; }
+        public string FirstClone { get; }
+        public int HookInvocations => !File.Exists(hookCountPath)
+            ? 0
+            : int.Parse(File.ReadAllText(hookCountPath).Trim(), System.Globalization.CultureInfo.InvariantCulture);
+
+        public string ReadRef(string branch) =>
+            Run(Bare, "git", "rev-parse", $"refs/heads/{branch}").Trim();
+
+        public string CloneForInspection()
+        {
+            var path = Path.Combine(temp.Path, $"inspect-{Guid.NewGuid():N}");
+            Run(temp.Path, "git", "clone", "--quiet", Bare, path);
+            return path;
+        }
+
+        public void RejectEveryPushWithoutAdvancingTarget() => InstallPreReceiveHook("""
+            count_file="$PWD/hooks/g779-push-count"
+            count=0
+            if [ -f "$count_file" ]; then
+              count=$(cat "$count_file")
+            fi
+            count=$((count + 1))
+            printf '%s\n' "$count" > "$count_file"
+            printf '%s\n' 'G779 test: protected default branch' >&2
+            exit 1
+            """);
+
+        public void AdvanceTargetThenRejectOnlyTheFirstPush() => InstallPreReceiveHook("""
+            count_file="$PWD/hooks/g779-push-count"
+            count=0
+            if [ -f "$count_file" ]; then
+              count=$(cat "$count_file")
+            fi
+            count=$((count + 1))
+            printf '%s\n' "$count" > "$count_file"
+            if [ "$count" -eq 1 ]; then
+              unset GIT_QUARANTINE_PATH GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+              old=$(git rev-parse refs/heads/main)
+              tree=$(git rev-parse "$old^{tree}")
+              advanced=$(printf '%s\n' 'G779 unrelated advance' | GIT_AUTHOR_NAME=g779 GIT_AUTHOR_EMAIL=g779@example.invalid GIT_COMMITTER_NAME=g779 GIT_COMMITTER_EMAIL=g779@example.invalid git commit-tree "$tree" -p "$old")
+              git update-ref refs/heads/main "$advanced" "$old"
+              printf '%s\n' 'G779 test: advanced default branch' >&2
+              exit 1
+            fi
+            exit 0
+            """);
+
+        public void AdvanceTargetThenRejectEveryPush() => InstallPreReceiveHook("""
+            count_file="$PWD/hooks/g779-push-count"
+            count=0
+            if [ -f "$count_file" ]; then
+              count=$(cat "$count_file")
+            fi
+            count=$((count + 1))
+            printf '%s\n' "$count" > "$count_file"
+            unset GIT_QUARANTINE_PATH GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+            old=$(git rev-parse refs/heads/main)
+            tree=$(git rev-parse "$old^{tree}")
+            advanced=$(printf '%s\n' 'G779 unrelated advance' | GIT_AUTHOR_NAME=g779 GIT_AUTHOR_EMAIL=g779@example.invalid GIT_COMMITTER_NAME=g779 GIT_COMMITTER_EMAIL=g779@example.invalid git commit-tree "$tree" -p "$old")
+            git update-ref refs/heads/main "$advanced" "$old"
+            printf '%s\n' 'G779 test: advanced default branch' >&2
+            exit 1
+            """);
+
+        private void InstallPreReceiveHook(string body)
+        {
+            var hookPath = Path.Combine(Bare, "hooks", "pre-receive");
+            File.WriteAllText(hookPath, "#!/bin/sh\nset -eu\n" + body + "\n", new UTF8Encoding(false));
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    hookPath,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+
+        public void Dispose() => temp.Dispose();
+    }
+
+    private enum MetadataFixture
+    {
+        HistoryOnly,
+        ActiveOnly,
+        AbsentEverywhere,
+    }
+
+    private sealed class ClaimMetadataRepositories : IDisposable
+    {
+        private readonly TempDirectory temp = new("claim-g779-metadata-");
+
+        public ClaimMetadataRepositories(MetadataFixture fixture)
+        {
+            Bare = Path.Combine(temp.Path, "origin.git");
+            var seed = Path.Combine(temp.Path, "seed");
+            FirstClone = Path.Combine(temp.Path, "first");
+            Directory.CreateDirectory(Bare);
+            Run(Bare, "git", "init", "--bare", "--quiet");
+            Directory.CreateDirectory(seed);
+            Run(seed, "git", "init", "--quiet", "--initial-branch=main");
+            Run(seed, "git", "config", "user.name", "g779-fixture");
+            Run(seed, "git", "config", "user.email", "g779-fixture@example.invalid");
+            File.WriteAllText(Path.Combine(seed, "README.md"), "g779 metadata fixture\n");
+            Run(seed, "git", "add", "README.md");
+            Run(seed, "git", "commit", "--quiet", "-m", "seed");
+            Run(seed, "git", "remote", "add", "origin", Bare);
+            Run(seed, "git", "push", "--quiet", "-u", "origin", "main");
+            Run(Bare, "git", "symbolic-ref", "HEAD", "refs/heads/main");
+
+            if (fixture is not MetadataFixture.AbsentEverywhere)
+            {
+                Run(seed, "git", "switch", "--quiet", "-c", "intent-metadata");
+                if (fixture == MetadataFixture.HistoryOnly)
+                {
+                    var path = Path.Combine(
+                        seed,
+                        ".intent-cli",
+                        "claims",
+                        "history",
+                        "g779-history",
+                        "released.json");
+                    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                    File.WriteAllText(path, "{\"operation\":\"release\"}\n", new UTF8Encoding(false));
+                }
+                else
+                {
+                    var record = new ClaimRecord(
+                        "1",
+                        "execution-unit:G779-history-only",
+                        "alice",
+                        "implementation",
+                        DateTimeOffset.Parse("2026-09-01T00:00:00Z"),
+                        "base-commit");
+                    var path = Path.Combine(
+                        seed,
+                        ClaimCommand.ClaimPath(record.Scope).Replace('/', Path.DirectorySeparatorChar));
+                    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                    File.WriteAllText(path, JsonSerializer.Serialize(record) + Environment.NewLine, new UTF8Encoding(false));
+                }
+                Run(seed, "git", "add", "--", ClaimCommand.ClaimsDirectory);
+                Run(seed, "git", "commit", "--quiet", "-m", "metadata claim evidence");
+                Run(seed, "git", "push", "--quiet", "-u", "origin", "intent-metadata");
+            }
+
+            Run(temp.Path, "git", "clone", "--quiet", Bare, FirstClone);
+            if (fixture is not MetadataFixture.AbsentEverywhere)
+            {
+                var configDirectory = Path.Combine(FirstClone, ".intent-cli");
+                Directory.CreateDirectory(configDirectory);
+                File.WriteAllText(
+                    Path.Combine(configDirectory, "config.toml"),
+                    "[project]\n"
+                    + "domain = \"intent-cli\"\n"
+                    + "artifact_root = \".intent-cli\"\n"
+                    + "metadata_source_branch = \"intent-metadata\"\n",
+                    new UTF8Encoding(false));
+            }
+        }
+
+        public string Bare { get; }
+        public string FirstClone { get; }
+
+        public void Dispose() => temp.Dispose();
+    }
+
+    private sealed class FakeLabelMutator(IReadOnlyList<string> labels) : IGitHubLabelMutator
+    {
+        public List<(IReadOnlyList<string> Add, IReadOnlyList<string> Remove)> Transitions { get; } = [];
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            Transitions.Add((addLabels.ToArray(), removeLabels.ToArray()));
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class FakeIssueLookup(string title) : IGitHubIssueLookup
+    {
+        public GitHubIssueLookupResult Lookup(string repo, int issueNumber) => new()
+        {
+            Number = issueNumber,
+            State = "OPEN",
+            Title = title,
+            Body = string.Empty,
+            Labels = Array.Empty<GitHubIssueLabel>(),
+        };
+    }
+
+    private static string Run(string workdir, string fileName, params string[] arguments)
+    {
+        var info = new ProcessStartInfo(fileName)
+        {
+            WorkingDirectory = workdir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments)
+        {
+            info.ArgumentList.Add(argument);
+        }
+        using var process = Process.Start(info)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"{fileName} {string.Join(' ', arguments)} failed: {error}");
+        return output;
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory(string prefix) => Path = Directory.CreateTempSubdirectory(prefix).FullName;
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Classify a rejected default-branch claim push with no remote advance as `push-rejected`, preserve server stderr, and do not retry.
- Keep bounded reapply only for evidenced remote advances and report terminal retry evidence accurately.
- Treat history-only metadata claims as adopted store evidence; add EN/JA reference documentation and regression coverage.

## Validation

- `dotnet test IntentSystem.sln --no-restore -c Release` — 5,823 passed, 1 skipped.
- Focused claim and Japanese terminology regressions — 47 passed.
- `git diff --check`

Closes #1699