### PR TITLE
docs: prepare v0.30.0 release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2812,7 +2812,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0291)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0301)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -3018,7 +3018,44 @@ rotated by this command; the result and `shrink-audit.jsonl` say so explicitly.
 out of scope. Use `--dry-run` to inspect the measured plan without writing the
 manifest, JSONL files, or audit.
 
-### Next release readiness (v0.29.1)
+### Next release readiness (v0.30.1)
+
+**RELEASE PREPARED / NOT PUBLISHED.**
+
+G787 measured the v0.30.0 preparation from the exact named product base
+`d9dc053dd81f53c3a8be420ee7c6798b808f4521`. With the rolled policy, its
+normal clean Release build reports `intent-cli 0.30.1-d9dc053-G772`; it is the
+new `nextVersion` placeholder identity, not v0.30.0. The same base built with
+explicit `-p:Version=0.30.0` reports `intent-cli 0.30.0-d9dc053-G772`.
+Published v0.30.0 derives `VERSION` from the release tag's `RAW` value in
+`release.yml`; `eng/version.json` governs local builds and dry runs only.
+
+The prepared files are `release-notes-v0.30.0.md` and the
+`release-notes-v0.30.1.md` DRAFT stub. The current policy is:
+
+```json
+{
+  "stableVersion": "0.30.0",
+  "nextVersion": "0.30.1"
+}
+```
+
+`0.30.1` is a replaceable development placeholder, not the next real release
+number. No tag, GitHub Release, package publish, workflow change, or product
+source change belongs to this prepare-only slice.
+
+The active package-policy evidence is `stableVersion 0.30.0`, `nextVersion 0.30.1`,
+and local candidate `JTechJapan.IntentSystem.Cli.0.30.1.nupkg`.
+The host-only release-prep claim boundary is `release-prep:<owner/repo>:0.30.1`;
+this child release-prep uses supplied authority and does not inspect or mutate host state.
+The eight-unit inventory is G779–G786; its EN/JA tuple and consumer-follow-up
+parity is guarded by `ReleaseNotesV0300DocsTests`, along with the measured
+identity, truthfulness, and placeholder checks.
+G780 changes a declared same-repository host's canonical claim location to
+`metadata_write_branch`. The arc's `--verify`, `--accept-evidence-gap`, and
+`--shell-policy` additions are option-level surfaces, not extra command routes.
+
+### Previous v0.29.0 release-prep evidence (retained in history only)
 
 **RELEASE PREPARED / NOT PUBLISHED.**
 

--- a/docs/en/release-notes-v0.30.0.md
+++ b/docs/en/release-notes-v0.30.0.md
@@ -1,7 +1,26 @@
 # Release Notes — intent-cli v0.30.0
 
-> **DRAFT / UNRELEASED.** This is the v0.30.0 contract entry for G780. It does
-> not create a tag, GitHub Release, package publish, or workflow change.
+> **PREPARED / NOT PUBLISHED.** This is the prepare-only release-note set for
+> the measured G779–G786 arc. It does not create a tag or GitHub Release,
+> publish packages, change a workflow trigger or publish configuration, post a
+> consumer comment, or change product source.
+
+No GitHub Release exists yet for v0.30.0; these notes are preparation evidence
+only. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.30.0`.
+
+The policy after this preparation is:
+
+```json
+{
+  "stableVersion": "0.30.0",
+  "nextVersion": "0.30.1"
+}
+```
+
+`0.30.1` is a replaceable development placeholder, not a decision about the
+next real release number. The EN and JA v0.30.1 files are planning scaffolds,
+not changelogs.
 
 ## Same-repo claim targets (G780)
 
@@ -24,11 +43,167 @@ This lets an unprotected `intent-metadata` branch accept claims while a
 protected `main` still reports an honest `push-rejected` result when the
 same-repo declaration is absent.
 
-## Minor-version justification
+## Independently measured minor justification
 
-This is a minor contract change because an already documented, existing
-`[project]` topology declaration now changes the externally observable claim
-target and enables same-repository hosts that could not acquire a claim on a
-protected product branch. It adds no new configuration key and preserves the
-default-topology behavior, but it changes the canonical claim location for a
-declared host; that is broader than a patch-level correction.
+The named product base revision is
+`d9dc053dd81f53c3a8be420ee7c6798b808f4521`. G780 is the deciding minor
+contract change: on a declared same-repository host, the canonical claim
+location moves to `metadata_write_branch`. That externally observable location
+change enables a host whose product branch is protected; it is broader than a
+patch correction while preserving undeclared-host default behavior.
+
+The v0.28.0 release rule remains the auditable distinction: **a command-route
+addition is a minor bump; option-level additions do not count as command
+routes.** This arc's `--verify`, `--accept-evidence-gap`, and `--shell-policy`
+options, plus G784 `update-field` values, are explicitly not counted as new
+command routes. The minor decision is G780's claim-location contract change,
+not those option-level additions.
+
+The tagged v0.29.0 tool was measured before treating G781 as a release fact:
+
+```text
+$ intent-cli --version
+intent-cli 0.29.0-8d019f8-G772
+$ intent-cli notify supervise install
+invalid-supervision-install: --domain, --team, and --owner-role are required safe identity values.
+Usage: intent-cli notify supervise install --domain <d> --team <t> --repo <owner/repo> --owner-role <role> --bound <seconds> --interval <seconds> [--startup-bound <seconds>; default 30] [--persistence persistent] [--event-mode] [--platform macos|windows|linux] [--output <path>] [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
+```
+
+That actual tagged usage has no `--verify`. The named-base head build exposes
+the new re-proof path:
+
+```text
+Usage: intent-cli notify supervise install --domain <d> --team <t> --repo <owner/repo> --owner-role <role> --bound <seconds> --interval <seconds> [--startup-bound <seconds>; default 120 for --write, 1 for --verify] [--persistence persistent] [--event-mode] [--pre-approve <agent-kind>:<prompt-class>]... [--pre-escalate <agent-kind>:<prompt-class>]... [--shell-policy <json>]... [--platform macos|windows|linux] [--output <path>] [--routing-root <host-root>] [--verify|--dry-run|--write] [--format markdown|json]
+```
+
+## Measured version identities
+
+The product base stayed at `d9dc053dd81f53c3a8be420ee7c6798b808f4521` while
+the prepare-only policy was rolled. After `dotnet clean`, the normal clean
+Release build was re-measured with the rolled policy:
+
+```text
+$ dotnet build IntentSystem.sln --configuration Release
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.30.1-d9dc053-G772
+```
+
+That normal identity is the `nextVersion` placeholder and is **not** v0.30.0.
+The same named product base measures v0.30.0 only when explicitly overridden:
+
+```text
+$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.30.0
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.30.0-d9dc053-G772
+```
+
+Published versioning is separately derived by `release.yml`, not by
+`eng/version.json`: on a release event it assigns `RAW` from the release tag
+and `VERSION="${RAW#v}"`. The measured tag transformation is:
+
+```text
+$ RAW=v0.30.0; VERSION="${RAW#v}"; printf 'RAW=%s\nVERSION=%s\n' "$RAW" "$VERSION"
+RAW=v0.30.0
+VERSION=0.30.0
+```
+
+Thus a published v0.30.0 derives from the `v0.30.0` tag; `eng/version.json`
+governs local builds and dry runs only. This preparation created no tag.
+
+## Release inventory: exactly eight units
+
+The exact first-parent range is
+`v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521`. Git measured eight
+commits, and every one is listed with one operator-observable outcome.
+
+- G779 — PR #1705 / issue #1699; merge commit `1057923311a0819d994c5180c1a58adff1e2fd8c`.
+  **Operator-observable outcome:** a rejected claim push reports its real
+  rejected-push cause instead of misreporting an unrelated remote advance.
+- G780 — PR #1713 / issue #1703; merge commit `a16af04342d4dbe05c73a36699fc9b570c9eba69`.
+  **Operator-observable outcome:** declared same-repository claims consistently
+  use `metadata_write_branch`, including explicit stranded migration.
+- G781 — PR #1711 / issue #1704; merge commit `d4bcdfcf3db347b887986ebd9beec75c57a8708c`.
+  **Operator-observable outcome:** `notify supervise install --verify` can
+  re-prove a completed first cycle without claiming a supervisor started when it did not.
+- G782 — PR #1714 / issue #1706; merge commit `c09caab877ebaf3a5fc2c1fe6e42a4cfb6709c58`.
+  **Operator-observable outcome:** bug-to-intent repair links accept their
+  documented flags and expose the repair issue to implementation readers.
+- G783 — PR #1715 / issue #1707; merge commit `14888e49288c1c4e826717e485fd6243ff16fcf6`.
+  **Operator-observable outcome:** issue-publish summaries say what write mode
+  did rather than what it would do.
+- G784 — PR #1716 / issue #1708; merge commit `e26faca0c5ee4e58f71257d08f0601c2934409f6`.
+  **Operator-observable outcome:** the sanctioned external-role frontend and
+  wake-command fields can be updated with CAS, confirmation, and dry-run behavior.
+- G785 — PR #1717 / issue #1709; merge commit `140bfc65a744ac7dbf14886a315b40f865d8001e`.
+  **Operator-observable outcome:** worker completion refuses a missing
+  required pasted-evidence fence unless a reasoned gap override is recorded.
+- G786 — PR #1718 / issue #1712; merge commit `d9dc053dd81f53c3a8be420ee7c6798b808f4521`.
+  **Operator-observable outcome:** the shell approval recognizer passes only
+  the command to AST verification and supervise install carries shell policy.
+
+## First-parent accounting
+
+```text
+$ git rev-list --first-parent --reverse v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521
+1057923311a0819d994c5180c1a58adff1e2fd8c
+a16af04342d4dbe05c73a36699fc9b570c9eba69
+d4bcdfcf3db347b887986ebd9beec75c57a8708c
+c09caab877ebaf3a5fc2c1fe6e42a4cfb6709c58
+14888e49288c1c4e826717e485fd6243ff16fcf6
+e26faca0c5ee4e58f71257d08f0601c2934409f6
+140bfc65a744ac7dbf14886a315b40f865d8001e
+d9dc053dd81f53c3a8be420ee7c6798b808f4521
+$ git rev-list --first-parent --count v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521
+8
+```
+
+| first-parent commit | classification | release inventory |
+| --- | --- | --- |
+| `1057923311a0819d994c5180c1a58adff1e2fd8c` | G779 / PR #1705 / issue #1699 | included |
+| `a16af04342d4dbe05c73a36699fc9b570c9eba69` | G780 / PR #1713 / issue #1703 | included |
+| `d4bcdfcf3db347b887986ebd9beec75c57a8708c` | G781 / PR #1711 / issue #1704 | included |
+| `c09caab877ebaf3a5fc2c1fe6e42a4cfb6709c58` | G782 / PR #1714 / issue #1706 | included |
+| `14888e49288c1c4e826717e485fd6243ff16fcf6` | G783 / PR #1715 / issue #1707 | included |
+| `e26faca0c5ee4e58f71257d08f0601c2934409f6` | G784 / PR #1716 / issue #1708 | included |
+| `140bfc65a744ac7dbf14886a315b40f865d8001e` | G785 / PR #1717 / issue #1709 | included |
+| `d9dc053dd81f53c3a8be420ee7c6798b808f4521` | G786 / PR #1718 / issue #1712 | included |
+
+## Consumer follow-ups after publication
+
+These remain open until a GitHub Release exists; this preparation posts no
+consumer comments. The table is deliberately tied to units in the inventory.
+
+| consumer issue | linked arc unit | post-publish follow-up |
+| --- | --- | --- |
+| #1697 | G779 | cite v0.30.0 |
+| #1658 | G780 | cite v0.30.0 |
+| #1700 | G784 | cite v0.30.0 |
+| #1701 | G781 | cite v0.30.0 |
+
+## Truthfulness boundaries
+
+- Undeclared hosts retain byte-identical claim behavior. A declared host moves
+  default-branch records only through explicit `claim stranded migrate`, never
+  automatically.
+- `install --verify` re-proves without rewriting the artifact; intent-cli never
+  loads, manages, or queries the scheduler job. On 2026-09-02, the real
+  `intent-cli-dev` supervisor returned `first-cycle-verified` in one attempt
+  without an artifact rewrite. That is evidence of this path, not a fleet claim.
+- G786 changed only what reaches the AST verifier. The AST verifier's rules are
+  unchanged; ShellCommandPolicy, G689 ledger identity, and G690 CAS are unchanged.
+- `--accept-evidence-gap` records its reason. Issues whose packets contain no
+  pasted-output phrases are unaffected.
+
+## Prepare-only verification
+
+The PR records parent absence, the intentional EN/JA mutation failure,
+focused release-note guards, the full Release suite, build identities,
+`git diff --check`, and CI. The diff is limited to release notes, version
+policy, placeholders, and tests; it includes no tag, GitHub Release, publish,
+workflow, consumer-comment, or product-source change.

--- a/docs/en/release-notes-v0.30.1.md
+++ b/docs/en/release-notes-v0.30.1.md
@@ -1,0 +1,9 @@
+# Release Notes — intent-cli v0.30.1
+
+> **DRAFT / UNRELEASED.** This is a replaceable planning scaffold, not a changelog.
+> The next release-prep packet will replace this placeholder after measuring
+> and deciding the next real release number. Do not treat this file as a changelog.
+
+This placeholder intentionally contains no release entries. No tag, GitHub
+Release, or package publish exists for v0.30.1. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.30.1`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3051,7 +3051,43 @@ result は literal bytes の削減、追加した reference bytes、record の n
 `shrink-audit.jsonl` に明記します。`.intent-cli/runs/*.provider.jsonl` は別の provider-run state なので
 scope 外です。`--dry-run` なら manifest、JSONL、audit を書き込まずに測定済み plan だけを確認できます。
 
-### 次リリース準備(v0.29.1)
+### 次リリース準備(v0.30.1)
+
+**RELEASE PREPARED / NOT PUBLISHED。**
+
+G787 は exact named product base
+`d9dc053dd81f53c3a8be420ee7c6798b808f4521` から v0.30.0 preparation を測定しました。
+rolled policy で normal clean Release build は `intent-cli 0.30.1-d9dc053-G772` を返し、
+これは新しい `nextVersion` placeholder identity であって v0.30.0 ではありません。同じ base を
+explicit `-p:Version=0.30.0` で build すると `intent-cli 0.30.0-d9dc053-G772` を返します。
+published v0.30.0 は `release.yml` の release tag `RAW` から `VERSION` を導出し、
+`eng/version.json` は local builds と dry runs だけを管理します。
+
+prepared files は `release-notes-v0.30.0.md` と
+`release-notes-v0.30.1.md` の DRAFT stub です。current policy は次のとおりです:
+
+```json
+{
+  "stableVersion": "0.30.0",
+  "nextVersion": "0.30.1"
+}
+```
+
+`0.30.1` は replaceable development placeholder であり、次の real release number
+ではありません。tag、GitHub Release、package publish、workflow change、product source
+change はこの prepare-only slice に含みません。
+
+active package-policy evidence は `stableVersion 0.30.0`、`nextVersion 0.30.1`、local
+candidate `JTechJapan.IntentSystem.Cli.0.30.1.nupkg` です。host-only release-prep claim boundary は
+`release-prep:<owner/repo>:0.30.1` で、この child release-prep は提供済みの権限を使い、
+host state を inspect/mutate しません。eight-unit inventory は G779–G786
+で、EN/JA tuple と consumer-follow-up parity、measured identity、truthfulness、placeholder
+check は `ReleaseNotesV0300DocsTests` が guard します。
+G780 は declared same-repository host の canonical claim location を
+`metadata_write_branch` に変更します。この arc の `--verify`、`--accept-evidence-gap`、
+`--shell-policy` は option-level surface であり、extra command route ではありません。
+
+### previous v0.29.0 release-prep evidence (history のみ)
 
 **RELEASE PREPARED / NOT PUBLISHED。**
 

--- a/docs/ja/release-notes-v0.30.0.md
+++ b/docs/ja/release-notes-v0.30.0.md
@@ -1,7 +1,25 @@
 # リリースノート — intent-cli v0.30.0
 
-> **DRAFT / 未リリース。** これは G780 の v0.30.0 contract entry です。tag、GitHub
-> Release、package publish、workflow change は作成しません。
+> **PREPARED / NOT PUBLISHED。** これは測定済み G779–G786 arc の prepare-only
+> release-note set です。tag / GitHub Release / package publish、workflow trigger
+> または publish configuration、consumer comment、product source の変更は行いません。
+
+v0.30.0 の GitHub Release はまだ存在せず、この notes は preparation evidence
+だけです。matching install query は
+`JTechJapan.IntentSystem.Cli --version 0.30.0` です。
+
+この preparation 後の policy は次のとおりです:
+
+```json
+{
+  "stableVersion": "0.30.0",
+  "nextVersion": "0.30.1"
+}
+```
+
+`0.30.1` は replaceable development placeholder であり、次の real release number
+の決定ではありません。EN/JA の v0.30.1 file は planning scaffold であり、changelog
+ではありません。
 
 ## same-repo の claim target (G780)
 
@@ -21,10 +39,165 @@ G779 の rejected-push classification と fields はどちらの target でも�
 unprotected な `intent-metadata` branch は claim を受け入れ、same-repo declaration がない場合の
 protected `main` は正直な `push-rejected` result を返します。
 
-## minor-version justification
+## 独自に測定した minor justification
 
-これは minor contract change です。既に文書化されている `[project]` topology declaration が
-externally observable な claim target を変え、protected product branch で claim を acquire
-できなかった same-repository host を有効にするからです。新しい configuration key は追加せず、
-default-topology behavior は維持しますが、declared host の canonical claim location を変えるため、
-patch-level correction より広い変更です。
+named product base revision は
+`d9dc053dd81f53c3a8be420ee7c6798b808f4521` です。G780 が minor を決める contract
+change です。declared same-repository host では canonical claim location が
+`metadata_write_branch` に移り、protected product branch の host を有効にします。
+undeclared host の default behavior を維持しつつ externally observable な location
+を変えるため、patch correction より広い変更です。
+
+v0.28.0 release rule の auditable distinction はそのままです: **a command-route
+addition is a minor bump; option-level additions do not count as command
+routes.** この arc の `--verify`、`--accept-evidence-gap`、`--shell-policy` option と
+G784 の `update-field` value は new command route として明示的に数えません。minor
+decision は option-level addition ではなく G780 の claim-location contract change です。
+
+G781 を release fact とする前に tagged v0.29.0 tool を測定しました:
+
+```text
+$ intent-cli --version
+intent-cli 0.29.0-8d019f8-G772
+$ intent-cli notify supervise install
+invalid-supervision-install: --domain, --team, and --owner-role are required safe identity values.
+Usage: intent-cli notify supervise install --domain <d> --team <t> --repo <owner/repo> --owner-role <role> --bound <seconds> --interval <seconds> [--startup-bound <seconds>; default 30] [--persistence persistent] [--event-mode] [--platform macos|windows|linux] [--output <path>] [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
+```
+
+この actual tagged usage には `--verify` がありません。named-base head build は新しい
+re-proof path を表示します:
+
+```text
+Usage: intent-cli notify supervise install --domain <d> --team <t> --repo <owner/repo> --owner-role <role> --bound <seconds> --interval <seconds> [--startup-bound <seconds>; default 120 for --write, 1 for --verify] [--persistence persistent] [--event-mode] [--pre-approve <agent-kind>:<prompt-class>]... [--pre-escalate <agent-kind>:<prompt-class>]... [--shell-policy <json>]... [--platform macos|windows|linux] [--output <path>] [--routing-root <host-root>] [--verify|--dry-run|--write] [--format markdown|json]
+```
+
+## 測定した version identities
+
+product base は `d9dc053dd81f53c3a8be420ee7c6798b808f4521` のまま、prepare-only
+policy を roll しました。`dotnet clean` 後、rolled policy による normal clean Release
+build を再測定しました:
+
+```text
+$ dotnet build IntentSystem.sln --configuration Release
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.30.1-d9dc053-G772
+```
+
+この normal identity は `nextVersion` placeholder であり、**v0.30.0 ではありません**。
+同じ named product base が v0.30.0 を測定するのは explicit override の場合だけです:
+
+```text
+$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.30.0
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.30.0-d9dc053-G772
+```
+
+published versioning は `eng/version.json` ではなく `release.yml` が別に導出します。
+release event では release tag から `RAW` を取り、`VERSION="${RAW#v}"` を設定します。
+measured tag transformation は次のとおりです:
+
+```text
+$ RAW=v0.30.0; VERSION="${RAW#v}"; printf 'RAW=%s\nVERSION=%s\n' "$RAW" "$VERSION"
+RAW=v0.30.0
+VERSION=0.30.0
+```
+
+したがって published v0.30.0 は `v0.30.0` tag から導出され、`eng/version.json` は
+local builds と dry runs だけを扱います。この preparation は tag を作成していません。
+
+## Release inventory: 正確に八 units
+
+exact first-parent range は
+`v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521` です。git は八 commit を測定し、
+すべてを operator-observable outcome とともに記録します。
+
+- G779 — PR #1705 / issue #1699; merge commit `1057923311a0819d994c5180c1a58adff1e2fd8c`。
+  **Operator-observable outcome:** rejected claim push は unrelated remote advance ではなく
+  real rejected-push cause を報告します。
+- G780 — PR #1713 / issue #1703; merge commit `a16af04342d4dbe05c73a36699fc9b570c9eba69`。
+  **Operator-observable outcome:** declared same-repository claim は explicit stranded
+  migration を含めて一貫して `metadata_write_branch` を使います。
+- G781 — PR #1711 / issue #1704; merge commit `d4bcdfcf3db347b887986ebd9beec75c57a8708c`。
+  **Operator-observable outcome:** `notify supervise install --verify` は、存在しない
+  supervisor start を claim せず completed first cycle を re-prove できます。
+- G782 — PR #1714 / issue #1706; merge commit `c09caab877ebaf3a5fc2c1fe6e42a4cfb6709c58`。
+  **Operator-observable outcome:** bug-to-intent repair link は documented flag を受け入れ、
+  implementation reader に repair issue を表示します。
+- G783 — PR #1715 / issue #1707; merge commit `14888e49288c1c4e826717e485fd6243ff16fcf6`。
+  **Operator-observable outcome:** issue-publish summary は write mode が行ったことを
+  would-do ではなく報告します。
+- G784 — PR #1716 / issue #1708; merge commit `e26faca0c5ee4e58f71257d08f0601c2934409f6`。
+  **Operator-observable outcome:** sanctioned external-role frontend と wake-command field は
+  CAS / confirmation / dry-run behavior 付きで update できます。
+- G785 — PR #1717 / issue #1709; merge commit `140bfc65a744ac7dbf14886a315b40f865d8001e`。
+  **Operator-observable outcome:** required pasted-evidence fence がない worker completion は
+  reasoned gap override を記録しない限り拒否されます。
+- G786 — PR #1718 / issue #1712; merge commit `d9dc053dd81f53c3a8be420ee7c6798b808f4521`。
+  **Operator-observable outcome:** shell approval recognizer は command だけを AST verifier
+  へ渡し、supervise install は shell policy を carry します。
+
+## First-parent accounting
+
+```text
+$ git rev-list --first-parent --reverse v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521
+1057923311a0819d994c5180c1a58adff1e2fd8c
+a16af04342d4dbe05c73a36699fc9b570c9eba69
+d4bcdfcf3db347b887986ebd9beec75c57a8708c
+c09caab877ebaf3a5fc2c1fe6e42a4cfb6709c58
+14888e49288c1c4e826717e485fd6243ff16fcf6
+e26faca0c5ee4e58f71257d08f0601c2934409f6
+140bfc65a744ac7dbf14886a315b40f865d8001e
+d9dc053dd81f53c3a8be420ee7c6798b808f4521
+$ git rev-list --first-parent --count v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521
+8
+```
+
+| first-parent commit | classification | release inventory |
+| --- | --- | --- |
+| `1057923311a0819d994c5180c1a58adff1e2fd8c` | G779 / PR #1705 / issue #1699 | included |
+| `a16af04342d4dbe05c73a36699fc9b570c9eba69` | G780 / PR #1713 / issue #1703 | included |
+| `d4bcdfcf3db347b887986ebd9beec75c57a8708c` | G781 / PR #1711 / issue #1704 | included |
+| `c09caab877ebaf3a5fc2c1fe6e42a4cfb6709c58` | G782 / PR #1714 / issue #1706 | included |
+| `14888e49288c1c4e826717e485fd6243ff16fcf6` | G783 / PR #1715 / issue #1707 | included |
+| `e26faca0c5ee4e58f71257d08f0601c2934409f6` | G784 / PR #1716 / issue #1708 | included |
+| `140bfc65a744ac7dbf14886a315b40f865d8001e` | G785 / PR #1717 / issue #1709 | included |
+| `d9dc053dd81f53c3a8be420ee7c6798b808f4521` | G786 / PR #1718 / issue #1712 | included |
+
+## Publish 後の consumer follow-ups
+
+GitHub Release が存在するまでこれらは open のままで、この preparation は consumer
+comment を投稿しません。table は inventory 内の unit に意図的に結び付けています。
+
+| consumer issue | linked arc unit | post-publish follow-up |
+| --- | --- | --- |
+| #1697 | G779 | cite v0.30.0 |
+| #1658 | G780 | cite v0.30.0 |
+| #1700 | G784 | cite v0.30.0 |
+| #1701 | G781 | cite v0.30.0 |
+
+## Truthfulness boundaries
+
+- undeclared host は byte-identical claim behavior を維持します。declared host が
+  default-branch record を移すのは explicit `claim stranded migrate` のみで、automatic
+  には行いません。
+- `install --verify` は artifact を rewrite せず re-prove します。intent-cli は scheduler
+  job を never loads, manages, or queries します。2026-09-02 に real `intent-cli-dev`
+  supervisor は一 attempt で artifact rewrite なしに `first-cycle-verified` を返しました。
+  これは path の evidence であり、fleet claim ではありません。
+- G786 は AST verifier に届くものだけを変更しました。AST verifier の rules は unchanged
+  であり、ShellCommandPolicy、G689 ledger identity、G690 CAS も unchanged です。
+- `--accept-evidence-gap` は reason を記録します。packet に pasted-output phrase がない
+  issue は unaffected です。
+
+## Prepare-only verification
+
+PR には parent absence、意図的な EN/JA mutation failure、focused release-note guard、
+full Release suite、build identities、`git diff --check`、CI の evidence を記録します。
+diff は release notes、version policy、placeholder、test に限定され、tag / GitHub Release /
+publish / workflow / consumer-comment / product-source change を含みません。

--- a/docs/ja/release-notes-v0.30.1.md
+++ b/docs/ja/release-notes-v0.30.1.md
@@ -1,0 +1,9 @@
+# リリースノート — intent-cli v0.30.1
+
+> **DRAFT / 未リリース。** これは replaceable planning scaffold であり、changelog ではありません。
+> 後続の release-prep packet が次の real release number を測定して決めた後、この
+> placeholder を replace します。この file を changelog として扱ってはいけません。
+
+この placeholder には release entry を記録しません。v0.30.1 の tag、GitHub
+Release、package publish はまだ存在しません。matching install query は
+`JTechJapan.IntentSystem.Cli --version 0.30.1` です。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.29.0",
-  "nextVersion": "0.29.1"
+  "stableVersion": "0.30.0",
+  "nextVersion": "0.30.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -287,8 +287,10 @@ public sealed class ReleaseNotesV0220DocsTests
         Assert.Contains($"release-notes-v{policy.NextVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains("RELEASE PREPARED / NOT PUBLISHED", section, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("placeholder", compact, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("repair-unreadable", section, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("--wake-command", section, StringComparison.Ordinal);
+        Assert.Contains("metadata_write_branch", section, StringComparison.Ordinal);
+        Assert.Contains("--verify", section, StringComparison.Ordinal);
+        Assert.Contains("--accept-evidence-gap", section, StringComparison.Ordinal);
+        Assert.Contains("--shell-policy", section, StringComparison.Ordinal);
         Assert.Contains("option-level", section, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("GitHub Release", section, StringComparison.Ordinal);
 

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
@@ -169,8 +169,8 @@ public sealed class ReleaseNotesV0240DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.29.0", policy.StableVersion);
-        Assert.Equal("0.29.1", policy.NextVersion);
+        Assert.Equal("0.30.0", policy.StableVersion);
+        Assert.Equal("0.30.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -198,7 +198,7 @@ public sealed class ReleaseNotesV0240DocsTests
             Assert.DoesNotContain("release-notes-v0.27.0.md", reference, StringComparison.Ordinal);
             Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
             Assert.Contains(
-                language == "en" ? "Next release readiness (v0.29.1)" : "次リリース準備(v0.29.1)",
+                language == "en" ? "Next release readiness (v0.30.1)" : "次リリース準備(v0.30.1)",
                 reference,
                 StringComparison.Ordinal);
             Assert.Contains("intent-cli 0.29.0-65e02d8-G772", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
@@ -165,8 +165,8 @@ public sealed class ReleaseNotesV0250DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
 
-        Assert.Equal("0.29.0", policy.StableVersion);
-        Assert.Equal("0.29.1", policy.NextVersion);
+        Assert.Equal("0.30.0", policy.StableVersion);
+        Assert.Equal("0.30.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -193,7 +193,7 @@ public sealed class ReleaseNotesV0250DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.29.1)" : "次リリース準備(v0.29.1)",
+            language == "en" ? "Next release readiness (v0.30.1)" : "次リリース準備(v0.30.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(CurrentStableInstallDisplayIdentity, reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
@@ -214,12 +214,12 @@ public sealed class ReleaseNotesV0260DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policyPath = Path.Combine(root, "eng", "version.json");
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.29.0", policy.StableVersion);
-        Assert.Equal("0.29.1", policy.NextVersion);
+        Assert.Equal("0.30.0", policy.StableVersion);
+        Assert.Equal("0.30.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
@@ -155,12 +155,12 @@ public sealed class ReleaseNotesV0270DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.29.0", policy.StableVersion);
-        Assert.Equal("0.29.1", policy.NextVersion);
+        Assert.Equal("0.30.0", policy.StableVersion);
+        Assert.Equal("0.30.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
@@ -18,12 +18,12 @@ public sealed class ReleaseNotesV0271DocsTests
         var policyPath = Path.Combine(root, "eng", "version.json");
 
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.29.0", policy.StableVersion);
-        Assert.Equal("0.29.1", policy.NextVersion);
+        Assert.Equal("0.30.0", policy.StableVersion);
+        Assert.Equal("0.30.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
@@ -156,12 +156,12 @@ public sealed class ReleaseNotesV0280DocsTests
         var policyPath = Path.Combine(root, "eng", "version.json");
 
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.29.0", policy.StableVersion);
-        Assert.Equal("0.29.1", policy.NextVersion);
+        Assert.Equal("0.30.0", policy.StableVersion);
+        Assert.Equal("0.30.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
@@ -124,12 +124,12 @@ public sealed class ReleaseNotesV0290DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.29.0\",\n  \"nextVersion\": \"0.29.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.29.0", policy.StableVersion);
-        Assert.Equal("0.29.1", policy.NextVersion);
+        Assert.Equal("0.30.0", policy.StableVersion);
+        Assert.Equal("0.30.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -151,7 +151,7 @@ public sealed class ReleaseNotesV0290DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "### Next release readiness (v0.29.1)" : "### 次リリース準備(v0.29.1)",
+            language == "en" ? "### Next release readiness (v0.30.1)" : "### 次リリース準備(v0.30.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(NormalBaseIdentity, reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
@@ -1,0 +1,227 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G787: v0.30.0 is a measured, prepare-only release line. These guards pin
+/// the eight-unit inventory, independently measured identities, bilingual
+/// consumer follow-ups, truthfulness limits, and the post-preparation policy.
+/// </summary>
+public sealed class ReleaseNotesV0300DocsTests
+{
+    private const string Base = "d9dc053dd81f53c3a8be420ee7c6798b808f4521";
+    private const string NormalPlaceholderIdentity = "intent-cli 0.30.1-d9dc053-G772";
+    private const string ExplicitReleaseIdentity = "intent-cli 0.30.0-d9dc053-G772";
+    private const string TaggedIdentity = "intent-cli 0.29.0-8d019f8-G772";
+
+    private static readonly (string Unit, string Pr, string Issue, string Merge)[] Units =
+    [
+        ("G779", "#1705", "#1699", "1057923311a0819d994c5180c1a58adff1e2fd8c"),
+        ("G780", "#1713", "#1703", "a16af04342d4dbe05c73a36699fc9b570c9eba69"),
+        ("G781", "#1711", "#1704", "d4bcdfcf3db347b887986ebd9beec75c57a8708c"),
+        ("G782", "#1714", "#1706", "c09caab877ebaf3a5fc2c1fe6e42a4cfb6709c58"),
+        ("G783", "#1715", "#1707", "14888e49288c1c4e826717e485fd6243ff16fcf6"),
+        ("G784", "#1716", "#1708", "e26faca0c5ee4e58f71257d08f0601c2934409f6"),
+        ("G785", "#1717", "#1709", "140bfc65a744ac7dbf14886a315b40f865d8001e"),
+        ("G786", "#1718", "#1712", "d9dc053dd81f53c3a8be420ee7c6798b808f4521"),
+    ];
+
+    private static readonly (string Issue, string Unit, string FollowUp)[] ConsumerFollowUps =
+    [
+        ("#1697", "G779", "cite v0.30.0"),
+        ("#1658", "G780", "cite v0.30.0"),
+        ("#1700", "G784", "cite v0.30.0"),
+        ("#1701", "G781", "cite v0.30.0"),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyTheEightGitDerivedUnits(string language)
+    {
+        var notes = ReadNotes(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(8, listed.Length);
+
+        foreach (var unit in Units)
+        {
+            var entry = FindEntry(notes, unit.Unit);
+            Assert.NotEmpty(entry);
+            Assert.Contains($"PR {unit.Pr} / issue {unit.Issue};", entry, StringComparison.Ordinal);
+            Assert.Contains($"merge commit `{unit.Merge}`", entry, StringComparison.Ordinal);
+            Assert.Contains("Operator-observable outcome", entry, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUps()
+    {
+        var english = ReadNotes("en");
+        var japanese = ReadNotes("ja");
+
+        Assert.Equal(Units, ParseInventory(english));
+        Assert.Equal(Units, ParseInventory(japanese));
+        Assert.Equal(ParseInventory(english), ParseInventory(japanese));
+        Assert.Equal(ConsumerFollowUps, ParseConsumerFollowUps(english));
+        Assert.Equal(ConsumerFollowUps, ParseConsumerFollowUps(japanese));
+        Assert.Equal(ParseConsumerFollowUps(english), ParseConsumerFollowUps(japanese));
+        Assert.All(
+            ParseConsumerFollowUps(english),
+            followUp => Assert.Contains(Units, unit => unit.Unit == followUp.Unit));
+    }
+
+    [Fact]
+    public void MirrorParityDetectsASingleFieldMutation()
+    {
+        var english = ReadNotes("en");
+        var japanese = ReadNotes("ja");
+
+        var changedIssue = japanese.Replace("issue #1699", "issue #9999", StringComparison.Ordinal);
+        var changedFollowUp = japanese.Replace("| #1697 | G779 | cite v0.30.0 |", "| #1697 | G786 | cite v0.30.0 |", StringComparison.Ordinal);
+
+        Assert.False(ParseInventory(english).SequenceEqual(ParseInventory(changedIssue)));
+        Assert.False(ParseConsumerFollowUps(english).SequenceEqual(ParseConsumerFollowUps(changedFollowUp)));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinThreeMeasuredVersionIdentitiesAndMinorDecision(string language)
+    {
+        var notes = ReadNotes(language);
+        var normalized = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Contains(Base, notes, StringComparison.Ordinal);
+        Assert.Contains("dotnet build IntentSystem.sln --configuration Release", notes, StringComparison.Ordinal);
+        Assert.Contains("-p:Version=0.30.0", notes, StringComparison.Ordinal);
+        Assert.Contains(NormalPlaceholderIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains(ExplicitReleaseIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains("release.yml", notes, StringComparison.Ordinal);
+        Assert.Contains("RAW=v0.30.0", notes, StringComparison.Ordinal);
+        Assert.Contains("VERSION=0.30.0", notes, StringComparison.Ordinal);
+        Assert.Contains("eng/version.json", notes, StringComparison.Ordinal);
+        Assert.Contains("local builds", notes, StringComparison.Ordinal);
+        Assert.Contains("dry runs", notes, StringComparison.Ordinal);
+        Assert.Contains("same_repo_topology = true", notes, StringComparison.Ordinal);
+        Assert.Contains("metadata_write_branch", notes, StringComparison.Ordinal);
+        Assert.Contains("refs/heads/<metadata_write_branch>", notes, StringComparison.Ordinal);
+        Assert.Contains("claim stranded", notes, StringComparison.Ordinal);
+        Assert.Contains("push-rejected", notes, StringComparison.Ordinal);
+        Assert.Contains("command-route", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("option-level", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--verify", notes, StringComparison.Ordinal);
+        Assert.Contains("--accept-evidence-gap", notes, StringComparison.Ordinal);
+        Assert.Contains("--shell-policy", notes, StringComparison.Ordinal);
+        Assert.Contains(TaggedIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains("[--verify|--dry-run|--write]", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "**not** v0.30.0" : "**v0.30.0 ではありません**", normalized, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinEveryFirstParentCommitAndPrepareOnlyBoundary(string language)
+    {
+        var notes = ReadNotes(language);
+        const string Range = "v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521";
+
+        Assert.Contains($"git rev-list --first-parent --reverse {Range}", notes, StringComparison.Ordinal);
+        Assert.Contains($"git rev-list --first-parent --count {Range}", notes, StringComparison.Ordinal);
+        Assert.Contains("\n8\n", notes, StringComparison.Ordinal);
+        Assert.Contains("PREPARED / NOT PUBLISHED", notes, StringComparison.Ordinal);
+        Assert.DoesNotContain("DRAFT /", notes, StringComparison.OrdinalIgnoreCase);
+
+        foreach (var unit in Units)
+        {
+            Assert.Contains(unit.Merge, notes, StringComparison.Ordinal);
+            Assert.Contains($"{unit.Unit} / PR {unit.Pr} / issue {unit.Issue}", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinFourTruthfulnessBoundaries(string language)
+    {
+        var notes = ReadNotes(language);
+        var normalized = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Contains("byte-identical", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("claim stranded migrate", notes, StringComparison.Ordinal);
+        Assert.Contains("automatic", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("install --verify", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "without rewriting" : "artifact を rewrite せず",
+            normalized,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("first-cycle-verified", notes, StringComparison.Ordinal);
+        Assert.Contains("fleet claim", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AST verifier", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "rules are unchanged" : "rules は unchanged",
+            normalized,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ShellCommandPolicy", notes, StringComparison.Ordinal);
+        Assert.Contains("G689 ledger identity", notes, StringComparison.Ordinal);
+        Assert.Contains("G690 CAS", notes, StringComparison.Ordinal);
+        Assert.Contains("--accept-evidence-gap", notes, StringComparison.Ordinal);
+        Assert.Contains("unaffected", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("never loads, manages, or queries", normalized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VersionPolicyRollAndNextVersionPlaceholdersAreExact()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        Assert.Equal(
+            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
+            File.ReadAllText(Path.Combine(root, "eng", "version.json")));
+
+        var policy = RepoVersionPolicySource.Read();
+        Assert.Equal("0.30.0", policy.StableVersion);
+        Assert.Equal("0.30.1", policy.NextVersion);
+
+        foreach (var language in new[] { "en", "ja" })
+        {
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.30.0.md")));
+            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.30.1.md"));
+            Assert.Contains("DRAFT", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(language == "en" ? "not a changelog" : "changelog ではありません", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("- G", stub, StringComparison.Ordinal);
+        }
+    }
+
+    private static string FindEntry(string notes, string unit)
+    {
+        var match = Regex.Match(notes, $@"(?ms)^- {Regex.Escape(unit)} —.*?(?=^- |^## |\z)");
+        return match.Success ? match.Value : string.Empty;
+    }
+
+    private static IReadOnlyList<(string Unit, string Pr, string Issue, string Merge)> ParseInventory(string notes) =>
+        Regex.Matches(
+                notes,
+                @"(?ms)^- (G\d+) — PR (#\d+) / issue (#\d+); merge commit `([0-9a-f]{40})`.*?(?=^- |^## |\z)")
+            .Select(match => (
+                match.Groups[1].Value,
+                match.Groups[2].Value,
+                match.Groups[3].Value,
+                match.Groups[4].Value))
+            .ToArray();
+
+    private static IReadOnlyList<(string Issue, string Unit, string FollowUp)> ParseConsumerFollowUps(string notes) =>
+        Regex.Matches(notes, @"(?m)^\| (#\d+) \| (G\d+) \| (cite v0\.30\.0) \|$")
+            .Select(match => (
+                match.Groups[1].Value,
+                match.Groups[2].Value,
+                match.Groups[3].Value))
+            .ToArray();
+
+    private static string ReadNotes(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.30.0.md"));
+}


### PR DESCRIPTION
# G787 — v0.30.0 prepare-only release artifacts

Closes #1719

Head: `af0675aa48f5b6c8d45edb90ca6c83cdfc6d112e`

This PR is prepare-only. It creates no tag or GitHub Release, publishes no
package, changes no workflow or publish configuration, posts no consumer
comment, and changes no product source.

## Criterion 1 — measured minor decision, eight-unit inventory, first-parent accounting, and consumer follow-ups

The EN/JA v0.30.0 mirrors retain the complete G780 same-repo claim-target
section, record exactly G779–G786 with issue/PR/merge/outcome, and map all four
waiting consumer issues to an inventory unit. G780's declared-host canonical
claim-location change is the deciding minor contract change; `--verify`,
`--accept-evidence-gap`, `--shell-policy`, and G784 field values are explicitly
documented as option-level, not additional command routes.

Criterion 1 collected output:
```text
$ git rev-list --first-parent --reverse v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521
1057923311a0819d994c5180c1a58adff1e2fd8c
a16af04342d4dbe05c73a36699fc9b570c9eba69
d4bcdfcf3db347b887986ebd9beec75c57a8708c
c09caab877ebaf3a5fc2c1fe6e42a4cfb6709c58
14888e49288c1c4e826717e485fd6243ff16fcf6
e26faca0c5ee4e58f71257d08f0601c2934409f6
140bfc65a744ac7dbf14886a315b40f865d8001e
d9dc053dd81f53c3a8be420ee7c6798b808f4521
$ git rev-list --first-parent --count v0.29.0..d9dc053dd81f53c3a8be420ee7c6798b808f4521
8
```

```text
$ intent-cli --version
intent-cli 0.29.0-8d019f8-G772
$ intent-cli notify supervise install
invalid-supervision-install: --domain, --team, and --owner-role are required safe identity values.
Usage: intent-cli notify supervise install --domain <d> --team <t> --repo <owner/repo> --owner-role <role> --bound <seconds> --interval <seconds> [--startup-bound <seconds>; default 30] [--persistence persistent] [--event-mode] [--platform macos|windows|linux] [--output <path>] [--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]
```

The tagged usage above has no `--verify`; the head usage recorded in the EN/JA
notes includes `[--verify|--dry-run|--write]`.

## Criterion 2 — three measured version identities

The named product base is `d9dc053dd81f53c3a8be420ee7c6798b808f4521`. The
policy was rolled in the prepare-only working tree before these measurements;
normal remains the placeholder identity, while 0.30.0 is only explicit.

Criterion 2 collected output:
```text
$ dotnet build IntentSystem.sln --configuration Release
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.30.1-d9dc053-G772

$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.30.0
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.30.0-d9dc053-G772

$ RAW=v0.30.0; VERSION="${RAW#v}"; printf 'RAW=%s\nVERSION=%s\n' "$RAW" "$VERSION"
RAW=v0.30.0
VERSION=0.30.0
```

The notes and `ReleaseNotesV0300DocsTests` pin `release.yml` tag derivation and
the local-only `eng/version.json` rule.

## Criterion 3 — EN/JA tuple and consumer-follow-up parity, with real mutation failures

The same parity guard rejected each single-field mutation below; both changes
were reverted before the final passing runs.

Criterion 3 issue-tuple mutation collected output:
```text
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUps
Failed IntentSystem.Cli.Tests.ReleaseNotesV0300DocsTests.EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUps
Expected: [Tuple ("G779", "#1705", "#1699", "1057923311a0819d994c5180c1a58adff1e2fd8c"), ...]
Actual:   [Tuple ("G779", "#1705", "#9999", "1057923311a0819d994c5180c1a58adff1e2fd8c"), ...]
Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1
```

Criterion 3 consumer-row mutation collected output:
```text
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUps
Failed IntentSystem.Cli.Tests.ReleaseNotesV0300DocsTests.EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUps
Expected: [Tuple ("#1697", "G779", "cite v0.30.0"), ...]
Actual:   [Tuple ("#1697", "G786", "cite v0.30.0"), ...]
Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1
```

## Criterion 4 — four truthfulness boundaries and real-host limitation

Both mirrors state and `ReleaseNotesV0300DocsTests` guards: byte-identical
undeclared-host claims plus explicit-only migration; verify re-proof without an
artifact rewrite or scheduler ownership; AST-input-only recognizer change with
unchanged rules/policy/ledger/CAS; and reasoned evidence-gap acceptance that
leaves no-paste issues unaffected. The notes cite the 2026-09-02
`first-cycle-verified` one-attempt, no-rewrite observation as path evidence,
not a fleet claim.

```text
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~ReleaseNotesV0300DocsTests
Passed!  - Failed:     0, Passed:    11, Skipped:     0, Total:    11
```

## Criterion 5 — policy roll, 0.30.1 placeholders, and no v0.30.0 DRAFT banner

```text
$ cat eng/version.json
{
  "stableVersion": "0.30.0",
  "nextVersion": "0.30.1"
}

$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~ReleaseNotes
Passed!  - Failed:     0, Passed:   283, Skipped:     0, Total:   283
```

The roll also refreshes both policy-derived next-release-readiness sections and
adds EN/JA v0.30.1 DRAFT placeholders.

## Criterion 6 — prepare-only diff scope

```text
$ git diff --check origin/main...HEAD
$ git diff --name-only origin/main...HEAD
docs/en/09-developer-reference.md
docs/en/release-notes-v0.30.0.md
docs/en/release-notes-v0.30.1.md
docs/ja/09-developer-reference.md
docs/ja/release-notes-v0.30.0.md
docs/ja/release-notes-v0.30.1.md
eng/version.json
tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
```

## Criterion 7 — parent absence for every new G787 guard

All new G787 test methods are in the one new class. The parent commit has no
such class:

Criterion 7 parent-absence collected output:
```text
$ git show d9dc053dd81f53c3a8be420ee7c6798b808f4521:tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs' exists on disk, but not in 'd9dc053dd81f53c3a8be420ee7c6798b808f4521'
```

## Criterion 8 — full Release validation

```text
$ dotnet test IntentSystem.sln --configuration Release --no-restore
Passed!  - Failed:     0, Passed:  5586, Skipped:     1, Total:  5587, Duration: 3 m 12 s - IntentSystem.Cli.Tests.dll (net10.0)
```

CI on `af0675aa48f5b6c8d45edb90ca6c83cdfc6d112e` is green: **Build and test
(source contract)** passed in 2m56s and **npm package dry-run (no publish)**
passed in 1m39s.
