### PR TITLE
G735: allow topology move when roles share a pane

### DIFF
--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -1339,7 +1339,7 @@ internal static class SessionLayerTopologyWriter
             }
 
             var recordedPanes = new HashSet<string>(StringComparer.Ordinal);
-            var mappedPanes = new HashSet<string>(StringComparer.Ordinal);
+            var newPaneToOldPane = new Dictionary<string, string>(StringComparer.Ordinal);
             foreach (var (roleName, roleNode) in roles!.OrderBy(entry => entry.Key, StringComparer.Ordinal))
             {
                 if (roleNode is not JsonObject role)
@@ -1377,15 +1377,18 @@ internal static class SessionLayerTopologyWriter
                         + "refusing a partial workspace move.");
                 }
 
-                if (!mappedPanes.Add(newPane))
+                if (newPaneToOldPane.TryGetValue(newPane, out var priorOldPane)
+                    && !string.Equals(priorOldPane, oldPane, StringComparison.Ordinal))
                 {
                     return MoveConflict(
                         request,
                         path,
                         currentDigest,
-                        $"--pane-map maps more than one recorded role to new pane '{newPane}'; refusing an "
-                        + "ambiguous workspace move.");
+                        $"--pane-map maps old panes '{priorOldPane}' and '{oldPane}' to the same new pane "
+                        + $"'{newPane}'; refusing an ambiguous workspace move.");
                 }
+
+                newPaneToOldPane[newPane] = oldPane;
 
                 var paneWorkspace = WorkspaceFromPane(newPane);
                 if (paneWorkspace is not null

--- a/tests/IntentSystem.Cli.Tests/TopologyWorkspaceMoveG697Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/TopologyWorkspaceMoveG697Tests.cs
@@ -278,6 +278,88 @@ public sealed class TopologyWorkspaceMoveG697Tests
         Assert.False(Directory.Exists(configDirectory));
     }
 
+    [Fact]
+    public void Move_SharedPane_RolesTravelTogether_G735()
+    {
+        var context = CreateFixture();
+        SetHerdrOnly(context);
+        RecordHerdr(context, "orchestrator", "w2X:p1", "/orchestration", "codex", "inline");
+        RecordHerdr(context, "orchestration", "w2X:p1", "/orchestration", "codex", "inline");
+        RecordHerdr(context, "implementation", "w2X:p2", "/implementation", "claude", "file-backed");
+
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(context.RepoRoot, Domain, Team);
+        var before = File.ReadAllText(topologyPath);
+
+        var preview = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44", "--pane-map", "w2X:p1=w44:p1", "--pane-map", "w2X:p2=w44:p2",
+            "--dry-run", "--format", "json",
+        ]);
+
+        Assert.Equal("dry-run", preview.GetProperty("mode").GetString());
+        Assert.False(preview.GetProperty("conflict").GetBoolean());
+        Assert.True(preview.GetProperty("changed").GetBoolean());
+        Assert.Equal("w2X", preview.GetProperty("previous_workspace_id").GetString());
+        Assert.Equal("w44", preview.GetProperty("workspace_id").GetString());
+        Assert.Equal(before, File.ReadAllText(topologyPath));
+
+        var afterRoles = preview.GetProperty("after").GetProperty("roles");
+        Assert.Equal("w44:p1", afterRoles.GetProperty("orchestrator").GetProperty("pane_id").GetString());
+        Assert.Equal("w44:p1", afterRoles.GetProperty("orchestration").GetProperty("pane_id").GetString());
+        Assert.Equal("w44", afterRoles.GetProperty("orchestrator").GetProperty("workspace_id").GetString());
+        Assert.Equal("w44", afterRoles.GetProperty("orchestration").GetProperty("workspace_id").GetString());
+        Assert.Equal("w44:p2", afterRoles.GetProperty("implementation").GetProperty("pane_id").GetString());
+
+        var write = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44", "--pane-map", "w2X:p1=w44:p1", "--pane-map", "w2X:p2=w44:p2",
+            "--current-digest", preview.GetProperty("current_digest").GetString()!, "--write", "--format", "json",
+        ]);
+
+        Assert.Equal("write", write.GetProperty("mode").GetString());
+        Assert.True(write.GetProperty("applied").GetBoolean());
+        Assert.False(write.GetProperty("conflict").GetBoolean());
+
+        var moved = JsonNode.Parse(File.ReadAllText(topologyPath))!.AsObject();
+        Assert.Equal("w44", moved["workspace_id"]!.GetValue<string>());
+        var movedRoles = moved["roles"]!.AsObject();
+        Assert.Equal("w44:p1", movedRoles["orchestrator"]!["pane_id"]!.GetValue<string>());
+        Assert.Equal("w44:p1", movedRoles["orchestration"]!["pane_id"]!.GetValue<string>());
+        Assert.Equal("w44", movedRoles["orchestrator"]!["workspace_id"]!.GetValue<string>());
+        Assert.Equal("w44", movedRoles["orchestration"]!["workspace_id"]!.GetValue<string>());
+        Assert.Equal("w44:p2", movedRoles["implementation"]!["pane_id"]!.GetValue<string>());
+
+        var validation = Run(context, [
+            "session-layer", "topology", "validate", "--domain", Domain, "--team", Team, "--format", "json",
+        ]);
+        Assert.True(validation.GetProperty("valid").GetBoolean());
+    }
+
+    [Fact]
+    public void Move_TwoOldPanesToOneNewPane_StillRefuses_G735()
+    {
+        var context = CreateFixture();
+        SetHerdrOnly(context);
+        RecordHerdr(context, "orchestration", "w2X:p1", "/orchestration", "codex", "inline");
+        RecordHerdr(context, "implementation", "w2X:p2", "/implementation", "claude", "inline");
+
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(context.RepoRoot, Domain, Team);
+        var before = File.ReadAllText(topologyPath);
+
+        var result = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44", "--pane-map", "w2X:p1=w44:p1", "--pane-map", "w2X:p2=w44:p1",
+            "--dry-run", "--format", "json",
+        ], expectedExitCode: 1);
+
+        Assert.True(result.GetProperty("conflict").GetBoolean());
+        Assert.Contains("old panes", result.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Contains("w2X:p1", result.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Contains("w2X:p2", result.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Contains("w44:p1", result.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllText(topologyPath));
+    }
+
     private static void AssertMoveGuide(JsonElement root)
     {
         Assert.Equal("guide topology-workspace-move", root.GetProperty("guide_surface").GetString());


### PR DESCRIPTION
Fixes #1593

## Problem

session-layer topology move (G697) refused a team whose orchestrator and orchestration roles share one pane — the standard four-thread layout the orchestrator guide itself describes. The whole-team move exists for the post-reboot rebuild, and it refused it.

topology record redirected to topology move ("use topology move"), and topology move refused ("maps more than one recorded role to new pane"). The two surfaces referred to each other and neither could perform the move.

## Root cause

The guard at SessionLayerTopologyCommand.cs:1380 used a HashSet<string> keyed on the new pane and rejected any repeat. It should only reject when two different old panes map to the same new pane.

## Fix

Replace the HashSet with a Dictionary<string, string> mapping new pane to the old pane that produced it. The guard now checks whether a different old pane already claimed the new pane. Roles traveling with their shared pane are not ambiguous.

## Verification

- New test Move_SharedPane_RolesTravelTogether_G735: records orchestrator and orchestration at w2X:p1, implementation at w2X:p2, moves to w44. Dry-run and write both succeed. Validate passes.
- New test Move_TwoOldPanesToOneNewPane_StillRefuses_G735: records orchestration at w2X:p1, implementation at w2X:p2, maps both to w44:p1. Refuses with a message naming both old panes.
- All 7 existing G697 tests pass unchanged.