### PR TITLE
fix: extract Codex shell approvals without choice chrome

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -863,6 +863,14 @@ same-wake scratch-ledger identity requirement; G690 does not weaken that
 contract. Any future design-answerable class still has to use the canonical
 adjudication surface and live CAS.
 
+For the Codex shell dialog, the payload is only the `$ `, `> `, or `Command:`
+line(s) after the header and before the **first choice**. `Environment:` is
+chrome, and a non-choice wrapped line before that boundary continues the
+preceding command. The first choice, every wrapped choice line, and the
+`Press enter` hint are dialog chrome rather than command text. A `$` command
+marker or a fenced block after the first choice is a hidden tail and rejects
+the entire extraction; the shell AST verifier is not relaxed or rewritten.
+
 Each supervision cycle also compares the structured argv of every running
 recorded seat with its kind's recorded recipe. The comparison covers exactly
 the security envelope: sandbox mode, approval mode, writable roots/add-dirs,
@@ -1004,6 +1012,8 @@ background shell:
 intent-cli notify supervise install --domain <domain> --team <team> \
   --repo <owner/repo> --owner-role <logical-role> --bound <seconds> \
   --interval <seconds> [--startup-bound <seconds>] [--platform macos|windows|linux] \
+  [--pre-approve <agent-kind>:<prompt-class>]... \
+  [--pre-escalate <agent-kind>:<prompt-class>]... [--shell-policy <json>]... \
   [--output <path>] [--routing-root <host-root>] [--verify|--dry-run|--write] --format json
 ```
 
@@ -1015,6 +1025,13 @@ explicit cross-authoring override. Every artifact is named and labelled
 supervise` invocation, including domain, team, repo, owner role, bound, and
 interval. Output names the written path, lifetime, runtime logs, legacy
 artifacts removed, and exact registration/unregistration/reconcile commands.
+Install accepts `--pre-approve`, `--pre-escalate`, and `--shell-policy` with
+the same validation as `notify supervise` and embeds each supplied policy
+argument in the artifact's `ProgramArguments`. When that artifact starts its
+supervisor, its first cycle records the policy under
+`pre-approval-policy.json`; reconcile continues to treat the artifact as a
+managed artifact. Omitting all three options preserves the existing
+policy-free invocation.
 G712 deliberately chooses the permitted GUI-session lifetime: the artifact is
 kept under the routing repository's
 `.intent-cli/supervision/<domain>/<team>/install/`, never under

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -734,6 +734,12 @@ shell scope（`owned-scratch-delete` を含む）は orchestration-only で、�
 要件も維持します。G690 はこの contract を弱めません。将来 design-answerable な class が追加されても、
 canonical adjudication surface と live CAS が必須です。
 
+Codex shell dialog の payload は、header の後で **first choice** の前にある `$ `、`> `、または
+`Command:` line(s) だけです。`Environment:` は chrome であり、boundary より前の non-choice wrapped
+line は直前の command の continuation になります。first choice、wrapped choice line、`Press enter` hint は
+command text ではなく dialog chrome です。first choice の後に `$` command marker または fenced block が
+現れた場合は hidden tail として extraction 全体を拒否し、shell AST verifier を緩めたり書き換えたりしません。
+
 各 supervision cycle は running recorded seat の structured argv と kind ごとの recorded
 recipe も比較します。比較対象は security envelope、すなわち sandbox mode、approval mode、
 writable roots/add-dirs、network access だけです。bound の欠落、extra root、より広い envelope は
@@ -848,6 +854,8 @@ standing loop の setup は ad-hoc な background shell ではなく出力専用
 intent-cli notify supervise install --domain <domain> --team <team> \
   --repo <owner/repo> --owner-role <logical-role> --bound <seconds> \
   --interval <seconds> [--startup-bound <seconds>] [--platform macos|windows|linux] \
+  [--pre-approve <agent-kind>:<prompt-class>]... \
+  [--pre-escalate <agent-kind>:<prompt-class>]... [--shell-policy <json>]... \
   [--output <path>] [--routing-root <host-root>] [--verify|--dry-run|--write] --format json
 ```
 
@@ -857,6 +865,12 @@ Windows の `schtasks` compatible Task Scheduler XML、または Linux の syste
 `intent-cli.supervise.<domain>.<team>` という team 固有の名前と label を持ち、domain、team、repo、
 owner role、bound、interval を含む完全な `notify supervise` invocation を埋め込みます。output は write 先、lifetime、
 runtime log、legacy artifact の削除、registration / unregistration / reconcile の正確な command を表示します。
+install は `--pre-approve`、`--pre-escalate`、`--shell-policy` を `notify supervise` と
+同じ validation で受け取り、supplied policy argument を artifact の
+`ProgramArguments` に埋め込みます。artifact から supervisor が開始した場合、first cycle
+は policy を `pre-approval-policy.json` に記録します。reconcile はその artifact を
+managed artifact として扱い続けます。3 つの option をすべて省略すると既存の
+policy-free invocation を保持します。
 G712 は許可された GUI-session lifetime を選びます。artifact は routing repository の
 `.intent-cli/supervision/<domain>/<team>/install/` 配下に置き、`~/Library/LaunchAgents` には置きません。macOS plist
 は `RunAtLoad` を持たないため login auto-load も reboot persistence もなく、logout/reboot で GUI domain が消えます。

--- a/src/IntentSystem.Cli/Commands/NotifyAdjudicateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyAdjudicateCommand.cs
@@ -174,7 +174,8 @@ internal static class NotifyAdjudicateCommand
         if (!options.Write)
         {
             return Emit(writer, options, Result(authorization, live, audited: false, executed: false)
-                with { Summary = authorization.Summary + " Dry-run: no audit or key sequence was written." });
+                with
+            { Summary = authorization.Summary + " Dry-run: no audit or key sequence was written." });
         }
 
         var initialAudit = NotifySupervisionStore.RecordPromptAudit(auditPath, audit, write: true);
@@ -207,7 +208,8 @@ internal static class NotifyAdjudicateCommand
                 audit with { Timestamp = Now(), Outcome = "stale-dialog-cas-refused", Rule = audit.Rule + " (stale-dialog-cas-refused)" },
                 write: true);
             return Emit(writer, options, Result(authorization, live, audited: true, executed: false)
-                with { Summary = authorization.Summary + $" No key was sent: {cas.Summary}" },
+                with
+            { Summary = authorization.Summary + $" No key was sent: {cas.Summary}" },
                 exitCode: 1);
         }
 
@@ -241,21 +243,21 @@ internal static class NotifyAdjudicateCommand
         {
             return Emit(writer, options, Result(authorization, live, audited: true, executed: execution.ExitCode == 0)
                 with
-                {
-                    Decision = "escalate",
-                    Rule = authorization.Rule + " (terminal-audit-write-failed)",
-                    Summary = $"The bounded answer {(execution.ExitCode == 0 ? "was sent" : "failed")}, but its terminal audit could not be durably appended: {terminalAudit.Error ?? "not applied"}. Reconciliation is required.",
-                    MechanicalExecutor = null,
-                },
+            {
+                Decision = "escalate",
+                Rule = authorization.Rule + " (terminal-audit-write-failed)",
+                Summary = $"The bounded answer {(execution.ExitCode == 0 ? "was sent" : "failed")}, but its terminal audit could not be durably appended: {terminalAudit.Error ?? "not applied"}. Reconciliation is required.",
+                MechanicalExecutor = null,
+            },
                 exitCode: 1);
         }
         return Emit(writer, options, Result(authorization, live, audited: true, executed: execution.ExitCode == 0)
             with
-            {
-                Summary = execution.ExitCode == 0
+        {
+            Summary = execution.ExitCode == 0
                     ? authorization.Summary + $" Executed only registry keys [{string.Join(", ", authorization.AnswerKeys)}]."
                     : authorization.Summary + $" The bounded answer failed: {execution.StandardError}",
-            },
+        },
             exitCode: execution.ExitCode == 0 ? 0 : 1);
     }
 
@@ -267,20 +269,23 @@ internal static class NotifyAdjudicateCommand
         LiveDialog live,
         bool audited,
         bool executed) => new()
-    {
-        Decision = authorization.Decision,
-        Rule = authorization.Rule,
-        Summary = authorization.Summary,
-        ActorRole = authorization.DecisionActorRole,
-        MechanicalExecutor = authorization.MechanicalExecutor,
-        AnswerableBy = authorization.AnswerableBy,
-        RiskTags = authorization.RiskTags,
-        ScopeOrRuleId = authorization.ScopeOrRuleId,
-        StateChangeSequence = live.Agent?.StateChangeSequence,
-        ObservedTextHash = live.TextHash,
-        Audited = audited,
-        Executed = executed,
-    };
+        {
+            Decision = authorization.Decision,
+            Rule = authorization.Rule,
+            Summary = authorization.Summary,
+            ActorRole = authorization.DecisionActorRole,
+            MechanicalExecutor = authorization.MechanicalExecutor,
+            AnswerableBy = authorization.AnswerableBy,
+            RiskTags = authorization.RiskTags,
+            ScopeOrRuleId = authorization.ScopeOrRuleId,
+            MatchedScopes = authorization.MatchedScopes,
+            AnswerKeys = authorization.AnswerKeys,
+            ExactAnswerScope = authorization.ExactAnswerScope,
+            StateChangeSequence = live.Agent?.StateChangeSequence,
+            ObservedTextHash = live.TextHash,
+            Audited = audited,
+            Executed = executed,
+        };
 
     private static AdjudicationResult Refused(string? actorRole, string rule, string summary) => new()
     {
@@ -498,6 +503,8 @@ internal static class NotifyAdjudicateCommand
             writer.WriteLine($"- rule: {result.Rule}");
             writer.WriteLine($"- actor: {result.ActorRole}");
             writer.WriteLine($"- mechanical executor: {result.MechanicalExecutor ?? "none"}");
+            writer.WriteLine($"- matched scopes: {string.Join(", ", result.MatchedScopes.DefaultIfEmpty("none"))}");
+            writer.WriteLine($"- answer keys: {string.Join(", ", result.AnswerKeys.DefaultIfEmpty("none"))}");
             writer.WriteLine($"- audited: {result.Audited}; executed: {result.Executed}");
             writer.WriteLine($"- summary: {result.Summary}");
         }
@@ -549,6 +556,9 @@ internal static class NotifyAdjudicateCommand
         public string? AnswerableBy { get; init; }
         public IReadOnlyList<string> RiskTags { get; init; } = [];
         public string? ScopeOrRuleId { get; init; }
+        public IReadOnlyList<string> MatchedScopes { get; init; } = [];
+        public IReadOnlyList<string> AnswerKeys { get; init; } = [];
+        public string? ExactAnswerScope { get; init; }
         public long? StateChangeSequence { get; init; }
         public string? ObservedTextHash { get; init; }
         public bool Audited { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseInstallCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseInstallCommand.cs
@@ -23,7 +23,9 @@ internal static class NotifySuperviseInstallCommand
         + "--owner-role <role> --bound <seconds> --interval <seconds> "
         + "[--startup-bound <seconds>; default 120 for --write, 1 for --verify] "
         + "[--persistence persistent] "
-        + "[--event-mode] [--platform macos|windows|linux] [--output <path>] [--routing-root <host-root>] "
+        + "[--event-mode] [--pre-approve <agent-kind>:<prompt-class>]... "
+        + "[--pre-escalate <agent-kind>:<prompt-class>]... [--shell-policy <json>]... "
+        + "[--platform macos|windows|linux] [--output <path>] [--routing-root <host-root>] "
         + "[--verify|--dry-run|--write] [--format markdown|json]";
 
     private const string FormatJson = "json";
@@ -549,6 +551,11 @@ internal static class NotifySuperviseInstallCommand
         {
             arguments.Add("--event-mode");
         }
+        foreach (var policyArgument in options.PolicyArguments)
+        {
+            arguments.Add(policyArgument.Option);
+            arguments.Add(policyArgument.Value);
+        }
         foreach (var binary in runtime.Binaries.Where(binary => (binary.Name is "herdr" or "bash") && binary.Resolved))
         {
             arguments.Add(binary.Name == "herdr" ? "--herdr-executable" : "--bash-executable");
@@ -713,23 +720,23 @@ RestartSec=30
         string platform,
         string label,
         string artifactPath) => platform switch
-    {
-        MacOs =>
-        (
-            $"launchctl bootstrap gui/$(id -u) {QuoteShellArgument(artifactPath)}",
-            $"launchctl bootout gui/$(id -u)/{label}"
-        ),
-        Windows =>
-        (
-            $"schtasks /Create /TN {QuoteWindowsArgument(label)} /XML {QuoteWindowsArgument(artifactPath)} /F",
-            $"schtasks /Delete /TN {QuoteWindowsArgument(label)} /F"
-        ),
-        _ =>
-        (
-            $"systemctl --user link {QuoteShellArgument(artifactPath)} && systemctl --user start {QuoteShellArgument(label + ".service")}",
-            $"systemctl --user stop {QuoteShellArgument(label + ".service")} && systemctl --user unlink {QuoteShellArgument(artifactPath)}"
-        ),
-    };
+        {
+            MacOs =>
+            (
+                $"launchctl bootstrap gui/$(id -u) {QuoteShellArgument(artifactPath)}",
+                $"launchctl bootout gui/$(id -u)/{label}"
+            ),
+            Windows =>
+            (
+                $"schtasks /Create /TN {QuoteWindowsArgument(label)} /XML {QuoteWindowsArgument(artifactPath)} /F",
+                $"schtasks /Delete /TN {QuoteWindowsArgument(label)} /F"
+            ),
+            _ =>
+            (
+                $"systemctl --user link {QuoteShellArgument(artifactPath)} && systemctl --user start {QuoteShellArgument(label + ".service")}",
+                $"systemctl --user stop {QuoteShellArgument(label + ".service")} && systemctl --user unlink {QuoteShellArgument(artifactPath)}"
+            ),
+        };
 
     private static string FormatShellInvocation(string executable, IReadOnlyList<string> arguments) =>
         executable + " " + string.Join(" ", arguments.Select(QuoteShellArgument));
@@ -771,6 +778,10 @@ RestartSec=30
         var verify = false;
         var eventMode = false;
         var format = FormatMarkdown;
+        var preApprovalAcceptRules = new List<NotifyPreApprovalRule>();
+        var preApprovalEscalateRules = new List<NotifyPreApprovalRule>();
+        var scopedPolicies = new List<NotifyScopedPromptPolicy>();
+        var policyArguments = new List<InstallPolicyArgument>();
         error = string.Empty;
 
         for (var index = 0; index < args.Length; index++)
@@ -807,6 +818,65 @@ RestartSec=30
                 case "--dry-run": dryRun = true; break;
                 case "--verify": verify = true; break;
                 case "--event-mode": eventMode = true; break;
+                case "--pre-approve":
+                    if (!ReadValue(args, ref index, argument, out var acceptRuleValue, out error)
+                        || !NotifyPreApprovalPolicyStore.TryParseRule(acceptRuleValue!, out var acceptRule))
+                    {
+                        error = "--pre-approve requires <agent-kind>:<prompt-class> using safe identifiers.";
+                        return Fail(out options);
+                    }
+                    if (!NotifyPreApprovalPolicyStore.TryValidateRule(acceptRule!, out error))
+                    {
+                        return Fail(out options);
+                    }
+                    preApprovalAcceptRules.Add(acceptRule!);
+                    policyArguments.Add(new InstallPolicyArgument(argument, acceptRuleValue!));
+                    break;
+                case "--pre-escalate":
+                    if (!ReadValue(args, ref index, argument, out var escalateRuleValue, out error)
+                        || !NotifyPreApprovalPolicyStore.TryParseRule(escalateRuleValue!, out var escalateRule))
+                    {
+                        error = "--pre-escalate requires <agent-kind>:<prompt-class> using safe identifiers.";
+                        return Fail(out options);
+                    }
+                    if (!NotifyPreApprovalPolicyStore.TryValidateRule(escalateRule!, out error))
+                    {
+                        return Fail(out options);
+                    }
+                    preApprovalEscalateRules.Add(escalateRule!);
+                    policyArguments.Add(new InstallPolicyArgument(argument, escalateRuleValue!));
+                    break;
+                case "--shell-policy":
+                case "--pre-approve-shell":
+                    if (!ReadValue(args, ref index, argument, out var shellPolicyValue, out error))
+                    {
+                        return Fail(out options);
+                    }
+                    NotifyScopedPromptPolicy? shellPolicy;
+                    try
+                    {
+                        shellPolicy = JsonSerializer.Deserialize<NotifyScopedPromptPolicy>(shellPolicyValue!, JsonOptions);
+                    }
+                    catch (JsonException exception)
+                    {
+                        error = $"{argument} requires one scoped policy JSON object: {exception.Message}";
+                        return Fail(out options);
+                    }
+                    if (shellPolicy is null)
+                    {
+                        error = $"{argument} requires one scoped policy JSON object.";
+                        return Fail(out options);
+                    }
+                    if (!NotifyPreApprovalPolicyStore.TryValidateScopedPolicy(
+                        shellPolicy,
+                        out error,
+                        requireScratchLedgerCycleId: false))
+                    {
+                        return Fail(out options);
+                    }
+                    scopedPolicies.Add(shellPolicy);
+                    policyArguments.Add(new InstallPolicyArgument(argument, shellPolicyValue!));
+                    break;
                 case "--format":
                     if (!ReadValue(args, ref index, argument, out format, out error)) return Fail(out options);
                     if (format is not FormatJson and not FormatMarkdown)
@@ -853,6 +923,25 @@ RestartSec=30
             error = "--write and --dry-run are mutually exclusive.";
             return Fail(out options);
         }
+        if ((preApprovalAcceptRules.Count == 0) != (preApprovalEscalateRules.Count == 0))
+        {
+            error = "A recorded pre-approval policy requires at least one --pre-approve and one --pre-escalate rule; without both, omit them and remain escalate-only.";
+            return Fail(out options);
+        }
+        if (!NotifyPreApprovalPolicyStore.TryValidateNoOverlap(
+            preApprovalAcceptRules,
+            preApprovalEscalateRules,
+            out error))
+        {
+            return Fail(out options);
+        }
+        if (!NotifyPreApprovalPolicyStore.TryValidateScopedPolicies(
+            scopedPolicies,
+            out error,
+            requireScratchLedgerCycleId: false))
+        {
+            return Fail(out options);
+        }
 
         options = new InstallOptions
         {
@@ -873,6 +962,7 @@ RestartSec=30
             Verify = verify,
             EventMode = eventMode,
             PersistenceIntent = persistenceIntent,
+            PolicyArguments = policyArguments,
         };
         return true;
     }
@@ -1013,8 +1103,11 @@ RestartSec=30
         public required bool Verify { get; init; }
         public bool EventMode { get; init; }
         public string? PersistenceIntent { get; init; }
+        public required IReadOnlyList<InstallPolicyArgument> PolicyArguments { get; init; }
         public required string Format { get; init; }
     }
+
+    private sealed record InstallPolicyArgument(string Option, string Value);
 
     private sealed record NotifySuperviseRuntimeResolution(
         IReadOnlyList<NotifySuperviseRuntimeBinary> Binaries,

--- a/src/IntentSystem.Cli/Commands/ShellCommandPolicy.cs
+++ b/src/IntentSystem.Cli/Commands/ShellCommandPolicy.cs
@@ -428,11 +428,17 @@ internal static class ShellCommandPolicyRegistry
                 .ToArray();
             if (candidates.Length == 0)
             {
+                var uncoveredTarget = FindUncoveredOwnedScratchTarget(
+                    segment,
+                    validPolicies,
+                    cwd,
+                    currentCycleId);
                 return Refused(
                     Rule(rulePrefix, matches.Select(policy => policy.Scope)),
                     payload,
                     "shell-segment-out-of-scope",
-                    "Every shell AST segment must be covered by a matching scoped policy; an unknown command, substitution, redirect, or out-of-scope path remains escalate-only.",
+                    "Every shell AST segment must be covered by a matching scoped policy; an unknown command, substitution, redirect, or out-of-scope path remains escalate-only."
+                    + (uncoveredTarget is null ? string.Empty : $" Uncovered path: {uncoveredTarget}."),
                     matches.Select(policy => policy.Scope).Distinct(StringComparer.Ordinal).OrderBy(value => value, StringComparer.Ordinal).ToArray());
             }
 
@@ -534,6 +540,35 @@ internal static class ShellCommandPolicyRegistry
     private static bool IsOwnedScratchSegment(ShellCommandSegment segment) =>
         segment.Argv.Count > 0
         && string.Equals(segment.Argv[0], "rm", StringComparison.Ordinal);
+
+    private static string? FindUncoveredOwnedScratchTarget(
+        ShellCommandSegment segment,
+        IReadOnlyList<NotifyScopedPromptPolicy> policies,
+        string? cwd,
+        string? currentCycleId)
+    {
+        if (!IsOwnedScratchSegment(segment) || cwd is null)
+        {
+            return null;
+        }
+
+        var eligiblePolicies = policies
+            .Where(policy => string.Equals(policy.Scope, OwnedScratchDeleteScope, StringComparison.Ordinal))
+            .Where(policy => string.Equals(policy.ScratchLedgerCycleId, currentCycleId, StringComparison.Ordinal))
+            .Where(policy => HasTokenPrefix(segment.Argv, policy.ArgvTokenPrefix))
+            .ToArray();
+        if (eligiblePolicies.Length == 0)
+        {
+            return null;
+        }
+
+        return segment.Argv
+            .Skip(1)
+            .Where(token => !token.StartsWith("-", StringComparison.Ordinal))
+            .FirstOrDefault(target => !eligiblePolicies.Any(policy =>
+                policy.ScratchLedgerPaths.Any(path => SamePathFrom(path, target, cwd))
+                && policy.PathConstraints.Any(path => SamePathFrom(path, target, cwd))));
+    }
 
     private static ShellCommandPolicyAuthorization Authorization(
         NotifyScopedPromptPolicy policy,

--- a/src/IntentSystem.Cli/Commands/ShellCommandPromptRecognizer.cs
+++ b/src/IntentSystem.Cli/Commands/ShellCommandPromptRecognizer.cs
@@ -41,7 +41,8 @@ internal static class ShellCommandPromptRecognizer
         var choiceBlockStarted = false;
         for (var index = headerIndex + 1; index < lines.Length; index++)
         {
-            var line = Normalize(lines[index]);
+            var rawLine = lines[index];
+            var line = NormalizeContent(rawLine);
             if (line.Length == 0 || IsFrame(line))
             {
                 continue;
@@ -49,17 +50,17 @@ internal static class ShellCommandPromptRecognizer
 
             if (!insideFence && choiceBlockStarted)
             {
-                if (IsChoice(line))
+                // Choice text, its wrapped lines, and the terminal hint are
+                // dialog chrome. They are never part of the command. A new
+                // command marker or fenced block is instead a hidden tail:
+                // fail closed rather than authorizing a truncated payload.
+                if (line.StartsWith('$')
+                    || IsCommandLine(line, out _)
+                    || line.StartsWith("```", StringComparison.Ordinal))
                 {
-                    continue;
+                    return false;
                 }
-
-                // Once terminal choice chrome has started, any residual
-                // non-choice content could be a hidden command tail. Do not
-                // truncate the payload at the first choice-looking line:
-                // reject the whole extraction so no unevaluated segment can
-                // reach policy authorization.
-                return false;
+                continue;
             }
 
             if (line.StartsWith("```", StringComparison.Ordinal))
@@ -68,26 +69,36 @@ internal static class ShellCommandPromptRecognizer
                 continue;
             }
 
-            if (!insideFence && IsChoice(line))
+            if (insideFence)
             {
-                if (commandLines.Count > 0)
-                {
-                    choiceBlockStarted = true;
-                }
-
                 continue;
             }
 
-            if (line.StartsWith("$ ", StringComparison.Ordinal)
-                || line.StartsWith("> ", StringComparison.Ordinal))
+            // Choice recognition intentionally consumes the raw line. The
+            // content normalizer removes numeric prefixes for headers and
+            // payloads, which would otherwise make "1. Yes" indistinguishable
+            // from arbitrary prose.
+            if (IsChoice(rawLine))
             {
-                line = line[2..].TrimStart();
+                choiceBlockStarted = true;
+                continue;
             }
-            if (line.StartsWith("Command:", StringComparison.OrdinalIgnoreCase))
+
+            if (line.StartsWith("Environment:", StringComparison.OrdinalIgnoreCase))
             {
-                line = line["Command:".Length..].TrimStart();
+                continue;
             }
-            if (line.Length > 0)
+
+            if (IsCommandLine(line, out var commandLine))
+            {
+                commandLines.Add(commandLine);
+                continue;
+            }
+
+            // A non-choice line is a continuation only after a structural
+            // command marker. This keeps header prose and environment chrome
+            // out of the payload while retaining wrapped commands.
+            if (commandLines.Count > 0)
             {
                 commandLines.Add(line);
             }
@@ -112,13 +123,13 @@ internal static class ShellCommandPromptRecognizer
 
     private static string Normalize(string line)
     {
-        var normalized = line.Trim().Trim('│', '┃', '║').Trim();
+        var normalized = NormalizeContent(line);
         if (normalized.Length == 0)
         {
             return normalized;
         }
 
-        if (normalized[0] is '›' or '❯' or '○' or '●' or '>')
+        if (normalized[0] == '>')
         {
             normalized = normalized[1..].TrimStart();
         }
@@ -136,13 +147,48 @@ internal static class ShellCommandPromptRecognizer
         return normalized;
     }
 
+    private static string NormalizeContent(string line)
+    {
+        var normalized = line.Trim().Trim('│', '┃', '║').Trim();
+        if (normalized.Length > 0 && normalized[0] is '›' or '❯' or '○' or '●')
+        {
+            normalized = normalized[1..].TrimStart();
+        }
+
+        return normalized;
+    }
+
+    private static bool IsCommandLine(string line, out string commandLine)
+    {
+        if (line.StartsWith('$'))
+        {
+            commandLine = line[1..].TrimStart();
+            return commandLine.Length > 0;
+        }
+
+        if (line.StartsWith("> ", StringComparison.Ordinal))
+        {
+            commandLine = line[2..].TrimStart();
+            return true;
+        }
+
+        if (line.StartsWith("Command:", StringComparison.OrdinalIgnoreCase))
+        {
+            commandLine = line["Command:".Length..].TrimStart();
+            return true;
+        }
+
+        commandLine = string.Empty;
+        return false;
+    }
+
     private static bool IsFrame(string line) => line.Length > 0
         && line.All(character => character is '┌' or '└' or '├' or '┤' or '─'
             or '╭' or '╰' or '╯' or '╮' or '┬' or '┴' or '┼');
 
-    private static bool IsChoice(string line)
+    private static bool IsChoice(string rawLine)
     {
-        var normalized = Normalize(line);
+        var normalized = NormalizeContent(rawLine);
         var lower = normalized.ToLowerInvariant();
         if (lower is "yes" or "no" or "y" or "n" or "allow" or "deny"
             or "cancel" or "reject" or "approve" or "run")
@@ -150,8 +196,8 @@ internal static class ShellCommandPromptRecognizer
             return true;
         }
 
-        if (lower.Contains("[y/n]", StringComparison.Ordinal)
-            || lower.Contains("[yes/no]", StringComparison.Ordinal)
+        if (lower.StartsWith("yes ", StringComparison.Ordinal)
+            || lower.StartsWith("no ", StringComparison.Ordinal)
             || lower.StartsWith("allow ", StringComparison.Ordinal)
             || lower.StartsWith("always allow", StringComparison.Ordinal)
             || lower.StartsWith("continue ", StringComparison.Ordinal)

--- a/src/IntentSystem.Cli/Commands/ShellCommandPromptRecognizer.cs
+++ b/src/IntentSystem.Cli/Commands/ShellCommandPromptRecognizer.cs
@@ -104,7 +104,10 @@ internal static class ShellCommandPromptRecognizer
             }
         }
 
-        var command = string.Join('\n', commandLines).Trim();
+        // Dialog wrapping is visual chrome. Every fragment collected here is
+        // before the first numbered choice, so join wrapped command text as a
+        // single shell command rather than turning it into a new segment.
+        var command = string.Join(' ', commandLines).Trim();
         if (command.Length == 0)
         {
             return false;

--- a/tests/IntentSystem.Cli.Tests/NotifySuperviseInstallG786Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySuperviseInstallG786Tests.cs
@@ -1,0 +1,227 @@
+using System.Text.Json;
+using System.Xml.Linq;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifySuperviseInstallG786Tests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private const string Label = "intent-cli.supervise.intent-cli.intent-cli-dev";
+    private readonly string root = Path.Combine(
+        RepoVersionPolicySource.RepoRoot(),
+        ".artifacts",
+        "g786-install-" + Guid.NewGuid().ToString("N"));
+    private readonly string home;
+
+    public NotifySuperviseInstallG786Tests()
+    {
+        Directory.CreateDirectory(root);
+        home = Path.Combine(root, "home");
+        NotifyCommand.ProcessRunnerFactory = () => new FixtureRunner();
+        NotifySuperviseInstallCommand.FirstCycleProbeFactory = _ => new NotifySuperviseFirstCycleResult
+        {
+            Verified = true,
+            Status = "first-cycle-verified",
+            CycleId = "g786-install-first-cycle",
+            Writer = new NotifySupervisionWriterIdentity
+            {
+                Pid = 7860,
+                ProcessStartTime = new DateTimeOffset(2026, 9, 2, 12, 0, 0, TimeSpan.Zero),
+                Host = "g786-fixture",
+            },
+            ObservedAt = new DateTimeOffset(2026, 9, 2, 12, 0, 1, TimeSpan.Zero),
+        };
+        NotifySuperviseReconcileCommand.MacOsDetector = () => true;
+        NotifySuperviseArtifactInventory.UserProfileDirectoryFactory = () => home;
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifySuperviseInstallCommand.FirstCycleProbeFactory = null;
+        NotifySuperviseReconcileCommand.MacOsDetector = OperatingSystem.IsMacOS;
+        NotifySuperviseArtifactInventory.UserProfileDirectoryFactory =
+            () => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    }
+
+    [Fact]
+    public void Install_EmbedsValidatedPolicyArgumentsAndLaunchedArtifactRecordsThem()
+    {
+        var shellPolicyJson = JsonSerializer.Serialize(ProjectTestPolicy());
+        using var installWriter = new StringWriter();
+        var installExitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(),
+            InstallArguments("--write")
+                .Concat(
+                [
+                    "--pre-approve", "codex:github-comment-post",
+                    "--pre-escalate", "codex:launch-hook-trust",
+                    "--shell-policy", shellPolicyJson,
+                    "--format", "json",
+                ])
+                .ToArray(),
+            installWriter);
+
+        Assert.Equal(0, installExitCode);
+        using var install = JsonDocument.Parse(installWriter.ToString());
+        var artifactPath = install.RootElement.GetProperty("artifact_path").GetString()!;
+        var programArguments = XDocument.Parse(File.ReadAllText(artifactPath))
+            .Descendants("array")
+            .Single()
+            .Elements("string")
+            .Select(element => element.Value)
+            .ToArray();
+
+        AssertContainsSequence(programArguments, "--pre-approve", "codex:github-comment-post");
+        AssertContainsSequence(programArguments, "--pre-escalate", "codex:launch-hook-trust");
+        AssertContainsSequence(programArguments, "--shell-policy", shellPolicyJson);
+
+        var artifactSuperviseArguments = programArguments
+            .SkipWhile(argument => !string.Equals(argument, "notify", StringComparison.Ordinal))
+            .Skip(2)
+            .Append("--once")
+            .ToArray();
+        using var supervisorWriter = new StringWriter();
+        Assert.Equal(
+            0,
+            NotifyCommand.ExecuteSupervise(CreateContext(), artifactSuperviseArguments, supervisorWriter));
+
+        var recorded = NotifyPreApprovalPolicyStore.Read(
+            CreateContext().ResolveSupervisionArtifactRootPath(),
+            Domain,
+            Team);
+        Assert.True(recorded.Resolved, recorded.Error);
+        Assert.NotNull(recorded.Policy);
+        Assert.Contains(recorded.Policy!.Accept, rule => rule.ToString() == "codex:github-comment-post");
+        Assert.Contains(recorded.Policy.Escalate, rule => rule.ToString() == "codex:launch-hook-trust");
+        Assert.Contains(recorded.Policy.ScopedPolicies, policy => policy.PolicyId == "g786-project-test");
+
+        using var reconcileWriter = new StringWriter();
+        Assert.Equal(
+            0,
+            NotifyCommand.ExecuteSupervise(
+                CreateContext(),
+                ["reconcile", "--domain", Domain, "--team", Team, "--platform", "macos", "--dry-run", "--format", "json"],
+                reconcileWriter));
+        using var reconcile = JsonDocument.Parse(reconcileWriter.ToString());
+        Assert.Contains(
+            reconcile.RootElement.GetProperty("artifacts_before").EnumerateArray().Select(value => value.GetString()),
+            value => string.Equals(value, artifactPath, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void InstallWithoutPolicies_PreservesThePolicyFreeInvocation()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            NotifyCommand.ExecuteSupervise(
+                CreateContext(),
+                InstallArguments("--dry-run").Concat(["--format", "json"]).ToArray(),
+                writer));
+
+        using var output = JsonDocument.Parse(writer.ToString());
+        var invocation = output.RootElement.GetProperty("supervise_invocation").GetString()!;
+        Assert.DoesNotContain("--pre-approve", invocation, StringComparison.Ordinal);
+        Assert.DoesNotContain("--pre-escalate", invocation, StringComparison.Ordinal);
+        Assert.DoesNotContain("--shell-policy", invocation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Install_UsesTheSameScopedPolicyValidationAsSupervise()
+    {
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(),
+            InstallArguments("--dry-run")
+                .Concat(["--pre-approve", "codex:shell-command", "--format", "json"])
+                .ToArray(),
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("scoped shell policy", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DocumentationStatesTheCommandOnlyRecognizerAndInstallPolicyPassThrough()
+    {
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var documentation = File.ReadAllText(Path.Combine(
+                RepoVersionPolicySource.RepoRoot(),
+                "docs",
+                language,
+                "12-agent-message-orchestration.md"));
+            Assert.Contains("--pre-approve <agent-kind>:<prompt-class>", documentation, StringComparison.Ordinal);
+            Assert.Contains("--pre-escalate <agent-kind>:<prompt-class>", documentation, StringComparison.Ordinal);
+            Assert.Contains("--shell-policy <json>", documentation, StringComparison.Ordinal);
+            Assert.Contains("first choice", documentation, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("chrome", documentation, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private IEnumerable<string> InstallArguments(string mode) =>
+    [
+        "install", "--domain", Domain, "--team", Team,
+        "--repo", "J-Tech-Japan/intent-system", "--owner-role", "orchestration",
+        "--bound", "900", "--interval", "300", "--platform", "macos",
+        "--routing-root", root, mode,
+    ];
+
+    private CliContext CreateContext() => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = Domain,
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+            Supervision = new SupervisionConfig { ArtifactRoot = ".intent-cli/supervision" },
+        },
+    };
+
+    private static NotifyScopedPromptPolicy ProjectTestPolicy() => new()
+    {
+        PolicyId = "g786-project-test",
+        AgentKind = "codex",
+        PromptClass = "shell-command",
+        Scope = "project-test",
+        Decision = "accept",
+        Category = "test-execution",
+        ArgvTokenPrefix = ["dotnet", "test"],
+        Cwd = "/repo",
+        Root = "/repo",
+        PathConstraints = ["/repo/tests"],
+        EffectTags = ["executes-tests"],
+    };
+
+    private static void AssertContainsSequence(IReadOnlyList<string> values, params string[] expected)
+    {
+        for (var index = 0; index <= values.Count - expected.Length; index++)
+        {
+            if (values.Skip(index).Take(expected.Length).SequenceEqual(expected, StringComparer.Ordinal))
+            {
+                return;
+            }
+        }
+
+        Assert.Fail("Expected ProgramArguments sequence was not emitted: " + string.Join(" ", expected));
+    }
+
+    private sealed class FixtureRunner : INotifyProcessRunner
+    {
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments) =>
+            string.Equals(fileName, "id", StringComparison.Ordinal)
+                && arguments.SequenceEqual(["-u"])
+                ? new NotifyProcessResult(0, "501\n", string.Empty)
+                : new NotifyProcessResult(0, "{\"result\":{\"agents\":[]}}", string.Empty);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/PromptAdjudicationG786Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PromptAdjudicationG786Tests.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class PromptAdjudicationG786Tests : IDisposable
+{
+    private const string Domain = "g786-adjudicate";
+    private const string Team = "g786-team";
+    private const string Workspace = "wG786";
+    private const string Pane = "wG786:p2";
+    private const long StateSequence = 786;
+    private const string CycleId = "g786-current-cycle";
+    private const string FirstScratchPath = "/tmp/g781-evidence.GuzWkP";
+    private const string SecondScratchPath = "/tmp/g781-default-evidence.iA5IUD";
+    private readonly string root = Path.Combine(
+        RepoVersionPolicySource.RepoRoot(),
+        ".artifacts",
+        "g786-adjudicate-" + Guid.NewGuid().ToString("N"));
+    private readonly CliContext context;
+
+    public PromptAdjudicationG786Tests()
+    {
+        Directory.CreateDirectory(root);
+        context = new CliContext
+        {
+            RepoRoot = root,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = Domain,
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                },
+                Supervision = new SupervisionConfig { ArtifactRoot = ".intent-cli/supervision" },
+            },
+        };
+    }
+
+    public void Dispose() => NotifyCommand.ProcessRunnerFactory = null;
+
+    [Fact]
+    public void DryRun_AnswersMeasuredDialogWithTheOwnedScratchScopeAndYesKey()
+    {
+        Prepare([FirstScratchPath, SecondScratchPath]);
+        var runner = new FixtureRunner(ObservedDialog());
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        using var writer = new StringWriter();
+        var exitCode = NotifyAdjudicateCommand.Execute(context, Arguments(), writer);
+
+        Assert.Equal(0, exitCode);
+        using var output = JsonDocument.Parse(writer.ToString());
+        var result = output.RootElement.GetProperty("result");
+        Assert.Equal("accept", result.GetProperty("Decision").GetString());
+        Assert.Contains(
+            result.GetProperty("MatchedScopes").EnumerateArray().Select(value => value.GetString()),
+            value => value == "owned-scratch-delete");
+        Assert.Contains(
+            result.GetProperty("AnswerKeys").EnumerateArray().Select(value => value.GetString()),
+            value => value == "y");
+        Assert.False(result.GetProperty("Audited").GetBoolean());
+        Assert.False(result.GetProperty("Executed").GetBoolean());
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "send-keys"]));
+    }
+
+    [Fact]
+    public void DryRun_EscalatesAndNamesTheUncoveredScratchPath()
+    {
+        Prepare([FirstScratchPath]);
+        var runner = new FixtureRunner(ObservedDialog());
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        using var writer = new StringWriter();
+        var exitCode = NotifyAdjudicateCommand.Execute(context, Arguments(), writer);
+
+        Assert.Equal(1, exitCode);
+        using var output = JsonDocument.Parse(writer.ToString());
+        var result = output.RootElement.GetProperty("result");
+        Assert.Equal("escalate", result.GetProperty("Decision").GetString());
+        Assert.Contains("shell-segment-out-of-scope", result.GetProperty("Rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains(SecondScratchPath, result.GetProperty("Summary").GetString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "send-keys"]));
+    }
+
+    private void Prepare(IReadOnlyList<string> scratchPaths)
+    {
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(root, Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(topologyPath)!);
+        File.WriteAllText(topologyPath, JsonSerializer.Serialize(new
+        {
+            domain = Domain,
+            team = Team,
+            workspace_id = Workspace,
+            roles = new Dictionary<string, object>
+            {
+                ["orchestration"] = new
+                {
+                    resident = "herdr",
+                    workspace_id = Workspace,
+                    pane_id = Pane,
+                    kind = "codex",
+                    cwd = "/repo",
+                },
+            },
+        }));
+
+        var cycle = NotifySupervisionStore.RecordCycle(
+            NotifySupervisionStore.ResolveCyclePath(context.ResolveSupervisionArtifactRootPath(), Domain, Team),
+            new NotifySupervisionCycle
+            {
+                CycleId = CycleId,
+                StartedAt = new DateTimeOffset(2026, 9, 2, 12, 0, 0, TimeSpan.Zero),
+                CompletedAt = new DateTimeOffset(2026, 9, 2, 12, 0, 1, TimeSpan.Zero),
+                IntervalSeconds = 60,
+            },
+            write: true);
+        Assert.True(cycle.Applied, cycle.Error);
+
+        var policy = NotifyPreApprovalPolicyStore.Record(
+            context.ResolveSupervisionArtifactRootPath(),
+            new NotifyPreApprovalPolicy
+            {
+                Domain = Domain,
+                Team = Team,
+                RecordedAt = new DateTimeOffset(2026, 9, 2, 12, 0, 1, TimeSpan.Zero),
+                Accept = [],
+                Escalate = [],
+                ScopedPolicies = [OwnedScratchPolicy(scratchPaths)],
+            },
+            write: true);
+        Assert.True(policy.Applied, policy.Error);
+    }
+
+    private string[] Arguments() =>
+    [
+        "--domain", Domain,
+        "--team", Team,
+        "--actor-role", "orchestration",
+        "--agent-kind", "codex",
+        "--prompt-class", "shell-command",
+        "--pane", Pane,
+        "--state-sequence", StateSequence.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        "--text-hash", PromptDialogCas.HashText(ObservedDialog()),
+        "--cycle-id", CycleId,
+        "--routing-root", root,
+        "--dry-run",
+        "--format", "json",
+    ];
+
+    private static string ObservedDialog() => "Would you like to run the following command?\n"
+        + "Environment: local\n"
+        + "$ rm -rf " + FirstScratchPath + " " + SecondScratchPath + "\n"
+        + "› 1. Yes, proceed (y)\n"
+        + "  2. Yes, and don't ask again for commands that\n"
+        + "     start with `rm -rf …`\n"
+        + "  3. No, and tell Codex what to do differently\n"
+        + "Press enter to confirm or esc to cancel";
+
+    private static NotifyScopedPromptPolicy OwnedScratchPolicy(IReadOnlyList<string> paths) => new()
+    {
+        PolicyId = "g786-owned-scratch",
+        AgentKind = "codex",
+        PromptClass = "shell-command",
+        Scope = "owned-scratch-delete",
+        Decision = "accept",
+        Category = "destructive-scratch-cleanup",
+        ArgvTokenPrefix = ["rm", "-rf"],
+        Cwd = "/repo",
+        PathConstraints = paths,
+        ScratchLedgerPaths = paths,
+        ScratchLedgerCycleId = CycleId,
+        EffectTags = ["destructive"],
+    };
+
+    private sealed class FixtureRunner(string prompt) : INotifyProcessRunner
+    {
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            if (arguments.SequenceEqual(["agent", "list"]))
+            {
+                return new NotifyProcessResult(0, JsonSerializer.Serialize(new
+                {
+                    result = new
+                    {
+                        agents = new[]
+                        {
+                            new
+                            {
+                                name = "orchestration",
+                                workspace_id = Workspace,
+                                pane_id = Pane,
+                                agent = "codex",
+                                agent_session = new { id = "orchestration" },
+                                agent_status = "working",
+                                interactive_ready = true,
+                                state_change_seq = StateSequence,
+                                cwd = "/repo",
+                            },
+                        },
+                    },
+                }), string.Empty);
+            }
+
+            if (arguments.Take(3).SequenceEqual(["agent", "read", Pane]))
+            {
+                return new NotifyProcessResult(0, prompt, string.Empty);
+            }
+
+            throw new InvalidOperationException($"Unexpected fixture transport call: {fileName} {string.Join(' ', arguments)}");
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/PromptAdjudicationG786Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PromptAdjudicationG786Tests.cs
@@ -44,7 +44,7 @@ public sealed class PromptAdjudicationG786Tests : IDisposable
     public void Dispose() => NotifyCommand.ProcessRunnerFactory = null;
 
     [Fact]
-    public void DryRun_AnswersMeasuredDialogWithTheOwnedScratchScopeAndYesKey()
+    public void DryRun_AnswersVerbatimFiftyColumnDialogWithTheOwnedScratchScopeAndYesKey()
     {
         Prepare([FirstScratchPath, SecondScratchPath]);
         var runner = new FixtureRunner(ObservedDialog());
@@ -69,7 +69,7 @@ public sealed class PromptAdjudicationG786Tests : IDisposable
     }
 
     [Fact]
-    public void DryRun_EscalatesAndNamesTheUncoveredScratchPath()
+    public void DryRun_VerbatimFiftyColumnDialogEscalatesAndNamesTheUncoveredScratchPath()
     {
         Prepare([FirstScratchPath]);
         var runner = new FixtureRunner(ObservedDialog());
@@ -154,7 +154,8 @@ public sealed class PromptAdjudicationG786Tests : IDisposable
 
     private static string ObservedDialog() => "Would you like to run the following command?\n"
         + "Environment: local\n"
-        + "$ rm -rf " + FirstScratchPath + " " + SecondScratchPath + "\n"
+        + "$ rm -rf " + FirstScratchPath + "\n"
+        + SecondScratchPath + "\n"
         + "› 1. Yes, proceed (y)\n"
         + "  2. Yes, and don't ask again for commands that\n"
         + "     start with `rm -rf …`\n"

--- a/tests/IntentSystem.Cli.Tests/ShellCommandPolicyG689Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ShellCommandPolicyG689Tests.cs
@@ -32,9 +32,9 @@ public sealed class ShellCommandPolicyG689Tests
     {
         var observed = "Would you like to run the following command?\n\n"
             + "$ dotnet test tests/IntentSystem.Cli.Tests.csproj\n"
-            + "read -p \"continue? [y/n]\" answer\n"
-            + "rm -rf " + Scratch + "\n\n"
-            + "1. Allow once\n2. Deny";
+            + "1. Allow once\n"
+            + "$ rm -rf " + Scratch + "\n"
+            + "2. Deny";
 
         Assert.False(ShellCommandPromptRecognizer.TryExtract(observed, out var payload));
         Assert.Null(payload);

--- a/tests/IntentSystem.Cli.Tests/ShellCommandPromptRecognizerG786Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ShellCommandPromptRecognizerG786Tests.cs
@@ -9,13 +9,14 @@ public sealed class ShellCommandPromptRecognizerG786Tests
     private const string CycleId = "g786-current-cycle";
 
     [Fact]
-    public void MeasuredDialog_ExtractsOnlyTheCommandAndTreatsChoicesAsChrome()
+    public void VerbatimFiftyColumnDialog_ExtractsTheSpaceJoinedCommandAndTreatsChoicesAsChrome()
     {
         var observed = MeasuredDialog();
 
         Assert.True(ShellCommandPromptRecognizer.TryExtract(observed, out var payload));
         Assert.NotNull(payload);
         Assert.Equal($"rm -rf {FirstScratchPath} {SecondScratchPath}", payload!.Command);
+        Assert.Equal(PromptDialogCas.HashText(observed), payload.DialogHash);
         Assert.DoesNotContain("Environment:", payload.Command, StringComparison.Ordinal);
         Assert.DoesNotContain("don't ask again", payload.Command, StringComparison.Ordinal);
         Assert.DoesNotContain("Press enter", payload.Command, StringComparison.Ordinal);
@@ -38,7 +39,7 @@ public sealed class ShellCommandPromptRecognizerG786Tests
     }
 
     [Fact]
-    public void EnvironmentAndBareContinuation_AreNotChoicesOrPayloadChrome()
+    public void PreChoiceWrappedContinuation_JoinsWithExactlyOneSpace()
     {
         var observed = Header + "\nEnvironment: local\n"
             + "$ rm -rf " + FirstScratchPath + "\n"
@@ -47,7 +48,7 @@ public sealed class ShellCommandPromptRecognizerG786Tests
             + "Press enter to confirm or esc to cancel";
 
         Assert.True(ShellCommandPromptRecognizer.TryExtract(observed, out var payload));
-        Assert.Equal($"rm -rf {FirstScratchPath}\n{SecondScratchPath}", payload!.Command);
+        Assert.Equal($"rm -rf {FirstScratchPath} {SecondScratchPath}", payload!.Command);
     }
 
     [Theory]
@@ -76,7 +77,7 @@ public sealed class ShellCommandPromptRecognizerG786Tests
     }
 
     [Fact]
-    public void MeasuredDialog_UsesBothOwnedScratchLedgerPathsForBoundedAuthorization()
+    public void VerbatimFiftyColumnDialog_UsesBothOwnedScratchLedgerPathsForBoundedAuthorization()
     {
         Assert.True(ShellCommandPromptRecognizer.TryExtract(MeasuredDialog(), out var payload));
         var covered = ShellCommandPolicyRegistry.Evaluate(
@@ -102,7 +103,15 @@ public sealed class ShellCommandPromptRecognizerG786Tests
 
     private const string Header = "Would you like to run the following command?";
 
-    private static string MeasuredDialog() => Dialog($"rm -rf {FirstScratchPath} {SecondScratchPath}");
+    private static string MeasuredDialog() => Header + "\n"
+        + "Environment: local\n"
+        + "$ rm -rf " + FirstScratchPath + "\n"
+        + SecondScratchPath + "\n"
+        + "› 1. Yes, proceed (y)\n"
+        + "  2. Yes, and don't ask again for commands that\n"
+        + "     start with `rm -rf …`\n"
+        + "  3. No, and tell Codex what to do differently\n"
+        + "Press enter to confirm or esc to cancel";
 
     private static string Dialog(string command) => Header + "\n"
         + "Environment: local\n"

--- a/tests/IntentSystem.Cli.Tests/ShellCommandPromptRecognizerG786Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ShellCommandPromptRecognizerG786Tests.cs
@@ -1,0 +1,132 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ShellCommandPromptRecognizerG786Tests
+{
+    private const string FirstScratchPath = "/tmp/g781-evidence.GuzWkP";
+    private const string SecondScratchPath = "/tmp/g781-default-evidence.iA5IUD";
+    private const string CycleId = "g786-current-cycle";
+
+    [Fact]
+    public void MeasuredDialog_ExtractsOnlyTheCommandAndTreatsChoicesAsChrome()
+    {
+        var observed = MeasuredDialog();
+
+        Assert.True(ShellCommandPromptRecognizer.TryExtract(observed, out var payload));
+        Assert.NotNull(payload);
+        Assert.Equal($"rm -rf {FirstScratchPath} {SecondScratchPath}", payload!.Command);
+        Assert.DoesNotContain("Environment:", payload.Command, StringComparison.Ordinal);
+        Assert.DoesNotContain("don't ask again", payload.Command, StringComparison.Ordinal);
+        Assert.DoesNotContain("Press enter", payload.Command, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("1. Yes, proceed (y)")]
+    [InlineData("› 1. Yes, proceed (y)")]
+    [InlineData("2. Yes, and don't ask again for commands that")]
+    [InlineData("3. No, and tell Codex what to do differently")]
+    public void RawNumberedChoices_StartTheChromeBoundary(string choice)
+    {
+        var observed = Header
+            + "\n$ printf '%s' safe\n"
+            + choice
+            + "\nPress enter to confirm or esc to cancel";
+
+        Assert.True(ShellCommandPromptRecognizer.TryExtract(observed, out var payload));
+        Assert.Equal("printf '%s' safe", payload!.Command);
+    }
+
+    [Fact]
+    public void EnvironmentAndBareContinuation_AreNotChoicesOrPayloadChrome()
+    {
+        var observed = Header + "\nEnvironment: local\n"
+            + "$ rm -rf " + FirstScratchPath + "\n"
+            + SecondScratchPath + "\n"
+            + "1. Yes, proceed (y)\n"
+            + "Press enter to confirm or esc to cancel";
+
+        Assert.True(ShellCommandPromptRecognizer.TryExtract(observed, out var payload));
+        Assert.Equal($"rm -rf {FirstScratchPath}\n{SecondScratchPath}", payload!.Command);
+    }
+
+    [Theory]
+    [InlineData("$ rm -rf /tmp/hidden-tail")]
+    [InlineData("$rm -rf /tmp/hidden-tail")]
+    [InlineData("$")]
+    [InlineData("```sh")]
+    public void HiddenCommandOrFenceAfterChoice_RejectsTheWholeDialog(string tail)
+    {
+        var observed = MeasuredDialog() + "\n" + tail;
+
+        Assert.False(ShellCommandPromptRecognizer.TryExtract(observed, out var payload));
+        Assert.Null(payload);
+    }
+
+    [Theory]
+    [InlineData("rm -rf `unparseable`")]
+    [InlineData("rm -rf $(pwd)")]
+    public void SyntaxInsideTheCommand_RemainsShellAstUnparseable(string command)
+    {
+        Assert.True(ShellCommandPromptRecognizer.TryExtract(Dialog(command), out var payload));
+        var authorization = ShellCommandPolicyRegistry.Evaluate(payload!, [], "/repo");
+
+        Assert.Equal("escalate", authorization.Decision);
+        Assert.Contains("shell-ast-unparseable", authorization.Rule, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MeasuredDialog_UsesBothOwnedScratchLedgerPathsForBoundedAuthorization()
+    {
+        Assert.True(ShellCommandPromptRecognizer.TryExtract(MeasuredDialog(), out var payload));
+        var covered = ShellCommandPolicyRegistry.Evaluate(
+            payload!,
+            [OwnedScratchPolicy([FirstScratchPath, SecondScratchPath])],
+            "/repo",
+            currentCycleId: CycleId);
+
+        Assert.Equal("accept", covered.Decision);
+        Assert.Contains("owned-scratch-delete", covered.MatchedScopes);
+        Assert.Equal(["y", "enter"], covered.AnswerKeys);
+
+        var missingOne = ShellCommandPolicyRegistry.Evaluate(
+            payload!,
+            [OwnedScratchPolicy([FirstScratchPath])],
+            "/repo",
+            currentCycleId: CycleId);
+
+        Assert.Equal("escalate", missingOne.Decision);
+        Assert.Contains("shell-segment-out-of-scope", missingOne.Rule, StringComparison.Ordinal);
+        Assert.Contains(SecondScratchPath, missingOne.Summary, StringComparison.Ordinal);
+    }
+
+    private const string Header = "Would you like to run the following command?";
+
+    private static string MeasuredDialog() => Dialog($"rm -rf {FirstScratchPath} {SecondScratchPath}");
+
+    private static string Dialog(string command) => Header + "\n"
+        + "Environment: local\n"
+        + "$ " + command + "\n"
+        + "› 1. Yes, proceed (y)\n"
+        + "  2. Yes, and don't ask again for commands that\n"
+        + "     start with `rm -rf …`\n"
+        + "  3. No, and tell Codex what to do differently\n"
+        + "Press enter to confirm or esc to cancel";
+
+    private static NotifyScopedPromptPolicy OwnedScratchPolicy(IReadOnlyList<string> paths) => new()
+    {
+        PolicyId = "g786-owned-scratch",
+        AgentKind = "codex",
+        PromptClass = "shell-command",
+        Scope = "owned-scratch-delete",
+        Decision = "accept",
+        Category = "destructive-scratch-cleanup",
+        ArgvTokenPrefix = ["rm", "-rf"],
+        Cwd = "/repo",
+        PathConstraints = paths,
+        ScratchLedgerPaths = paths,
+        ScratchLedgerCycleId = CycleId,
+        EffectTags = ["destructive"],
+        Applicable = true,
+    };
+}


### PR DESCRIPTION
## Summary

- Extract only the shell command from a Codex approval dialog; choices, wrapped choice text, terminal hints, and Environment chrome are not payload.
- Keep hidden-tail rejection and the existing shell AST / G689 ledger rules fail-closed.
- Carry validated operator pre-approval, escalation, and scoped-shell policy arguments into supervisor installation artifacts, then expose dry-run matched scopes and answer keys.

## Verification

- Focused Release suite: `Passed: 27, Failed: 0, Skipped: 0`.
- Full Release suite: `Counters total="5545" executed="5544" passed="5544" failed="0"`; the sole unexecuted case is the existing documented skip.
- `git diff --check origin/main...HEAD` passed.

## Durable fixture evidence

### Extractor, parent vs. head

Parent implementation result on the verbatim dialog:

```json
{
  "Extracted": true,
  "Command": "Environment: local\nrm -rf /tmp/g781-evidence.GuzWkP /tmp/g781-default-evidence.iA5IUD\nYes, proceed (y)\nYes, and don\u0027t ask again for commands that\nstart with \u0060rm -rf \u2026\u0060\nNo, and tell Codex what to do differently\nPress enter to confirm or esc to cancel",
  "Parsed": false,
  "ParseError": "Backticks and subshell syntax are not accepted by the shell AST verifier."
}
```

Head (`dd2d61a0`) result on the same dialog:

```json
{
  "Extracted": true,
  "Command": "rm -rf /tmp/g781-evidence.GuzWkP /tmp/g781-default-evidence.iA5IUD",
  "Parsed": true,
  "ParseError": null
}
```

Head hidden-tail fixture (`$` after the first choice):

```json
{ "Extracted": false, "Command": null, "Parsed": null, "ParseError": null }
```

Head command-contained-backtick fixture:

```json
{
  "Extracted": true,
  "Command": "rm -rf \u0060unparseable\u0060",
  "Parsed": false,
  "ParseError": "Backticks and subshell syntax are not accepted by the shell AST verifier."
}
```

### Install and adjudication fixtures

- Installed artifact `ProgramArguments` contains the exact sequences `--pre-approve codex:github-comment-post`, `--pre-escalate codex:launch-hook-trust`, and `--shell-policy` with policy id `g786-project-test`; the artifact-launched first cycle records those accept, escalate, and scoped policy values. Reconcile dry-run lists that artifact in `artifacts_before`.
- The no-policy installation fixture contains none of `--pre-approve`, `--pre-escalate`, or `--shell-policy`.
- Covered-ledger adjudication dry run returns `Decision=accept`, `MatchedScopes=[owned-scratch-delete]`, `AnswerKeys=[y, enter]`, `Audited=false`, `Executed=false`; the fixture transport records no `agent send-keys` call.
- The one-path-missing ledger dry run returns `Decision=escalate`, includes `shell-segment-out-of-scope`, and names `/tmp/g781-default-evidence.iA5IUD`; it likewise records no `agent send-keys` call.

### Parent absence proof for every new regression file

```text
fatal: path 'tests/IntentSystem.Cli.Tests/ShellCommandPromptRecognizerG786Tests.cs' exists on disk, but not in 'origin/main'
fatal: path 'tests/IntentSystem.Cli.Tests/NotifySuperviseInstallG786Tests.cs' exists on disk, but not in 'origin/main'
fatal: path 'tests/IntentSystem.Cli.Tests/PromptAdjudicationG786Tests.cs' exists on disk, but not in 'origin/main'
```

Closes #1712