### PR TITLE
fix: report completed issue publish

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
@@ -224,7 +224,7 @@ internal static class AutomationIssuePublishCommand
             RemoveLabels = Array.Empty<string>(),
             CurrentLabels = currentLabels,
             PublishedAt = publishedAt,
-            Summary = BuildSummary(issue.Value, AppliedLabel),
+            Summary = BuildSummary(issue.Value, AppliedLabel, mode),
         };
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
@@ -423,8 +423,13 @@ internal static class AutomationIssuePublishCommand
     private static string BuildIssueUrl(string repo, int issue) =>
         $"https://github.com/{repo}/issues/{issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
 
-    private static string BuildSummary(int issue, string label) =>
-        $"Would publish issue #{issue.ToString(System.Globalization.CultureInfo.InvariantCulture)} by adding {label}.";
+    private static string BuildSummary(int issue, string label, string mode)
+    {
+        var issueText = issue.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal)
+            ? $"Published issue #{issueText} by adding {label}."
+            : $"Would publish issue #{issueText} by adding {label}.";
+    }
 
     private static void WriteText(TextWriter writer, AutomationIssuePublishResult result)
     {

--- a/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
@@ -139,6 +139,40 @@ public sealed class AutomationIssuePublishCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_G783_ModeAwareSummaryMatchesJsonAndTextOutput()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+
+        var dryRunJson = ExecutePublish(workspace.Context, "json");
+        var writeJson = ExecutePublish(workspace.Context, "json", "--write");
+        var dryRunText = ExecutePublish(workspace.Context, "text");
+        var writeText = ExecutePublish(workspace.Context, "text", "--write");
+
+        var dryRunResult = JsonSerializer.Deserialize<AutomationIssuePublishResult>(dryRunJson.Output)!;
+        var writeResult = JsonSerializer.Deserialize<AutomationIssuePublishResult>(writeJson.Output)!;
+        const string dryRunSummary = "Would publish issue #783 by adding intent-target.";
+        const string writeSummary = "Published issue #783 by adding intent-target.";
+
+        Assert.Equal(0, dryRunJson.ExitCode);
+        Assert.Equal(0, writeJson.ExitCode);
+        Assert.Equal(0, dryRunText.ExitCode);
+        Assert.Equal(0, writeText.ExitCode);
+        Assert.Equal(dryRunSummary, dryRunResult.Summary);
+        Assert.Equal(writeSummary, writeResult.Summary);
+        Assert.DoesNotContain("Would", writeResult.Summary, StringComparison.Ordinal);
+        Assert.NotEqual(dryRunResult.Summary, writeResult.Summary);
+        Assert.StartsWith(dryRunSummary, dryRunText.Output, StringComparison.Ordinal);
+        Assert.StartsWith(writeSummary, writeText.Output, StringComparison.Ordinal);
+
+        Console.WriteLine($"G783 dry-run JSON:{Environment.NewLine}{dryRunJson.Output}");
+        Console.WriteLine($"G783 write JSON:{Environment.NewLine}{writeJson.Output}");
+        Console.WriteLine($"G783 dry-run text:{Environment.NewLine}{dryRunText.Output}");
+        Console.WriteLine($"G783 write text:{Environment.NewLine}{writeText.Output}");
+    }
+
+    [Fact]
     public void Execute_TextOutputIncludesPublishMetadata()
     {
         using var workspace = new AutomationIssuePublishWorkspace();
@@ -366,6 +400,25 @@ public sealed class AutomationIssuePublishCommandTests : IDisposable
             IReadOnlyCollection<string> addLabels,
             IReadOnlyCollection<string> removeLabels) =>
             throw new NotSupportedException("reconcile path not exercised by these tests");
+    }
+
+    private static (int ExitCode, string Output) ExecutePublish(
+        CliContext context,
+        string format,
+        params string[] modeArguments)
+    {
+        var arguments = new List<string>
+        {
+            "--repo", "J-Tech-Japan/intent-system",
+            "--issue", "783"
+        };
+        arguments.AddRange(modeArguments);
+        arguments.Add("--format");
+        arguments.Add(format);
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationIssuePublishCommand.Execute(context, [.. arguments], writer);
+        return (exitCode, writer.ToString());
     }
 
     private sealed record AppliedTransition(


### PR DESCRIPTION
Closes #1707

## Summary

- Make `automation issue-publish` report `Published …` after a successful `--write` while retaining `Would publish …` for dry-run.
- Preserve every result/refusal field and the label transition itself.
- Add one regression that runs both modes through JSON and text rendering and emits the actual fixture documents below.

## Parent evidence

The parent implementation used the dry-run sentence unconditionally:

```text
$ git show origin/main:src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs | rg -n -C 1 'BuildSummary|Would publish issue'
226-            PublishedAt = publishedAt,
227:            Summary = BuildSummary(issue.Value, AppliedLabel),
228-        };
--
425-
426:    private static string BuildSummary(int issue, string label) =>
427:        $"Would publish issue #{issue.ToString(System.Globalization.CultureInfo.InvariantCulture)} by adding {label}.";
428-
```

The one new regression was absent from the parent:

```text
$ git grep -n 'Execute_G783_ModeAwareSummaryMatchesJsonAndTextOutput' origin/main -- tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
exit status: 1
```

## Actual fixture output

```text
G783 dry-run JSON:
{
  "repo": "J-Tech-Japan/intent-system",
  "issue": 783,
  "issue_url": "https://github.com/J-Tech-Japan/intent-system/issues/783",
  "issueUrl": "https://github.com/J-Tech-Japan/intent-system/issues/783",
  "mode": "dry-run",
  "applied": false,
  "refused": false,
  "refusal_reason": null,
  "applied_label": "intent-target",
  "appliedLabel": "intent-target",
  "add_labels": [
    "intent-target"
  ],
  "addLabels": [
    "intent-target"
  ],
  "remove_labels": [],
  "removeLabels": [],
  "current_labels": [],
  "currentLabels": [],
  "published_at": "2026-05-02T01:54:00+00:00",
  "publishedAt": "2026-05-02T01:54:00+00:00",
  "summary": "Would publish issue #783 by adding intent-target."
}

G783 write JSON:
{
  "repo": "J-Tech-Japan/intent-system",
  "issue": 783,
  "issue_url": "https://github.com/J-Tech-Japan/intent-system/issues/783",
  "issueUrl": "https://github.com/J-Tech-Japan/intent-system/issues/783",
  "mode": "write",
  "applied": true,
  "refused": false,
  "refusal_reason": null,
  "applied_label": "intent-target",
  "appliedLabel": "intent-target",
  "add_labels": [
    "intent-target"
  ],
  "addLabels": [
    "intent-target"
  ],
  "remove_labels": [],
  "removeLabels": [],
  "current_labels": [],
  "currentLabels": [],
  "published_at": "2026-05-02T01:54:00+00:00",
  "publishedAt": "2026-05-02T01:54:00+00:00",
  "summary": "Published issue #783 by adding intent-target."
}

G783 dry-run text:
Would publish issue #783 by adding intent-target.
mode: dry-run
repo: J-Tech-Japan/intent-system
issue: 783
issue_url: https://github.com/J-Tech-Japan/intent-system/issues/783
applied_label: intent-target
applied: false
published_at: 2026-05-02T01:54:00.0000000+00:00

G783 write text:
Published issue #783 by adding intent-target.
mode: write
repo: J-Tech-Japan/intent-system
issue: 783
issue_url: https://github.com/J-Tech-Japan/intent-system/issues/783
applied_label: intent-target
applied: true
published_at: 2026-05-02T01:54:00.0000000+00:00
```

## Scope evidence

- There is no already-labelled/no-change result path today: `AutomationIssuePublishCommand.cs:192-203` unconditionally calls `ApplyLabelTransitions(... [AppliedLabel] ...)` in write mode and then sets `applied = true`. This PR does not invent a new transition path.
- Neither `docs/en/08-command-reference.md` nor `docs/ja/08-command-reference.md` quotes the summary sentence. Actual check: `rg -n -F 'Would publish issue #' docs/en/08-command-reference.md docs/ja/08-command-reference.md` exited 1 with no output, so neither mirror changed.

## Validation

```text
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --nologo --filter 'FullyQualifiedName~AutomationIssuePublishCommandTests' --logger 'console;verbosity=detailed'
Total tests: 14
Passed: 14

$ dotnet test IntentSystem.sln --configuration Release --no-restore --nologo --logger 'console;verbosity=minimal'
IntentSystem.Cli.Tests:              Passed: 5499, Skipped: 1, Total: 5500
IntentSystem.ConceptIntake.Tests:    Passed:   36, Skipped: 0, Total:   36
IntentSystem.Projection.Tests:       Passed:   80, Skipped: 0, Total:   80
IntentSystem.Supervisor.Tests:       Passed:   66, Skipped: 0, Total:   66
IntentSystem.Drift.Tests:            Passed:    6, Skipped: 0, Total:    6
IntentSystem.Review.Tests:           Passed:   35, Skipped: 0, Total:   35
IntentSystem.DomainBinding.Tests:    Passed:   13, Skipped: 0, Total:   13
IntentSystem.Workflow.Tests:         Passed:   21, Skipped: 0, Total:   21
IntentSystem.DogfoodingBridge.Tests: Passed:   10, Skipped: 0, Total:   10
IntentSystem.Clarify.Tests:          Passed:   47, Skipped: 0, Total:   47
IntentSystem.WorkerAdapter.Tests:    Passed:   16, Skipped: 0, Total:   16
Aggregate: Passed 5829, Skipped 1, Failed 0
```

`dotnet format IntentSystem.sln --verify-no-changes --no-restore --include <changed C# files>` and `git diff --check` both exited 0.
