### PR TITLE
G788: recognize downstream execution evidence

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -676,7 +676,7 @@ recovery for that finding. A declared bound below the configured interval is a
 structural false-alarm warning, emitted at supervise start and on each cycle,
 not a value the CLI silently corrects.
 
-### Delivered delegation with no observable start (G741)
+### Delivered delegation with no observable start (G741/G788)
 
 `notify supervise` emits `delegation-delivered-never-executed` only when a
 delegation's durable delivery evidence says `delivery_succeeded=true`, the
@@ -694,6 +694,21 @@ not satisfy this finding. The full conjunction also requires the canonical
 report for the task to be absent, every expected artifact source to be absent,
 and the durable target-entity transition source to be absent. A working/started
 seat, visible artifact, report, or target transition is a non-finding.
+
+G788 makes that absence decision source-derived rather than inferred from a
+single missing report. It extracts one shared `execution-unit token` from the
+configured execution-unit regex, then checks `pending-ledger`, `report-outbox`,
+`notification-events`, `queue-state`, `continuation-chain`, and
+`expected-artifact`. The latter two preserve the earlier continuation and
+expected artifact checks; the first four capture downstream delegation,
+child-report delivery, and post-delivery queue progress. Any matching source is
+positive execution evidence and suppresses the finding. When recipient-issued
+downstream activity is visible but carries no target token, supervision records
+the informational `delegation-in-progress-no-direct-report` result without an
+escalation wake. Only a true six-source absence emits the finding, with a
+`Source-derived` count for each named source. Token matching is case-insensitive
+for configured forms such as `G779-start`, `design-delegate-SKS-G909`, and
+lower-case equivalents; tokenless text is not evidence.
 
 The finding names `task_id`, seat, `delivered_at`, the window, and every
 checked source. It wakes the delegation's owner role through the recorded

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -697,7 +697,9 @@ seat, visible artifact, report, or target transition is a non-finding.
 
 G788 makes that absence decision source-derived rather than inferred from a
 single missing report. It extracts one shared `execution-unit token` from the
-configured execution-unit regex, then checks `pending-ledger`, `report-outbox`,
+configured execution-unit regex, taking only the first configured match in
+task-id, then objective, then input order; a later token cannot override that
+first token. It then checks `pending-ledger`, `report-outbox`,
 `notification-events`, `queue-state`, `continuation-chain`, and
 `expected-artifact`. The latter two preserve the earlier continuation and
 expected artifact checks; the first four capture downstream delegation,

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -597,7 +597,7 @@ message を黙らせず、2 つの outcome を operator が整合できるよう
 
 **活動証拠 (G652 — 1.x を通じた preview)。** 実行中 process は作業の証拠ではありません。herdr では status が `agent_status`、`state_change_seq`、最後の状態変更時刻も示します。`working` には working agent と進行する活動が必要です。sequence baseline がまだない場合、status は `live-idle` を断定せず `activity-unknown` を返します。dispatch 後の状態変更時刻は cold-start の `working` の十分な証拠です。supervision は最初の baseline を live-idle finding なしで記録し、その後に変化しない live-idle recipient に report がなければ一度だけ表示して terminal の確認を remedy として示します。この finding のために terminal content を読んだり recovery に入ったりしません。declared bound が configured interval より小さい場合は、supervise start と各 cycle で structural false alarm warning を出し、CLI が黙って補正する値ではありません。
 
-### delivery 済みだが observable start がない委譲 (G741)
+### delivery 済みだが observable start がない委譲 (G741/G788)
 
 `notify supervise` は、永続的な delivery evidence が
 `delivery_succeeded=true`、recipient が後続 observation でも
@@ -608,6 +608,20 @@ task の canonical report が absent、全 expected artifact source が absent�
 永続的な target-entity transition source が absent でなければなりません。
 seat が working/started、artifact・report・target transition が見える場合は
 non-finding です。
+
+G788 では、この absence 判定を単一の missing report から推測せず source-derived にします。
+configured execution-unit regex から共有の `execution-unit token` を抽出し、
+`pending-ledger`、`report-outbox`、`notification-events`、`queue-state`、
+`continuation-chain`、`expected-artifact` を確認します。後ろの 2 つは従来の
+continuation と expected artifact check を保持し、最初の 4 つは downstream delegation、
+child-report delivery、delivery 後の queue progress を示します。token に一致する source
+が一つでもあれば positive execution evidence となり finding は抑制されます。
+recipient が downstream activity を発行しているが target token を持たない場合は、
+escalation wake を出さず informational な
+`delegation-in-progress-no-direct-report` を記録します。6 source が全て absent のときだけ
+finding を出し、各 source の `Source-derived` count を記録します。configured form の
+`G779-start`、`design-delegate-SKS-G909`、lower-case equivalent は case-insensitive に
+token は一致し、tokenless text は evidence ではありません。
 
 recipient activity の観測 state set は `idle` と `done` の 2 つです。`idle` は
 開始されなかった seat、`done` は turn を完了したが delegated work を生成しなかった

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -611,6 +611,8 @@ non-finding です。
 
 G788 では、この absence 判定を単一の missing report から推測せず source-derived にします。
 configured execution-unit regex から共有の `execution-unit token` を抽出し、
+task id、objective、input の順で最初の configured match だけを用いるため、後方の token が
+最初の token を上書きすることはありません。
 `pending-ledger`、`report-outbox`、`notification-events`、`queue-state`、
 `continuation-chain`、`expected-artifact` を確認します。後ろの 2 つは従来の
 continuation と expected artifact check を保持し、最初の 4 つは downstream delegation、

--- a/src/IntentSystem.Cli/Commands/NextSliceDomainBindingsExecutionUnitRegex.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceDomainBindingsExecutionUnitRegex.cs
@@ -57,6 +57,37 @@ internal static class NextSliceDomainBindingsExecutionUnitRegex
         }
 
         var bindingsPath = ResolveBindingsAbsolutePath(context, domain);
+        return ResolveBindingsPath(bindingsPath);
+    }
+
+    /// <summary>
+    /// Resolves the same domain binding from an explicit runtime root. Host
+    /// supervisors use this rather than their caller's cwd so an explicit
+    /// <c>--routing-root</c> governs the unit-token boundary as well as the
+    /// evidence files it already governs.
+    /// </summary>
+    internal static ExecutionUnitRegexResolution ResolveAtRoot(string root, string? domain)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return ExecutionUnitRegexResolution.MissingOrAbsent("(no domain configured)");
+        }
+
+        string bindingsPath;
+        try
+        {
+            bindingsPath = Path.GetFullPath(Path.Combine(root, "intents", domain, "automation", "bindings.md"));
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            return ExecutionUnitRegexResolution.MissingOrAbsent($"(unresolved: {exception.Message})");
+        }
+
+        return ResolveBindingsPath(bindingsPath);
+    }
+
+    private static ExecutionUnitRegexResolution ResolveBindingsPath(string? bindingsPath)
+    {
         if (string.IsNullOrWhiteSpace(bindingsPath) || !File.Exists(bindingsPath))
         {
             return ExecutionUnitRegexResolution.MissingOrAbsent(bindingsPath ?? "(unresolved)");

--- a/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
@@ -127,7 +127,11 @@ internal sealed record NotifyDelegationExecutionEvidence
         }
         var unitToken = unitPattern is null
             ? null
-            : ExtractExecutionUnitToken(record.TaskId, unitPattern);
+            : ExtractExecutionUnitToken(
+                record.TaskId,
+                record.Objective,
+                record.Inputs,
+                unitPattern);
 
         var expectedArtifactPresent = false;
         IReadOnlyList<string> expectedArtifacts = record.ExpectedArtifacts is { Count: > 0 } artifacts
@@ -179,13 +183,18 @@ internal sealed record NotifyDelegationExecutionEvidence
                     .ToArray();
                 foreach (var candidate in downstream)
                 {
-                    if (CarriesExecutionUnitToken(candidate, unitToken, unitPattern))
+                    var candidateUnitToken = ExtractExecutionUnitToken(
+                        candidate.TaskId,
+                        candidate.Objective,
+                        candidate.Inputs,
+                        unitPattern);
+                    if (string.Equals(candidateUnitToken, unitToken, StringComparison.OrdinalIgnoreCase))
                     {
                         pendingLedgerPresent = true;
                         pendingDetails.Add(
                             $"pending-ledger:task_id={candidate.TaskId}; delegating_role={candidate.DelegatingRole}; dispatched_at={candidate.DispatchedAt:O}; source={pendingLedgerPath}");
                     }
-                    else
+                    else if (candidateUnitToken is null)
                     {
                         hasTokenlessDownstream = true;
                         tokenlessDownstreamDetails.Add(
@@ -206,9 +215,18 @@ internal sealed record NotifyDelegationExecutionEvidence
             else if (unitPattern is not null && unitToken is not null)
             {
                 foreach (var entry in outbox.Where(entry => entry.CreatedAt > deliveredAt
-                    && !string.Equals(entry.TaskId, record.TaskId, StringComparison.Ordinal)
-                    && CarriesExecutionUnitToken(entry, unitToken, unitPattern)))
+                    && !string.Equals(entry.TaskId, record.TaskId, StringComparison.Ordinal)))
                 {
+                    var entryUnitToken = ExtractExecutionUnitToken(
+                        entry.TaskId,
+                        entry.Summary,
+                        [entry.Artifact],
+                        unitPattern);
+                    if (!string.Equals(entryUnitToken, unitToken, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
                     reportOutboxPresent = true;
                     reportOutboxDetails.Add(
                         $"report-outbox:task_id={entry.TaskId}; from_role={entry.FromRole}; created_at={entry.CreatedAt:O}; source={reportOutboxPath}");
@@ -259,10 +277,17 @@ internal sealed record NotifyDelegationExecutionEvidence
                             eventUnit,
                             record.TaskId,
                             StringComparison.Ordinal);
+                        var eventUnitToken = unitPattern is null
+                            ? null
+                            : ExtractExecutionUnitToken(
+                                eventUnit,
+                                summary,
+                                artifact is null ? null : [artifact],
+                                unitPattern);
                         var isTokenCarryingChildReport = unitPattern is not null
                             && unitToken is not null
                             && !string.Equals(eventUnit, record.TaskId, StringComparison.Ordinal)
-                            && CarriesExecutionUnitToken(unitToken, unitPattern, eventUnit, summary, artifact);
+                            && string.Equals(eventUnitToken, unitToken, StringComparison.OrdinalIgnoreCase);
                         if (!isExactTaskReport && !isTokenCarryingChildReport)
                         {
                             continue;
@@ -364,12 +389,41 @@ internal sealed record NotifyDelegationExecutionEvidence
     }
 
     /// <summary>
-    /// Extracts one configured execution-unit token from a task id or prose
-    /// field. All G788 source checks call this rule, so the same token governs
-    /// downstream delegation, child-report, event, and queue matching.
+    /// Extracts one configured, case-insensitive execution-unit token in record
+    /// field order: task id, objective, then inputs. All G788 source checks
+    /// call this rule, so a later token cannot override an earlier token from
+    /// the same carrier.
     /// </summary>
-    internal static string? ExtractExecutionUnitToken(string? value, Regex executionUnitPattern) =>
-        ExtractExecutionUnitTokens(value, executionUnitPattern).FirstOrDefault();
+    internal static string? ExtractExecutionUnitToken(
+        string? taskId,
+        string? objective,
+        IEnumerable<string?>? inputs,
+        Regex executionUnitPattern)
+    {
+        var orderedFields = new List<string?> { taskId, objective };
+        if (inputs is not null)
+        {
+            orderedFields.AddRange(inputs);
+        }
+
+        foreach (var value in orderedFields)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            foreach (Match candidate in CandidateExecutionUnitPattern.Matches(value))
+            {
+                if (executionUnitPattern.IsMatch(candidate.Value))
+                {
+                    return candidate.Value.ToUpperInvariant();
+                }
+            }
+        }
+
+        return null;
+    }
 
     private static readonly Regex CandidateExecutionUnitPattern = new(
         @"(?<![A-Za-z0-9])(?:[A-Za-z][A-Za-z0-9]*-)?G[0-9]+(?![A-Za-z0-9])",
@@ -378,22 +432,6 @@ internal sealed record NotifyDelegationExecutionEvidence
     private static readonly Regex DefaultExecutionUnitPattern = new(
         @"^(?:[A-Za-z][A-Za-z0-9]*-)?G[0-9]+$",
         RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-
-    private static IEnumerable<string> ExtractExecutionUnitTokens(string? value, Regex executionUnitPattern)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            yield break;
-        }
-
-        foreach (Match candidate in CandidateExecutionUnitPattern.Matches(value))
-        {
-            if (executionUnitPattern.IsMatch(candidate.Value))
-            {
-                yield return candidate.Value.ToUpperInvariant();
-            }
-        }
-    }
 
     private static Regex? ResolveUnitPattern(string routingRoot, string domain, out string? error)
     {
@@ -424,34 +462,6 @@ internal sealed record NotifyDelegationExecutionEvidence
             return null;
         }
     }
-
-    private static bool CarriesExecutionUnitToken(
-        NotifyPendingDelegation candidate,
-        string unitToken,
-        Regex executionUnitPattern)
-    {
-        var values = new List<string?> { candidate.TaskId, candidate.Objective };
-        values.AddRange(candidate.Inputs ?? []);
-        return CarriesExecutionUnitToken(unitToken, executionUnitPattern, values.ToArray());
-    }
-
-    private static bool CarriesExecutionUnitToken(
-        NotifyReportOutboxEntry entry,
-        string unitToken,
-        Regex executionUnitPattern) =>
-        CarriesExecutionUnitToken(
-            unitToken,
-            executionUnitPattern,
-            entry.TaskId,
-            entry.Summary,
-            entry.Artifact);
-
-    private static bool CarriesExecutionUnitToken(
-        string unitToken,
-        Regex executionUnitPattern,
-        params string?[] values) => values
-        .SelectMany(value => ExtractExecutionUnitTokens(value, executionUnitPattern))
-        .Any(candidate => string.Equals(candidate, unitToken, StringComparison.OrdinalIgnoreCase));
 
     private static IReadOnlyList<string> ResolveEventPaths(
         string routingRoot,

--- a/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
@@ -1,172 +1,512 @@
 using System.Globalization;
 using System.Text.Json;
+using System.Text.RegularExpressions;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// Read-only evidence used by G741 to distinguish a delivered delegation
-/// without an observable start from a delegation whose work has become
+/// Read-only evidence used by G741/G788 to distinguish a delivered delegation
+/// without an observable start from a delegation whose execution has become
 /// visible. Unknown or unreadable evidence is deliberately not a finding.
 /// </summary>
 internal sealed record NotifyDelegationExecutionEvidence
 {
+    public bool? PendingLedgerPresent { get; init; }
+    public bool? ReportOutboxPresent { get; init; }
+    public bool? NotificationEventsPresent { get; init; }
+    public bool? QueueStatePresent { get; init; }
+    public bool? ContinuationChainPresent { get; init; }
     public bool? ExpectedArtifactPresent { get; init; }
-    public bool? TargetEntityTransitionPresent { get; init; }
-    public required string ArtifactSource { get; init; }
-    public required string TargetEntitySource { get; init; }
-    public IReadOnlyList<string> ArtifactDetails { get; init; } = [];
-    public IReadOnlyList<string> TargetEntityDetails { get; init; } = [];
+    public required string PendingLedgerSource { get; init; }
+    public required string ReportOutboxSource { get; init; }
+    public required string NotificationEventsSource { get; init; }
+    public required string QueueStateSource { get; init; }
+    public required string ContinuationChainSource { get; init; }
+    public required string ExpectedArtifactSource { get; init; }
+    public string? ExecutionUnitToken { get; init; }
+    public bool HasTokenlessDownstreamDelegation { get; init; }
+    public IReadOnlyList<string> PendingLedgerDetails { get; init; } = [];
+    public IReadOnlyList<string> ReportOutboxDetails { get; init; } = [];
+    public IReadOnlyList<string> NotificationEventDetails { get; init; } = [];
+    public IReadOnlyList<string> QueueStateDetails { get; init; } = [];
+    public IReadOnlyList<string> ContinuationChainDetails { get; init; } = [];
+    public IReadOnlyList<string> ExpectedArtifactDetails { get; init; } = [];
+    public IReadOnlyList<string> TokenlessDownstreamDetails { get; init; } = [];
     public string? Error { get; init; }
 
     internal bool IsResolved => Error is null
-        && ExpectedArtifactPresent is not null
-        && TargetEntityTransitionPresent is not null;
+        && PendingLedgerPresent is not null
+        && ReportOutboxPresent is not null
+        && NotificationEventsPresent is not null
+        && QueueStatePresent is not null
+        && ContinuationChainPresent is not null
+        && ExpectedArtifactPresent is not null;
+
+    internal bool HasExecutionEvidence => IsResolved
+        && (PendingLedgerPresent == true
+            || ReportOutboxPresent == true
+            || NotificationEventsPresent == true
+            || QueueStatePresent == true
+            || ContinuationChainPresent == true
+            || ExpectedArtifactPresent == true);
+
+    /// <summary>
+    /// The fixed, source-derived wording used by the true-stall summary. The
+    /// numbers are derived from the same details persisted in the cycle, so a
+    /// conclusion never claims an absence that the resolver did not measure.
+    /// </summary>
+    internal string SourceCountSummary => string.Join(
+        "; ",
+        $"pending-ledger={PendingLedgerDetails.Count}",
+        $"report-outbox={ReportOutboxDetails.Count}",
+        $"notification-events={NotificationEventDetails.Count}",
+        $"queue-state={QueueStateDetails.Count}",
+        $"continuation-chain={ContinuationChainDetails.Count}",
+        $"expected-artifact={ExpectedArtifactDetails.Count}");
+
+    internal IReadOnlyList<string> BuildConsultedObservations(string taskId)
+    {
+        var observations = new List<string>
+        {
+            $"delegation-execution-evidence: task_id={taskId}; unit={ExecutionUnitToken ?? "<none>"}; {SourceCountSummary}",
+            $"pending-ledger:count={PendingLedgerDetails.Count}; source={PendingLedgerSource}",
+            $"report-outbox:count={ReportOutboxDetails.Count}; source={ReportOutboxSource}",
+            $"notification-events:count={NotificationEventDetails.Count}; source={NotificationEventsSource}",
+            $"queue-state:count={QueueStateDetails.Count}; source={QueueStateSource}",
+            $"continuation-chain:count={ContinuationChainDetails.Count}; source={ContinuationChainSource}",
+            $"expected-artifact:count={ExpectedArtifactDetails.Count}; source={ExpectedArtifactSource}",
+        };
+        observations.AddRange(PendingLedgerDetails);
+        observations.AddRange(ReportOutboxDetails);
+        observations.AddRange(NotificationEventDetails);
+        observations.AddRange(QueueStateDetails);
+        observations.AddRange(ContinuationChainDetails);
+        observations.AddRange(ExpectedArtifactDetails);
+        observations.AddRange(TokenlessDownstreamDetails);
+        return observations;
+    }
 
     internal static NotifyDelegationExecutionEvidence Resolve(
         string routingRoot,
         NotifyPendingDelegation record,
         DateTimeOffset deliveredAt)
     {
-        var artifactDetails = new List<string>();
-        var artifactSources = new List<string>();
-        string? error = null;
-        var artifactPresent = false;
+        string pendingLedgerPath;
+        string reportOutboxPath;
+        string queueStatePath;
+        string continuationPath;
+        try
+        {
+            pendingLedgerPath = NotifyPendingDelegationStore.ResolvePath(routingRoot, record.Domain, record.Team);
+            reportOutboxPath = NotifyReportOutboxStore.ResolvePath(routingRoot, record.Domain, record.Team);
+            queueStatePath = CliRuntimeContracts.GetQueueStatePath(routingRoot);
+            continuationPath = ContinuationChainStore.ResolvePath(routingRoot, record.Domain, record.Team);
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            return Unresolved(routingRoot, exception.Message);
+        }
 
+        var eventPaths = ResolveEventPaths(routingRoot, record, out var eventResolutionError);
+        var pendingDetails = new List<string>();
+        var reportOutboxDetails = new List<string>();
+        var notificationEventDetails = new List<string>();
+        var queueStateDetails = new List<string>();
+        var continuationChainDetails = new List<string>();
+        var expectedArtifactDetails = new List<string>();
+        var tokenlessDownstreamDetails = new List<string>();
+        var expectedArtifactSources = new List<string>();
+        string? error = eventResolutionError;
+
+        var unitPattern = ResolveUnitPattern(routingRoot, record.Domain, out var unitPatternError);
+        if (error is null && unitPatternError is not null)
+        {
+            error = unitPatternError;
+        }
+        var unitToken = unitPattern is null
+            ? null
+            : ExtractExecutionUnitToken(record.TaskId, unitPattern);
+
+        var expectedArtifactPresent = false;
         IReadOnlyList<string> expectedArtifacts = record.ExpectedArtifacts is { Count: > 0 } artifacts
             ? artifacts
             : [record.ExpectedArtifact];
         foreach (var expectedArtifact in expectedArtifacts)
         {
-            if (TryResolveArtifactPath(expectedArtifact, record.Cwd, out var artifactPath))
+            if (!TryResolveArtifactPath(expectedArtifact, record.Cwd, out var artifactPath))
             {
-                artifactSources.Add(artifactPath);
-                try
+                expectedArtifactSources.Add($"non-filesystem:{expectedArtifact}");
+                continue;
+            }
+
+            expectedArtifactSources.Add(artifactPath);
+            if (error is not null)
+            {
+                continue;
+            }
+
+            try
+            {
+                if (File.Exists(artifactPath) || Directory.Exists(artifactPath))
                 {
-                    if (File.Exists(artifactPath) || Directory.Exists(artifactPath))
+                    expectedArtifactPresent = true;
+                    expectedArtifactDetails.Add($"expected-artifact:path={artifactPath}");
+                }
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                error = $"expected-artifact source '{artifactPath}' could not be checked: {exception.Message}";
+            }
+        }
+
+        var pendingLedgerPresent = false;
+        var hasTokenlessDownstream = false;
+        if (error is null)
+        {
+            var ledger = NotifyPendingDelegationStore.ReadAll(routingRoot, record.Domain, record.Team, out var ledgerError);
+            if (ledgerError is not null)
+            {
+                error = ledgerError;
+            }
+            else if (unitPattern is not null && unitToken is not null)
+            {
+                var downstream = ledger.Where(candidate =>
+                        !string.Equals(candidate.TaskId, record.TaskId, StringComparison.Ordinal)
+                        && string.Equals(candidate.DelegatingRole, record.RecipientRole, StringComparison.OrdinalIgnoreCase)
+                        && candidate.DispatchedAt > deliveredAt)
+                    .ToArray();
+                foreach (var candidate in downstream)
+                {
+                    if (CarriesExecutionUnitToken(candidate, unitToken, unitPattern))
                     {
-                        artifactPresent = true;
-                        artifactDetails.Add($"path:{artifactPath}");
+                        pendingLedgerPresent = true;
+                        pendingDetails.Add(
+                            $"pending-ledger:task_id={candidate.TaskId}; delegating_role={candidate.DelegatingRole}; dispatched_at={candidate.DispatchedAt:O}; source={pendingLedgerPath}");
+                    }
+                    else
+                    {
+                        hasTokenlessDownstream = true;
+                        tokenlessDownstreamDetails.Add(
+                            $"pending-ledger:tokenless-downstream task_id={candidate.TaskId}; delegating_role={candidate.DelegatingRole}; dispatched_at={candidate.DispatchedAt:O}; source={pendingLedgerPath}");
                     }
                 }
-                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            }
+        }
+
+        var reportOutboxPresent = false;
+        if (error is null)
+        {
+            var outbox = NotifyReportOutboxStore.ReadAll(routingRoot, record.Domain, record.Team, out var outboxError);
+            if (outboxError is not null)
+            {
+                error = outboxError;
+            }
+            else if (unitPattern is not null && unitToken is not null)
+            {
+                foreach (var entry in outbox.Where(entry => entry.CreatedAt > deliveredAt
+                    && !string.Equals(entry.TaskId, record.TaskId, StringComparison.Ordinal)
+                    && CarriesExecutionUnitToken(entry, unitToken, unitPattern)))
                 {
-                    error = $"expected artifact source '{artifactPath}' could not be checked: {exception.Message}";
+                    reportOutboxPresent = true;
+                    reportOutboxDetails.Add(
+                        $"report-outbox:task_id={entry.TaskId}; from_role={entry.FromRole}; created_at={entry.CreatedAt:O}; source={reportOutboxPath}");
+                }
+            }
+        }
+
+        var notificationEventsPresent = false;
+        if (error is null)
+        {
+            foreach (var eventPath in eventPaths)
+            {
+                if (!File.Exists(eventPath))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    foreach (var line in File.ReadLines(eventPath))
+                    {
+                        if (string.IsNullOrWhiteSpace(line))
+                        {
+                            continue;
+                        }
+
+                        using var document = JsonDocument.Parse(line);
+                        var root = document.RootElement;
+                        var eventUnit = ReadString(root, "unit");
+                        var summary = ReadString(root, "summary");
+                        var artifact = ReadString(root, "artifact");
+                        if (!root.TryGetProperty("timestamp", out var timestampElement)
+                            || !DateTimeOffset.TryParse(
+                                timestampElement.GetString(),
+                                CultureInfo.InvariantCulture,
+                                DateTimeStyles.RoundtripKind,
+                                out var timestamp)
+                            || timestamp <= deliveredAt)
+                        {
+                            continue;
+                        }
+
+                        // G741's exact-task event is still direct report evidence.
+                        // G788 adds a distinct child-report path which must carry the
+                        // configured unit token rather than accidentally treating any
+                        // unrelated post-delivery event as progress.
+                        var isExactTaskReport = string.Equals(
+                            eventUnit,
+                            record.TaskId,
+                            StringComparison.Ordinal);
+                        var isTokenCarryingChildReport = unitPattern is not null
+                            && unitToken is not null
+                            && !string.Equals(eventUnit, record.TaskId, StringComparison.Ordinal)
+                            && CarriesExecutionUnitToken(unitToken, unitPattern, eventUnit, summary, artifact);
+                        if (!isExactTaskReport && !isTokenCarryingChildReport)
+                        {
+                            continue;
+                        }
+
+                        notificationEventsPresent = true;
+                        var kind = ReadString(root, "kind") ?? "unknown";
+                        notificationEventDetails.Add(
+                            $"notification-events:unit={eventUnit ?? "<none>"}; kind={kind}; timestamp={timestamp:O}; source={eventPath}");
+                    }
+                }
+                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException)
+                {
+                    error = $"notification-events source '{eventPath}' could not be read: {exception.Message}";
                     break;
                 }
             }
-            else
-            {
-                artifactSources.Add($"non-filesystem:{expectedArtifact}");
-            }
         }
 
-        var eventSource = ResolveEventSource(routingRoot, record, out var eventPath, out var eventResolutionError);
-        artifactSources.Add(eventSource);
-        if (error is null && !string.IsNullOrWhiteSpace(eventResolutionError))
-        {
-            error = eventResolutionError;
-        }
-
-        if (error is null && eventPath is not null && File.Exists(eventPath))
+        var queueStatePresent = false;
+        if (error is null && File.Exists(queueStatePath))
         {
             try
             {
-                foreach (var line in File.ReadLines(eventPath))
+                var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+                if (unitToken is not null && queueState.UpdatedAt > deliveredAt)
                 {
-                    if (string.IsNullOrWhiteSpace(line))
+                    foreach (var item in queueState.Items.Where(item =>
+                        string.Equals(item.ExecutionUnit, unitToken, StringComparison.OrdinalIgnoreCase)
+                        && (!string.IsNullOrWhiteSpace(item.LinkedPr) || item.State != QueueItemState.Queued)))
                     {
-                        continue;
+                        queueStatePresent = true;
+                        queueStateDetails.Add(
+                            $"queue-state:execution_unit={item.ExecutionUnit}; state={item.State.ToString().ToLowerInvariant()}; linked_pr={item.LinkedPr ?? "<none>"}; updated_at={queueState.UpdatedAt:O}; source={queueStatePath}");
                     }
-
-                    using var document = JsonDocument.Parse(line);
-                    var root = document.RootElement;
-                    if (!root.TryGetProperty("unit", out var unit)
-                        || !string.Equals(unit.GetString(), record.TaskId, StringComparison.Ordinal)
-                        || !root.TryGetProperty("timestamp", out var timestampElement)
-                        || !DateTimeOffset.TryParse(
-                            timestampElement.GetString(),
-                            CultureInfo.InvariantCulture,
-                            DateTimeStyles.RoundtripKind,
-                            out var timestamp)
-                        || timestamp <= deliveredAt)
-                    {
-                        continue;
-                    }
-
-                    artifactPresent = true;
-                    var kind = root.TryGetProperty("kind", out var kindElement)
-                        ? kindElement.GetString() ?? "unknown"
-                        : "unknown";
-                    artifactDetails.Add($"event:{eventPath};kind={kind};timestamp={timestamp:O}");
                 }
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException)
             {
-                error = $"notification event source '{eventPath}' could not be read: {exception.Message}";
+                error = $"queue-state source '{queueStatePath}' could not be read: {exception.Message}";
             }
         }
 
-        var artifactSource = artifactSources.Count == 0
-            ? "expected-artifacts:none; notification-events:none"
-            : $"expected-artifacts={string.Join("|", artifactSources)}";
-
-        var continuation = ContinuationChainStore.Read(
-            routingRoot,
-            record.Domain,
-            record.Team,
-            taskId: record.TaskId);
-        var transitionSource = $"continuation-chain:{continuation.Path}; links={ContinuationChainStore.CanonicalStateClassified}|{ContinuationChainStore.RequiredContinuationStarted}|{ContinuationChainStore.NamedBlockerRecorded}";
-        var transitionDetails = new List<string>();
-        bool? transitionPresent = null;
-        if (error is null && !continuation.Resolved)
+        var continuationChainPresent = false;
+        if (error is null)
         {
-            error = continuation.Error ?? $"continuation-chain source '{continuation.Path}' could not be read.";
-        }
-        else if (error is null)
-        {
-            var transitionLinks = continuation.Records
-                .SelectMany(chain => chain.Links)
-                .Where(link => link.Name is ContinuationChainStore.CanonicalStateClassified
-                    or ContinuationChainStore.RequiredContinuationStarted
-                    or ContinuationChainStore.NamedBlockerRecorded)
-                .ToArray();
-            transitionPresent = transitionLinks.Length > 0;
-            transitionDetails.AddRange(transitionLinks.Select(link =>
-                $"link:{link.Name};timestamp={link.Timestamp:O};source={link.Source}"));
+            var continuation = ContinuationChainStore.Read(
+                routingRoot,
+                record.Domain,
+                record.Team,
+                taskId: record.TaskId);
+            if (!continuation.Resolved)
+            {
+                error = continuation.Error ?? $"continuation-chain source '{continuation.Path}' could not be read.";
+            }
+            else
+            {
+                var transitionLinks = continuation.Records
+                    .SelectMany(chain => chain.Links)
+                    .Where(link => link.Name is ContinuationChainStore.CanonicalStateClassified
+                        or ContinuationChainStore.RequiredContinuationStarted
+                        or ContinuationChainStore.NamedBlockerRecorded)
+                    .ToArray();
+                continuationChainPresent = transitionLinks.Length > 0;
+                continuationChainDetails.AddRange(transitionLinks.Select(link =>
+                    $"continuation-chain:link={link.Name}; timestamp={link.Timestamp:O}; source={link.Source}"));
+            }
         }
 
         return new NotifyDelegationExecutionEvidence
         {
-            ExpectedArtifactPresent = error is null ? artifactPresent : null,
-            TargetEntityTransitionPresent = error is null ? transitionPresent : null,
-            ArtifactSource = artifactSource,
-            TargetEntitySource = transitionSource,
-            ArtifactDetails = artifactDetails,
-            TargetEntityDetails = transitionDetails,
+            PendingLedgerPresent = error is null ? pendingLedgerPresent : null,
+            ReportOutboxPresent = error is null ? reportOutboxPresent : null,
+            NotificationEventsPresent = error is null ? notificationEventsPresent : null,
+            QueueStatePresent = error is null ? queueStatePresent : null,
+            ContinuationChainPresent = error is null ? continuationChainPresent : null,
+            ExpectedArtifactPresent = error is null ? expectedArtifactPresent : null,
+            PendingLedgerSource = pendingLedgerPath,
+            ReportOutboxSource = reportOutboxPath,
+            NotificationEventsSource = eventPaths.Count == 0
+                ? "notification-events:none"
+                : string.Join("|", eventPaths),
+            QueueStateSource = queueStatePath,
+            ContinuationChainSource = continuationPath,
+            ExpectedArtifactSource = expectedArtifactSources.Count == 0
+                ? "expected-artifact:none"
+                : string.Join("|", expectedArtifactSources),
+            ExecutionUnitToken = unitToken,
+            HasTokenlessDownstreamDelegation = error is null && hasTokenlessDownstream,
+            PendingLedgerDetails = pendingDetails,
+            ReportOutboxDetails = reportOutboxDetails,
+            NotificationEventDetails = notificationEventDetails,
+            QueueStateDetails = queueStateDetails,
+            ContinuationChainDetails = continuationChainDetails,
+            ExpectedArtifactDetails = expectedArtifactDetails,
+            TokenlessDownstreamDetails = tokenlessDownstreamDetails,
             Error = error,
         };
     }
 
-    private static string ResolveEventSource(
+    /// <summary>
+    /// Extracts one configured execution-unit token from a task id or prose
+    /// field. All G788 source checks call this rule, so the same token governs
+    /// downstream delegation, child-report, event, and queue matching.
+    /// </summary>
+    internal static string? ExtractExecutionUnitToken(string? value, Regex executionUnitPattern) =>
+        ExtractExecutionUnitTokens(value, executionUnitPattern).FirstOrDefault();
+
+    private static readonly Regex CandidateExecutionUnitPattern = new(
+        @"(?<![A-Za-z0-9])(?:[A-Za-z][A-Za-z0-9]*-)?G[0-9]+(?![A-Za-z0-9])",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex DefaultExecutionUnitPattern = new(
+        @"^(?:[A-Za-z][A-Za-z0-9]*-)?G[0-9]+$",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static IEnumerable<string> ExtractExecutionUnitTokens(string? value, Regex executionUnitPattern)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            yield break;
+        }
+
+        foreach (Match candidate in CandidateExecutionUnitPattern.Matches(value))
+        {
+            if (executionUnitPattern.IsMatch(candidate.Value))
+            {
+                yield return candidate.Value.ToUpperInvariant();
+            }
+        }
+    }
+
+    private static Regex? ResolveUnitPattern(string routingRoot, string domain, out string? error)
+    {
+        var resolution = NextSliceDomainBindingsExecutionUnitRegex.ResolveAtRoot(routingRoot, domain);
+        if (resolution.Kind == ExecutionUnitRegexResolutionKind.InvalidPattern)
+        {
+            error = $"execution-unit regex source '{resolution.BindingsPath}' is invalid: {resolution.Detail}";
+            return null;
+        }
+
+        if (resolution.Pattern is null)
+        {
+            error = null;
+            return DefaultExecutionUnitPattern;
+        }
+
+        try
+        {
+            error = null;
+            return new Regex(
+                resolution.Pattern,
+                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+                TimeSpan.FromMilliseconds(200));
+        }
+        catch (ArgumentException exception)
+        {
+            error = $"execution-unit regex source '{resolution.BindingsPath}' is invalid: {exception.Message}";
+            return null;
+        }
+    }
+
+    private static bool CarriesExecutionUnitToken(
+        NotifyPendingDelegation candidate,
+        string unitToken,
+        Regex executionUnitPattern)
+    {
+        var values = new List<string?> { candidate.TaskId, candidate.Objective };
+        values.AddRange(candidate.Inputs ?? []);
+        return CarriesExecutionUnitToken(unitToken, executionUnitPattern, values.ToArray());
+    }
+
+    private static bool CarriesExecutionUnitToken(
+        NotifyReportOutboxEntry entry,
+        string unitToken,
+        Regex executionUnitPattern) =>
+        CarriesExecutionUnitToken(
+            unitToken,
+            executionUnitPattern,
+            entry.TaskId,
+            entry.Summary,
+            entry.Artifact);
+
+    private static bool CarriesExecutionUnitToken(
+        string unitToken,
+        Regex executionUnitPattern,
+        params string?[] values) => values
+        .SelectMany(value => ExtractExecutionUnitTokens(value, executionUnitPattern))
+        .Any(candidate => string.Equals(candidate, unitToken, StringComparison.OrdinalIgnoreCase));
+
+    private static IReadOnlyList<string> ResolveEventPaths(
         string routingRoot,
         NotifyPendingDelegation record,
-        out string? path,
         out string? error)
     {
-        if (NotifyEventWriter.TryResolveReadPath(
+        var paths = new HashSet<string>(StringComparer.Ordinal);
+        if (!NotifyEventWriter.TryResolveReadPath(
             routingRoot,
             record.Domain,
             record.Team,
             record.Reader,
-            out path,
+            out var eventPath,
             out error))
         {
-            return $"notification-events:{path}";
+            return [];
         }
 
-        path = null;
-        return $"notification-events:unresolved:{error}";
+        paths.Add(eventPath);
+        var eventsRoot = Path.Combine(routingRoot, NotifyEventWriter.EventsDirectoryRelativePath, record.Domain);
+        if (Directory.Exists(eventsRoot))
+        {
+            try
+            {
+                foreach (var path in Directory.EnumerateFiles(eventsRoot, "*.jsonl", SearchOption.TopDirectoryOnly))
+                {
+                    paths.Add(path);
+                }
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                error = $"notification-events source '{eventsRoot}' could not be enumerated: {exception.Message}";
+                return [];
+            }
+        }
+
+        error = null;
+        return paths.OrderBy(path => path, StringComparer.Ordinal).ToArray();
     }
+
+    private static string? ReadString(JsonElement root, string property) =>
+        root.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static NotifyDelegationExecutionEvidence Unresolved(string routingRoot, string error) => new()
+    {
+        PendingLedgerSource = routingRoot,
+        ReportOutboxSource = routingRoot,
+        NotificationEventsSource = routingRoot,
+        QueueStateSource = routingRoot,
+        ContinuationChainSource = routingRoot,
+        ExpectedArtifactSource = routingRoot,
+        Error = error,
+    };
 
     private static bool TryResolveArtifactPath(
         string value,

--- a/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
@@ -262,6 +262,7 @@ internal sealed class NotifyMeasuredSupervisor
         var observations = new List<NotifySupervisionObservation>();
         var actions = new List<NotifySupervisorAction>();
         var warnings = new List<string>();
+        var delegationEvidenceObservations = new List<string>();
         if (emissionPolicyWrite.Error is not null)
         {
             warnings.Add($"supervision-emission-policy-write-failed: {emissionPolicyWrite.Error}");
@@ -361,7 +362,8 @@ internal sealed class NotifyMeasuredSupervisor
                     previousCycle,
                     now,
                     observations,
-                    warnings);
+                    warnings,
+                    delegationEvidenceObservations);
                 if (!activity.Resolved || activity.Running != true || activity.StateChangeSequence is not { } sequence)
                 {
                     continue;
@@ -772,6 +774,9 @@ internal sealed class NotifyMeasuredSupervisor
             LastObservedAgentStatuses = observedStatuses,
             LastObservedAgentStatusConsecutiveCounts = observedStatusConsecutiveCounts,
             LastObservedAgentStatusRunFrom = observedStatusRunFrom,
+            DelegationExecutionEvidence = delegationEvidenceObservations.Count == 0
+                ? null
+                : delegationEvidenceObservations,
             Transitions = observations
                 .Where(observation => string.Equals(observation.Kind, "seat-state-transition", StringComparison.Ordinal))
                 .Select(observation =>
@@ -1307,7 +1312,8 @@ internal sealed class NotifyMeasuredSupervisor
         NotifySupervisionCycle? previousCycle,
         DateTimeOffset now,
         ICollection<NotifySupervisionObservation> observations,
-        ICollection<string> warnings)
+        ICollection<string> warnings,
+        ICollection<string> delegationEvidenceObservations)
     {
         if (!activity.Resolved
             || activity.Running != true
@@ -1357,20 +1363,6 @@ internal sealed class NotifyMeasuredSupervisor
             return;
         }
 
-        if (!evidence.IsResolved
-            || evidence.ExpectedArtifactPresent != false
-            || evidence.TargetEntityTransitionPresent != false)
-        {
-            if (!evidence.IsResolved)
-            {
-                warnings.Add($"delegation-execution-evidence-unavailable: task '{pending.TaskId}': "
-                    + (evidence.Error ?? "one or more evidence sources were unresolved; no finding was emitted."));
-            }
-
-            return;
-        }
-
-        var pendingPath = NotifyPendingDelegationStore.ResolvePath(routingRoot, pending.Domain, pending.Team);
         var seat = string.IsNullOrWhiteSpace(pending.RecipientIdentity)
             ? pending.RecipientRole
             : pending.RecipientIdentity;
@@ -1378,8 +1370,11 @@ internal sealed class NotifyMeasuredSupervisor
         var activityObservation =
             $"activity:{paneKey}: running={activity.Running}; agent_status={activity.AgentStatus}; "
             + $"state_change_seq={sequence.ToString(CultureInfo.InvariantCulture)}; source={activity.Source}";
-        var checkedSources =
-            $"delivery-evidence:{deliveryEvidence.Path}; pending-store:{pendingPath}; {evidence.ArtifactSource}; {evidence.TargetEntitySource}";
+        var consultedEvidence = evidence.BuildConsultedObservations(pending.TaskId);
+        foreach (var consulted in consultedEvidence)
+        {
+            delegationEvidenceObservations.Add(consulted);
+        }
         var evidenceLines = new List<string>
         {
             $"task_id:{pending.TaskId}",
@@ -1388,12 +1383,53 @@ internal sealed class NotifyMeasuredSupervisor
             $"window_seconds:{window}",
             $"delivery_evidence:success; source={deliveryEvidence.Path}",
             $"recipient_idle:true; source={activity.Source}; state_change_seq={sequence.ToString(CultureInfo.InvariantCulture)}",
-            $"canonical_report:absent; source={pendingPath}",
-            $"expected_artifact:absent; source={evidence.ArtifactSource}",
-            $"durable_target_entity_transition:absent; source={evidence.TargetEntitySource}",
+            $"source_counts:{evidence.SourceCountSummary}",
         };
-        evidenceLines.AddRange(evidence.ArtifactDetails);
-        evidenceLines.AddRange(evidence.TargetEntityDetails);
+        evidenceLines.AddRange(consultedEvidence);
+        var findingConsulted = new List<string>
+        {
+            activityObservation,
+            $"delivery-evidence:success; source={deliveryEvidence.Path}; delivered_at={deliveredAt:O}",
+            $"delivery:task_id={pending.TaskId}; delivery_succeeded=true; delivered_at={deliveredAt:O}; source={deliveryEvidence.Path}",
+        };
+        findingConsulted.AddRange(consultedEvidence);
+
+        if (!evidence.IsResolved)
+        {
+            warnings.Add($"delegation-execution-evidence-unavailable: task '{pending.TaskId}': "
+                + (evidence.Error ?? "one or more evidence sources were unresolved; no finding was emitted."));
+
+            return;
+        }
+
+        if (evidence.HasExecutionEvidence)
+        {
+            return;
+        }
+
+        if (evidence.HasTokenlessDownstreamDelegation)
+        {
+            observations.Add(new NotifySupervisionObservation
+            {
+                Key = $"delegation-in-progress-no-direct-report:{pending.TaskId}:{pending.ResultNonce ?? "legacy"}",
+                Kind = "delegation-in-progress-no-direct-report",
+                OwnerRole = pending.DelegatingRole ?? ownerRole,
+                SubjectRole = pending.RecipientRole,
+                Source = "notify-pending-delegation.execution",
+                Summary = $"Delegation task '{pending.TaskId}' has downstream activity from recipient seat '{seat}' after delivery, "
+                    + $"but no downstream task id, objective, or input carries execution-unit token '{evidence.ExecutionUnitToken ?? "<none>"}'. "
+                    + $"This is informational and has no escalation wake class. Source-derived execution evidence counts: "
+                    + $"{evidence.SourceCountSummary}. Checked sources: {BuildCheckedSources(evidence)}.",
+                DetectableAt = deliveredAt.AddSeconds(delegationExecutionWindowSeconds),
+                WorkspaceId = pending.WorkspaceId,
+                PaneId = pending.PaneId,
+                WakeSuppressed = true,
+                Evidence = evidenceLines,
+                ConsultedObservations = findingConsulted,
+            });
+
+            return;
+        }
 
         observations.Add(new NotifySupervisionObservation
         {
@@ -1404,31 +1440,34 @@ internal sealed class NotifyMeasuredSupervisor
             Source = "notify-pending-delegation.execution",
             Summary = $"Delegation task '{pending.TaskId}' was delivered to seat '{seat}' at '{deliveredAt:O}', "
                 + $"but the recipient is idle after the configured {window}s execution-start window. "
-                + $"Canonical report absent, expected artifact absent, and durable target-entity transition absent. "
-                + $"Checked sources: {checkedSources}. This observation is observation-only; it sends no keys, "
+                + $"Source-derived execution evidence counts: {evidence.SourceCountSummary}. "
+                + $"Checked sources: {BuildCheckedSources(evidence)}. This observation is observation-only; it sends no keys, "
                 + "answers no dialog, and restarts no seat; the finding routes to the delegation owner role.",
             DetectableAt = deliveredAt.AddSeconds(delegationExecutionWindowSeconds),
             WorkspaceId = pending.WorkspaceId,
             PaneId = pending.PaneId,
             Evidence = evidenceLines,
-            ConsultedObservations =
-            [
-                activityObservation,
-                $"delivery-evidence:success; source={deliveryEvidence.Path}; delivered_at={deliveredAt:O}",
-                $"delivery:task_id={pending.TaskId}; delivery_succeeded=true; delivered_at={deliveredAt:O}; source={deliveryEvidence.Path}",
-                $"canonical-report:absent; source={pendingPath}",
-                $"expected-artifact:absent; source={evidence.ArtifactSource}",
-                $"durable-target-entity-transition:absent; source={evidence.TargetEntitySource}",
-            ],
+            ConsultedObservations = findingConsulted,
         });
     }
+
+    private static string BuildCheckedSources(NotifyDelegationExecutionEvidence evidence) => string.Join(
+        "; ",
+        $"pending-ledger:{evidence.PendingLedgerSource}",
+        $"report-outbox:{evidence.ReportOutboxSource}",
+        $"notification-events:{evidence.NotificationEventsSource}",
+        $"queue-state:{evidence.QueueStateSource}",
+        $"continuation-chain:{evidence.ContinuationChainSource}",
+        $"expected-artifact:{evidence.ExpectedArtifactSource}");
 
     private string ResolveWakeTarget(NotifySupervisionObservation observation) =>
         observation.Prompt?.AdjudicationTargetRole
             ?? (IsOwnerSubject(observation.SubjectRole) ? DesignRole : observation.OwnerRole);
 
     private string? ResolveWakeClass(NotifySupervisionObservation observation) =>
-        observation.Prompt is { Decision: "accept" }
+        observation.WakeSuppressed
+            ? null
+            : observation.Prompt is { Decision: "accept" }
             ? "bounded-prompt-answer"
             : observation.Prompt is not null || IsOwnerSubject(observation.SubjectRole) ? "escalation" : null;
 

--- a/src/IntentSystem.Cli/Commands/NotifyPendingDelegationStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyPendingDelegationStore.cs
@@ -447,6 +447,41 @@ internal static class NotifyPendingDelegationStore
         return records.OrderBy(value => value.DispatchedAt).ToArray();
     }
 
+    /// <summary>
+    /// Reads the current record for every dispatch generation in one team
+    /// ledger. Unlike <see cref="ReadOpen"/>, settled children remain visible:
+    /// their original dispatch is still evidence that the recipient delegated
+    /// the delivered unit downstream.
+    /// </summary>
+    public static IReadOnlyList<NotifyPendingDelegation> ReadAll(
+        string routingRoot,
+        string domain,
+        string team,
+        out string? error)
+    {
+        string path;
+        try
+        {
+            path = ResolvePath(routingRoot, domain, team);
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            error = exception.Message;
+            return [];
+        }
+
+        lock (Sync)
+        {
+            var current = ReadCurrent(path, out error);
+            return error is null
+                ? current.Values
+                    .OrderBy(value => value.DispatchedAt)
+                    .ThenBy(value => value.TaskId, StringComparer.Ordinal)
+                    .ToArray()
+                : [];
+        }
+    }
+
     private static NotifyPendingStoreWriteResult Append(string path, NotifyPendingDelegation record)
     {
         var eventRecord = new NotifyPendingEvent

--- a/src/IntentSystem.Cli/Commands/NotifyReportOutboxStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyReportOutboxStore.cs
@@ -124,6 +124,40 @@ internal static class NotifyReportOutboxStore
         }
     }
 
+    /// <summary>
+    /// Reads every current sender-side report entry for the team. A delivered
+    /// child report remains execution evidence even after its local outbox
+    /// state changes from <c>undelivered</c> to <c>delivered</c>.
+    /// </summary>
+    public static IReadOnlyList<NotifyReportOutboxEntry> ReadAll(
+        string routingRoot,
+        string domain,
+        string team,
+        out string? error)
+    {
+        string path;
+        try
+        {
+            path = ResolvePath(routingRoot, domain, team);
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            error = exception.Message;
+            return [];
+        }
+
+        lock (Sync)
+        {
+            var current = ReadCurrent(path, out error);
+            return error is null
+                ? current.Values
+                    .OrderBy(value => value.CreatedAt)
+                    .ThenBy(value => value.TaskId, StringComparer.Ordinal)
+                    .ToArray()
+                : [];
+        }
+    }
+
     private static Dictionary<string, NotifyReportOutboxEntry> ReadCurrent(string path, out string? error)
     {
         error = null;

--- a/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
@@ -3408,6 +3408,16 @@ internal sealed record NotifySupervisionCycle
     [JsonPropertyName("last_observed_agent_statuses")] public IReadOnlyDictionary<string, string> LastObservedAgentStatuses { get; init; } = new Dictionary<string, string>(StringComparer.Ordinal);
     [JsonPropertyName("last_observed_agent_status_consecutive_counts")] public IReadOnlyDictionary<string, int> LastObservedAgentStatusConsecutiveCounts { get; init; } = new Dictionary<string, int>(StringComparer.Ordinal);
     [JsonPropertyName("last_observed_agent_status_run_from")] public IReadOnlyDictionary<string, string> LastObservedAgentStatusRunFrom { get; init; } = new Dictionary<string, string>(StringComparer.Ordinal);
+    /// <summary>
+    /// G788 additive audit of the six delivered-delegation evidence sources.
+    /// It is recorded for suppressing evidence as well as true stalls, so a
+    /// no-finding result still names what the cycle actually consulted.
+    /// </summary>
+    // Keep no-delegation cycles byte-compatible with parent records. A cycle
+    // that did consult G788 evidence writes the non-null audit explicitly.
+    [JsonPropertyName("delegation_execution_evidence")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? DelegationExecutionEvidence { get; init; }
     [JsonPropertyName("transitions")] public IReadOnlyList<NotifySupervisionTransition> Transitions { get; init; } = [];
     [JsonPropertyName("wait_events")] public IReadOnlyList<NotifySupervisionWaitEvent> WaitEvents { get; init; } = [];
 }

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionG741Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionG741Tests.cs
@@ -71,16 +71,25 @@ public sealed class NotifySupervisionG741Tests : IDisposable
         Assert.Contains("G741-fired", finding.Summary, StringComparison.Ordinal);
         Assert.Contains("seat 'role=implementation;workspace=wG741;pane=wG741:p2'", finding.Summary, StringComparison.Ordinal);
         Assert.Contains("300s execution-start window", finding.Summary, StringComparison.Ordinal);
-        Assert.Contains("Canonical report absent", finding.Summary, StringComparison.Ordinal);
-        Assert.Contains("expected artifact absent", finding.Summary, StringComparison.Ordinal);
-        Assert.Contains("durable target-entity transition absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("Source-derived execution evidence counts:", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("pending-ledger=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("report-outbox=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("notification-events=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("queue-state=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("continuation-chain=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("expected-artifact=0", finding.Summary, StringComparison.Ordinal);
+        Assert.DoesNotContain("Canonical report absent", finding.Summary, StringComparison.Ordinal);
         Assert.Contains("Checked sources:", finding.Summary, StringComparison.Ordinal);
         Assert.Contains("task_id:G741-fired", finding.Evidence!, StringComparer.Ordinal);
         Assert.Contains($"delivered_at:{firstNow:O}", finding.Evidence!, StringComparer.Ordinal);
         Assert.Contains("window_seconds:300", finding.Evidence!, StringComparer.Ordinal);
-        Assert.Contains(finding.Evidence!, item => item.StartsWith("canonical_report:absent", StringComparison.Ordinal));
-        Assert.Contains(finding.Evidence!, item => item.StartsWith("expected_artifact:absent", StringComparison.Ordinal));
-        Assert.Contains(finding.Evidence!, item => item.StartsWith("durable_target_entity_transition:absent", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("source_counts:", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("pending-ledger:count=0", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("report-outbox:count=0", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("notification-events:count=0", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("queue-state:count=0", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("continuation-chain:count=0", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("expected-artifact:count=0", StringComparison.Ordinal));
         Assert.Contains(runner.Calls, call =>
             call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wG741:p1"]));
 

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionG748Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionG748Tests.cs
@@ -60,9 +60,13 @@ public sealed class NotifySupervisionG748Tests : IDisposable
         Assert.Contains("task_id:G748-done", finding.Evidence!, StringComparer.Ordinal);
         Assert.Contains("seat 'role=implementation;workspace=wG748;pane=wG748:p2'", finding.Summary, StringComparison.Ordinal);
         Assert.Contains("300s execution-start window", finding.Summary, StringComparison.Ordinal);
-        Assert.Contains("Canonical report absent", finding.Summary, StringComparison.Ordinal);
-        Assert.Contains("expected artifact absent", finding.Summary, StringComparison.Ordinal);
-        Assert.Contains("durable target-entity transition absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("Source-derived execution evidence counts:", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("pending-ledger=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("report-outbox=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("notification-events=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("queue-state=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("continuation-chain=0", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("expected-artifact=0", finding.Summary, StringComparison.Ordinal);
         Assert.Contains("window_seconds:300", finding.Evidence!, StringComparer.Ordinal);
         Assert.Equal(pending.TaskId, NotifyPendingDelegationStore.Find(
             root,

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionG788Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionG788Tests.cs
@@ -1,0 +1,551 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G788: a delivered parent delegation can be visibly executed by recipient
+/// downstream work, a child report, or a queue transition. The true-stall
+/// branch remains deliberately discriminated from those evidence cases.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifySupervisionG788Tests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private readonly string root = Path.Combine(Path.GetTempPath(), $"intent-g788-{Guid.NewGuid():N}");
+    private readonly DateTimeOffset firstNow = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+    private DateTimeOffset now;
+
+    public NotifySupervisionG788Tests()
+    {
+        Directory.CreateDirectory(root);
+        now = firstNow;
+        NotifyCommand.UtcNowFactory = () => now;
+        NotifySupervisor.Delay = _ => { };
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.UtcNowFactory = null;
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.AgmsgScriptsDirectoryFactory = null;
+        NotifyCommand.HerdrExecutableFactory = null;
+        NotifyCommand.BashExecutableFactory = null;
+        NotifySupervisionStore.WriteOverride = null;
+        NotifyPendingDelegationStore.WriteOverride = null;
+        NotifyReportOutboxStore.WriteOverride = null;
+        NotifySupervisor.Delay = Thread.Sleep;
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DiscriminatingPair_TokenCarryingRecipientDownstreamDelegationSuppressesButNoEvidenceFires_G788()
+    {
+        var suppressed = CreateScenario("pair-with-ledger");
+        var child = WriteDownstreamDelegation(suppressed, tokenCarrier: "task-id");
+        var suppressedPass = RunAfterWindow(suppressed);
+
+        Assert.DoesNotContain(suppressedPass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        var suppressedState = NotifySupervisionStore.Read(
+            suppressed.Context.ResolveSupervisionArtifactRootPath(),
+            Domain,
+            Team);
+        Assert.Contains(
+            suppressedState.LastCycle!.DelegationExecutionEvidence!,
+            observation => observation.Contains($"pending-ledger:task_id={child.TaskId}", StringComparison.Ordinal));
+        Assert.Contains(
+            suppressedState.LastCycle.DelegationExecutionEvidence!,
+            observation => observation.Contains("pending-ledger:count=1", StringComparison.Ordinal));
+
+        var fired = CreateScenario("pair-no-evidence");
+        var firedPass = RunAfterWindow(fired);
+        var finding = Assert.Single(firedPass.Findings, item =>
+            item.Kind == "delegation-delivered-never-executed");
+
+        Assert.Equal("delegation-delivered-never-executed:G788-start:g788-parent-nonce", finding.Key);
+        Assert.Equal("design", finding.OwnerRole);
+        Assert.Equal("design", finding.WakeTargetRole);
+        Assert.Null(finding.WakeClass);
+        Assert.Contains("Source-derived execution evidence counts: pending-ledger=0; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0.", finding.Summary, StringComparison.Ordinal);
+        Assert.DoesNotContain("Canonical report absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains(finding.ConsultedObservations!, item =>
+            item.Contains("delegation-execution-evidence: task_id=G788-start; unit=G788", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("task-id")]
+    [InlineData("objective")]
+    [InlineData("input")]
+    public void RecipientDownstreamTokenCanAppearInEveryConfiguredCarrier_G788(string tokenCarrier)
+    {
+        var scenario = CreateScenario($"downstream-{tokenCarrier}");
+        WriteDownstreamDelegation(scenario, tokenCarrier);
+
+        var pass = RunAfterWindow(scenario);
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        Assert.Contains(
+            NotifySupervisionStore.Read(scenario.Context.ResolveSupervisionArtifactRootPath(), Domain, Team)
+                .LastCycle!.DelegationExecutionEvidence!,
+            item => item.Contains("pending-ledger:count=1", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("outbox")]
+    [InlineData("event")]
+    public void ChildReportEvidenceFromOutboxOrNotificationEventSuppressesFinding_G788(string source)
+    {
+        var scenario = CreateScenario($"child-report-{source}");
+        if (source == "outbox")
+        {
+            WriteChildReportOutbox(scenario);
+        }
+        else
+        {
+            WriteChildNotificationEvent(scenario);
+        }
+
+        var pass = RunAfterWindow(scenario);
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        var audit = NotifySupervisionStore.Read(
+            scenario.Context.ResolveSupervisionArtifactRootPath(),
+            Domain,
+            Team).LastCycle!.DelegationExecutionEvidence!;
+        Assert.Contains(audit, item => item.StartsWith($"{(source == "outbox" ? "report-outbox" : "notification-events")}:count=1", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void QueueTransitionAfterDeliverySuppressesFinding_G788()
+    {
+        var scenario = CreateScenario("queue-transition");
+        WriteQueueTransition(scenario);
+
+        var pass = RunAfterWindow(scenario);
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        Assert.Contains(
+            NotifySupervisionStore.Read(scenario.Context.ResolveSupervisionArtifactRootPath(), Domain, Team)
+                .LastCycle!.DelegationExecutionEvidence!,
+            item => item.Contains("queue-state:execution_unit=G788; state=active", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ExistingExactTaskNotificationEventRemainsExecutionEvidence_G788()
+    {
+        var scenario = CreateScenario("existing-exact-event");
+        Assert.True(NotifyEventWriter.TryResolveWritePath(scenario.Root, Domain, Team, out var path, out var error), error);
+        NotifyEventWriter.Append(path, new NotifyDesignEvent
+        {
+            Timestamp = firstNow.AddSeconds(10),
+            Team = Team,
+            Kind = "report",
+            Unit = "G788-start",
+            Summary = "existing direct-task report evidence",
+            Artifact = "https://example.test/direct",
+        });
+
+        var pass = RunAfterWindow(scenario);
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        Assert.Contains(
+            NotifySupervisionStore.Read(scenario.Context.ResolveSupervisionArtifactRootPath(), Domain, Team)
+                .LastCycle!.DelegationExecutionEvidence!,
+            item => item.StartsWith("notification-events:count=1", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TokenlessDownstreamIsInformationalAndDoesNotWake_G788()
+    {
+        var scenario = CreateScenario("tokenless");
+        WriteDownstreamDelegation(scenario, tokenCarrier: "none");
+
+        var pass = RunAfterWindow(scenario);
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        var informational = Assert.Single(pass.Findings, finding =>
+            finding.Kind == "delegation-in-progress-no-direct-report");
+        Assert.Null(informational.WakeClass);
+        Assert.False(informational.WakeAttempted);
+        Assert.False(informational.WakeDelivered);
+        Assert.Contains("no escalation wake class", informational.Summary, StringComparison.Ordinal);
+        Assert.Contains(informational.ConsultedObservations!, item =>
+            item.Contains("tokenless-downstream", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EvidenceArrivingAfterAFirstFindingPreventsReemissionWithoutRetraction_G788()
+    {
+        var scenario = CreateScenario("two-cycle");
+        var firstPass = RunAfterWindow(scenario);
+        Assert.Contains(firstPass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+
+        now = firstNow.AddSeconds(302);
+        WriteDownstreamDelegation(scenario, tokenCarrier: "input", dispatchedAt: now);
+        var secondPass = scenario.Supervisor.RunOnce();
+
+        Assert.DoesNotContain(secondPass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        Assert.Contains(secondPass.RecoveryRecords, record =>
+            record.Kind == "delegation-delivered-never-executed" && record.ClearedAt is not null);
+    }
+
+    [Theory]
+    [InlineData("G779-start", "G779")]
+    [InlineData("design-delegate-SKS-G909-implement-20260902", "SKS-G909")]
+    [InlineData("sks-g909-implementation-20260902", "SKS-G909")]
+    [InlineData("tokenless-task-id", null)]
+    public void ExecutionUnitTokenRuleIsSharedAndCaseInsensitive_G788(string taskId, string? expected)
+    {
+        var pattern = new Regex(@"^(?:[A-Z]+-)?G[0-9]+$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+        var actual = NotifyDelegationExecutionEvidence.ExtractExecutionUnitToken(taskId, pattern);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseDocsCarryTheSameG788Terms_G788()
+    {
+        var repoRoot = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(repoRoot, "docs", "en", "12-agent-message-orchestration.md"));
+        var japanese = File.ReadAllText(Path.Combine(repoRoot, "docs", "ja", "12-agent-message-orchestration.md"));
+        var canonicalTerms = new[]
+        {
+            "G788",
+            "pending-ledger",
+            "report-outbox",
+            "notification-events",
+            "queue-state",
+            "continuation-chain",
+            "expected-artifact",
+            "delegation-in-progress-no-direct-report",
+            "execution-unit token",
+            "Source-derived",
+        };
+
+        foreach (var term in canonicalTerms)
+        {
+            Assert.Contains(term, english, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(term, japanese, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private Scenario CreateScenario(string name)
+    {
+        now = firstNow;
+        var scenarioRoot = Path.Combine(root, name);
+        Directory.CreateDirectory(scenarioRoot);
+        var context = CreateContext(scenarioRoot);
+        RecordHerdrOnlyMode(context);
+        WriteExecutionUnitBinding(scenarioRoot);
+        WriteTopology(scenarioRoot);
+        var pending = WriteDeliveredParentDelegation(scenarioRoot);
+        var runner = new FixtureRunner();
+        return new Scenario
+        {
+            Root = scenarioRoot,
+            Context = context,
+            Pending = pending,
+            Runner = runner,
+            Supervisor = CreateSupervisor(context, scenarioRoot, runner),
+        };
+    }
+
+    private NotifySupervisorPass RunAfterWindow(Scenario scenario)
+    {
+        var baseline = scenario.Supervisor.RunOnce();
+        Assert.DoesNotContain(baseline.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        now = firstNow.AddSeconds(301);
+        return scenario.Supervisor.RunOnce();
+    }
+
+    private NotifyMeasuredSupervisor CreateSupervisor(
+        CliContext context,
+        string scenarioRoot,
+        FixtureRunner runner) => new(
+        context: context,
+        routingRoot: scenarioRoot,
+        domain: Domain,
+        team: Team,
+        repo: null,
+        ownerRole: "design",
+        intervalSeconds: 600,
+        declaredBoundSeconds: null,
+        staleMinutes: 45,
+        claimedSilentMinutes: 720,
+        backlogIdleMinutes: 45,
+        repairSilentMinutes: 180,
+        autoRedispatch: false,
+        write: true,
+        format: "json",
+        runner: runner,
+        herdrExecutable: "fake-herdr",
+        agmsgScriptsDirectory: scenarioRoot,
+        delegationExecutionWindowSeconds: 300);
+
+    private NotifyPendingDelegation WriteDeliveredParentDelegation(string scenarioRoot)
+    {
+        var pending = new NotifyPendingDelegation
+        {
+            Domain = Domain,
+            Team = Team,
+            TaskId = "G788-start",
+            DelegatingRole = "design",
+            RecipientRole = "orchestration",
+            ReportToRole = "design",
+            RecipientIdentity = "role=orchestration;workspace=wG788;pane=wG788:p2",
+            ExpectedArtifact = "expected-artifact.txt",
+            ExpectedArtifacts = ["expected-artifact.txt"],
+            Objective = "coordinate the G788 delegation",
+            Inputs = ["fixture"],
+            ResultNonce = "g788-parent-nonce",
+            DispatchedAt = firstNow.AddSeconds(-1),
+            TransportMode = SessionLayerMode.HerdrOnly,
+            Resident = NotifyRecordedRole.HerdrResident,
+            WorkspaceId = "wG788",
+            PaneId = "wG788:p2",
+            Cwd = Path.Combine(scenarioRoot, "work", "parent"),
+            Kind = "orchestration",
+            LaunchArguments = ["fixture"],
+        };
+        var dispatch = NotifyPendingDelegationStore.WriteDispatch(scenarioRoot, pending);
+        Assert.True(dispatch.Written, dispatch.Error);
+        var delivery = NotifyDelegationDeliveryStore.Write(scenarioRoot, pending, firstNow);
+        Assert.True(delivery.Written, delivery.Error);
+        return pending;
+    }
+
+    private NotifyPendingDelegation WriteDownstreamDelegation(
+        Scenario scenario,
+        string tokenCarrier,
+        DateTimeOffset? dispatchedAt = null)
+    {
+        var taskId = tokenCarrier == "task-id" ? "G788-implementation" : "child-implementation";
+        var objective = tokenCarrier == "objective" ? "implement G788 downstream" : "implement the child work";
+        IReadOnlyList<string> inputs = tokenCarrier == "input" ? ["G788 evidence"] : ["ordinary input"];
+        var child = new NotifyPendingDelegation
+        {
+            Domain = Domain,
+            Team = Team,
+            TaskId = taskId,
+            DelegatingRole = "orchestration",
+            RecipientRole = "implementation",
+            ReportToRole = "orchestration",
+            RecipientIdentity = "role=implementation;workspace=wG788;pane=wG788:p3",
+            ExpectedArtifact = "child-artifact.txt",
+            ExpectedArtifacts = ["child-artifact.txt"],
+            Objective = objective,
+            Inputs = inputs,
+            ResultNonce = $"{tokenCarrier}-child-nonce",
+            DispatchedAt = dispatchedAt ?? firstNow.AddSeconds(10),
+            TransportMode = SessionLayerMode.HerdrOnly,
+            Resident = NotifyRecordedRole.HerdrResident,
+            WorkspaceId = "wG788",
+            PaneId = "wG788:p3",
+            Cwd = Path.Combine(scenario.Root, "work", tokenCarrier),
+            Kind = "implementation",
+            LaunchArguments = ["fixture"],
+        };
+        var dispatch = NotifyPendingDelegationStore.WriteDispatch(scenario.Root, child);
+        Assert.True(dispatch.Written, dispatch.Error);
+        return child;
+    }
+
+    private void WriteChildReportOutbox(Scenario scenario)
+    {
+        var write = NotifyReportOutboxStore.WriteNew(scenario.Root, new NotifyReportOutboxEntry
+        {
+            Domain = Domain,
+            Team = Team,
+            TaskId = "G788-child-report",
+            ResultNonce = "g788-child-report-nonce",
+            FromRole = "implementation",
+            ToRole = "design",
+            Status = "completed",
+            Artifact = "https://example.test/G788-child",
+            Summary = "child report for G788",
+            CreatedAt = firstNow.AddSeconds(10),
+            DeliveryState = "delivered",
+        });
+        Assert.True(write.Written, write.Error);
+    }
+
+    private void WriteChildNotificationEvent(Scenario scenario)
+    {
+        Assert.True(NotifyEventWriter.TryResolveWritePath(scenario.Root, Domain, Team, out var path, out var error), error);
+        NotifyEventWriter.Append(path, new NotifyDesignEvent
+        {
+            Timestamp = firstNow.AddSeconds(10),
+            Team = Team,
+            Kind = "report",
+            Unit = "G788-child-event",
+            Summary = "child report",
+            Artifact = "https://example.test/child",
+        });
+    }
+
+    private void WriteQueueTransition(Scenario scenario)
+    {
+        var item = new QueueItem
+        {
+            ExecutionUnit = "G788",
+            Title = "G788 fixture",
+            State = QueueItemState.Active,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = string.Empty,
+            PacketPaths = new PacketPaths
+            {
+                Yaml = ".intent-cli/issues/G788/packet.yaml",
+                Implementation = ".intent-cli/issues/G788/implementation.md",
+                ReviewContext = ".intent-cli/issues/G788/review-context.md",
+            },
+            WorkerRole = "implementation",
+            ReviewRole = "review",
+            Priority = "high",
+        };
+        var queueState = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = firstNow.AddSeconds(10),
+            Items = [item],
+        };
+        var path = scenario.Context.GetQueueStatePath();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, QueueStateSerializer.Serialize(queueState));
+    }
+
+    private static CliContext CreateContext(string scenarioRoot) => new()
+    {
+        RepoRoot = scenarioRoot,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = Domain, ArtifactRoot = ".intent-cli" },
+        },
+    };
+
+    private static void RecordHerdrOnlyMode(CliContext context)
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            SessionLayerCommand.ExecuteSet(
+                context,
+                ["--domain", Domain, "--team", Team, "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+                writer));
+    }
+
+    private static void WriteExecutionUnitBinding(string scenarioRoot)
+    {
+        var path = Path.Combine(scenarioRoot, "intents", Domain, "automation", "bindings.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "---\nexecution_unit_regex: '^(?:[A-Z]+-)?G[0-9]+$'\n---\n");
+    }
+
+    private static void WriteTopology(string scenarioRoot)
+    {
+        var path = NotifyRoleTopologyStore.ResolvePath(scenarioRoot, Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(new
+            {
+                domain = Domain,
+                team = Team,
+                workspace_id = "wG788",
+                roles = new Dictionary<string, object>
+                {
+                    ["design"] = new { resident = "herdr", workspace_id = "wG788", pane_id = "wG788:p1" },
+                    ["orchestration"] = new { resident = "herdr", workspace_id = "wG788", pane_id = "wG788:p2" },
+                    ["implementation"] = new { resident = "herdr", workspace_id = "wG788", pane_id = "wG788:p3" },
+                },
+            }));
+    }
+
+    private sealed record Scenario
+    {
+        public required string Root { get; init; }
+        public required CliContext Context { get; init; }
+        public required NotifyPendingDelegation Pending { get; init; }
+        public required FixtureRunner Runner { get; init; }
+        public required NotifyMeasuredSupervisor Supervisor { get; init; }
+    }
+
+    private sealed class FixtureRunner : INotifyProcessRunner
+    {
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            if (arguments.SequenceEqual(["agent", "list"]))
+            {
+                return new NotifyProcessResult(0, AgentsJson(), string.Empty);
+            }
+
+            if (arguments.Count >= 2
+                && arguments[0] == "pane"
+                && arguments[1] == "process-info")
+            {
+                return new NotifyProcessResult(0, "{\"result\":{\"process_info\":{\"foreground_processes\":[]}}}", string.Empty);
+            }
+
+            if (arguments.Count >= 2
+                && arguments[0] == "agent"
+                && arguments[1] is "prompt" or "wait")
+            {
+                return new NotifyProcessResult(0, string.Empty, string.Empty);
+            }
+
+            return new NotifyProcessResult(0, string.Empty, string.Empty);
+        }
+
+        private static string AgentsJson()
+        {
+            static object Agent(string role, string pane, string status, long sequence) => new
+            {
+                name = role,
+                workspace_id = "wG788",
+                pane_id = pane,
+                agent = "fixture",
+                agent_session = new { id = role },
+                agent_status = status,
+                agent_running = true,
+                interactive_ready = true,
+                state_change_seq = sequence,
+                last_state_change_at = "2026-09-03T12:00:00.0000000+00:00",
+            };
+
+            return JsonSerializer.Serialize(new
+            {
+                result = new
+                {
+                    agents = new[]
+                    {
+                        Agent("design", "wG788:p1", "working", 1),
+                        Agent("orchestration", "wG788:p2", "idle", 7),
+                        Agent("implementation", "wG788:p3", "working", 8),
+                    },
+                },
+            });
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionG788Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionG788Tests.cs
@@ -102,18 +102,50 @@ public sealed class NotifySupervisionG788Tests : IDisposable
     }
 
     [Theory]
-    [InlineData("outbox")]
-    [InlineData("event")]
-    public void ChildReportEvidenceFromOutboxOrNotificationEventSuppressesFinding_G788(string source)
+    [InlineData("objective")]
+    [InlineData("input")]
+    public void DeliveredParentTokenFromObjectiveOrInputMatchesRecipientDownstream_G788(string parentTokenCarrier)
     {
-        var scenario = CreateScenario($"child-report-{source}");
+        var scenario = CreateScenario(
+            $"parent-{parentTokenCarrier}-fallback",
+            parentTaskId: "parent-start",
+            parentObjective: parentTokenCarrier == "objective"
+                ? "coordinate execution unit G788"
+                : "coordinate the child delegation",
+            parentInputs: parentTokenCarrier == "input" ? ["G788 fixture input"] : ["ordinary input"]);
+        var child = WriteDownstreamDelegation(scenario, tokenCarrier: "task-id");
+
+        var pass = RunAfterWindow(scenario);
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        var audit = NotifySupervisionStore.Read(
+            scenario.Context.ResolveSupervisionArtifactRootPath(),
+            Domain,
+            Team).LastCycle!.DelegationExecutionEvidence!;
+        Assert.Contains(audit, item => item.Contains("task_id=parent-start; unit=G788", StringComparison.Ordinal));
+        Assert.Contains(audit, item => item.Contains($"pending-ledger:task_id={child.TaskId}", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("outbox", "task-id")]
+    [InlineData("outbox", "summary")]
+    [InlineData("outbox", "artifact")]
+    [InlineData("event", "task-id")]
+    [InlineData("event", "summary")]
+    [InlineData("event", "artifact")]
+    public void ChildReportEvidenceFromEveryConfiguredCarrierSuppressesFinding_G788(
+        string source,
+        string tokenCarrier)
+    {
+        var scenario = CreateScenario($"child-report-{source}-{tokenCarrier}");
         if (source == "outbox")
         {
-            WriteChildReportOutbox(scenario);
+            WriteChildReportOutbox(scenario, tokenCarrier);
         }
         else
         {
-            WriteChildNotificationEvent(scenario);
+            WriteChildNotificationEvent(scenario, tokenCarrier);
         }
 
         var pass = RunAfterWindow(scenario);
@@ -125,6 +157,44 @@ public sealed class NotifySupervisionG788Tests : IDisposable
             Domain,
             Team).LastCycle!.DelegationExecutionEvidence!;
         Assert.Contains(audit, item => item.StartsWith($"{(source == "outbox" ? "report-outbox" : "notification-events")}:count=1", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("delegation")]
+    [InlineData("outbox")]
+    [InlineData("event")]
+    public void EarlierDifferentUnitInChildCarrierDoesNotSuppressTrueStall_G788(string source)
+    {
+        var scenario = CreateScenario($"earlier-different-unit-{source}");
+        switch (source)
+        {
+            case "delegation":
+                WriteDownstreamDelegation(scenario, tokenCarrier: "earlier-different-unit");
+                break;
+            case "outbox":
+                WriteChildReportOutbox(scenario, tokenCarrier: "earlier-different-unit");
+                break;
+            default:
+                WriteChildNotificationEvent(scenario, tokenCarrier: "earlier-different-unit");
+                break;
+        }
+
+        var pass = RunAfterWindow(scenario);
+
+        var finding = Assert.Single(pass.Findings, item =>
+            item.Kind == "delegation-delivered-never-executed");
+        Assert.Contains(
+            "pending-ledger=0; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0.",
+            finding.Summary,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(pass.Findings, item =>
+            item.Kind == "delegation-in-progress-no-direct-report");
+        Assert.Contains(
+            NotifySupervisionStore.Read(scenario.Context.ResolveSupervisionArtifactRootPath(), Domain, Team)
+                .LastCycle!.DelegationExecutionEvidence!,
+            item => item.StartsWith(
+                $"{(source == "delegation" ? "pending-ledger" : source == "outbox" ? "report-outbox" : "notification-events")}:count=0",
+                StringComparison.Ordinal));
     }
 
     [Fact]
@@ -207,15 +277,27 @@ public sealed class NotifySupervisionG788Tests : IDisposable
     }
 
     [Theory]
-    [InlineData("G779-start", "G779")]
-    [InlineData("design-delegate-SKS-G909-implement-20260902", "SKS-G909")]
-    [InlineData("sks-g909-implementation-20260902", "SKS-G909")]
-    [InlineData("tokenless-task-id", null)]
-    public void ExecutionUnitTokenRuleIsSharedAndCaseInsensitive_G788(string taskId, string? expected)
+    [InlineData("G779-start", null, null, "G779")]
+    [InlineData("design-delegate-SKS-G909-implement-20260902", null, null, "SKS-G909")]
+    [InlineData("sks-g909-implementation-20260902", null, null, "SKS-G909")]
+    [InlineData("tokenless-task-id", null, null, null)]
+    [InlineData("parent-start", "coordinate G788 downstream", "ordinary input", "G788")]
+    [InlineData("parent-start", "coordinate ordinary work", "G788 input", "G788")]
+    [InlineData("G789-parent", "coordinate G788 downstream", "G788 input", "G789")]
+    [InlineData("parent-start", "implement G789 before G788 downstream", "G788 input", "G789")]
+    public void ExecutionUnitTokenRuleIsOrderedAndCaseInsensitive_G788(
+        string taskId,
+        string? objective,
+        string? input,
+        string? expected)
     {
         var pattern = new Regex(@"^(?:[A-Z]+-)?G[0-9]+$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
-        var actual = NotifyDelegationExecutionEvidence.ExtractExecutionUnitToken(taskId, pattern);
+        var actual = NotifyDelegationExecutionEvidence.ExtractExecutionUnitToken(
+            taskId,
+            objective,
+            input is null ? null : [input],
+            pattern);
 
         Assert.Equal(expected, actual);
     }
@@ -247,7 +329,11 @@ public sealed class NotifySupervisionG788Tests : IDisposable
         }
     }
 
-    private Scenario CreateScenario(string name)
+    private Scenario CreateScenario(
+        string name,
+        string parentTaskId = "G788-start",
+        string? parentObjective = null,
+        IReadOnlyList<string>? parentInputs = null)
     {
         now = firstNow;
         var scenarioRoot = Path.Combine(root, name);
@@ -256,7 +342,11 @@ public sealed class NotifySupervisionG788Tests : IDisposable
         RecordHerdrOnlyMode(context);
         WriteExecutionUnitBinding(scenarioRoot);
         WriteTopology(scenarioRoot);
-        var pending = WriteDeliveredParentDelegation(scenarioRoot);
+        var pending = WriteDeliveredParentDelegation(
+            scenarioRoot,
+            parentTaskId,
+            parentObjective,
+            parentInputs);
         var runner = new FixtureRunner();
         return new Scenario
         {
@@ -301,21 +391,25 @@ public sealed class NotifySupervisionG788Tests : IDisposable
         agmsgScriptsDirectory: scenarioRoot,
         delegationExecutionWindowSeconds: 300);
 
-    private NotifyPendingDelegation WriteDeliveredParentDelegation(string scenarioRoot)
+    private NotifyPendingDelegation WriteDeliveredParentDelegation(
+        string scenarioRoot,
+        string taskId,
+        string? objective,
+        IReadOnlyList<string>? inputs)
     {
         var pending = new NotifyPendingDelegation
         {
             Domain = Domain,
             Team = Team,
-            TaskId = "G788-start",
+            TaskId = taskId,
             DelegatingRole = "design",
             RecipientRole = "orchestration",
             ReportToRole = "design",
             RecipientIdentity = "role=orchestration;workspace=wG788;pane=wG788:p2",
             ExpectedArtifact = "expected-artifact.txt",
             ExpectedArtifacts = ["expected-artifact.txt"],
-            Objective = "coordinate the G788 delegation",
-            Inputs = ["fixture"],
+            Objective = objective ?? "coordinate the G788 delegation",
+            Inputs = inputs ?? ["fixture"],
             ResultNonce = "g788-parent-nonce",
             DispatchedAt = firstNow.AddSeconds(-1),
             TransportMode = SessionLayerMode.HerdrOnly,
@@ -339,7 +433,11 @@ public sealed class NotifySupervisionG788Tests : IDisposable
         DateTimeOffset? dispatchedAt = null)
     {
         var taskId = tokenCarrier == "task-id" ? "G788-implementation" : "child-implementation";
-        var objective = tokenCarrier == "objective" ? "implement G788 downstream" : "implement the child work";
+        var objective = tokenCarrier == "objective"
+            ? "implement G788 downstream"
+            : tokenCarrier == "earlier-different-unit"
+                ? "implement G789 before G788 downstream"
+                : "implement the child work";
         IReadOnlyList<string> inputs = tokenCarrier == "input" ? ["G788 evidence"] : ["ordinary input"];
         var child = new NotifyPendingDelegation
         {
@@ -369,36 +467,54 @@ public sealed class NotifySupervisionG788Tests : IDisposable
         return child;
     }
 
-    private void WriteChildReportOutbox(Scenario scenario)
+    private void WriteChildReportOutbox(Scenario scenario, string tokenCarrier = "task-id")
     {
+        var taskId = tokenCarrier == "task-id" ? "G788-child-report" : "child-report";
+        var summary = tokenCarrier == "summary"
+            ? "child report for G788"
+            : tokenCarrier == "earlier-different-unit"
+                ? "child report for G789 before G788"
+                : "child report";
+        var artifact = tokenCarrier == "artifact"
+            ? "https://example.test/G788-child"
+            : "https://example.test/child";
         var write = NotifyReportOutboxStore.WriteNew(scenario.Root, new NotifyReportOutboxEntry
         {
             Domain = Domain,
             Team = Team,
-            TaskId = "G788-child-report",
+            TaskId = taskId,
             ResultNonce = "g788-child-report-nonce",
             FromRole = "implementation",
             ToRole = "design",
             Status = "completed",
-            Artifact = "https://example.test/G788-child",
-            Summary = "child report for G788",
+            Artifact = artifact,
+            Summary = summary,
             CreatedAt = firstNow.AddSeconds(10),
             DeliveryState = "delivered",
         });
         Assert.True(write.Written, write.Error);
     }
 
-    private void WriteChildNotificationEvent(Scenario scenario)
+    private void WriteChildNotificationEvent(Scenario scenario, string tokenCarrier = "task-id")
     {
+        var unit = tokenCarrier == "task-id" ? "G788-child-event" : "child-event";
+        var summary = tokenCarrier == "summary"
+            ? "child report for G788"
+            : tokenCarrier == "earlier-different-unit"
+                ? "child report for G789 before G788"
+                : "child report";
+        var artifact = tokenCarrier == "artifact"
+            ? "https://example.test/G788-child"
+            : "https://example.test/child";
         Assert.True(NotifyEventWriter.TryResolveWritePath(scenario.Root, Domain, Team, out var path, out var error), error);
         NotifyEventWriter.Append(path, new NotifyDesignEvent
         {
             Timestamp = firstNow.AddSeconds(10),
             Team = Team,
             Kind = "report",
-            Unit = "G788-child-event",
-            Summary = "child report",
-            Artifact = "https://example.test/child",
+            Unit = unit,
+            Summary = summary,
+            Artifact = artifact,
         });
     }
 


### PR DESCRIPTION
Closes #1722

## G788 implementation

Head: `90cf178fe51dc51a7478e898627b0c0d3b20bcd7` (base `f4b01c25`).

This keeps the G741 detector observation-only and emission-policy behavior,
while resolving six durable sources under one configured, case-insensitive
execution-unit token rule:

- `pending-ledger`, `report-outbox`, `notification-events`, `queue-state`,
  `continuation-chain`, and `expected-artifact`;
- recipient-issued, post-delivery downstream delegation suppresses the finding
  only when its task/objective/input carries the delivered unit token;
- child reports from any role and post-delivery queue progress suppress it;
- tokenless downstream work produces the informational,
  no-wake `delegation-in-progress-no-direct-report` tier;
- no-evidence results retain the existing finding key/routing and now report
  source-derived counts. Existing exact-task event, expected-artifact, and
  continuation evidence are preserved.

Both EN and JA `12-agent-message-orchestration.md` mirrors document the six
sources, token rule, informational tier, and `Source-derived` summary shape.

## Actual host-root fixture outputs

All runs used the Release head’s `notify supervise --once --write` against
isolated host-root fixtures with a recorded idle recipient. The selected JSON
below is literal command output (the selection command is shown so no expected
values are substituted for observed output).

### Required discriminating pair

No evidence, second cycle:

```json
{
  "findings": [
    {
      "key": "delegation-delivered-never-executed:G788-start:g788-parent-nonce",
      "kind": "delegation-delivered-never-executed",
      "summary": "Delegation task 'G788-start' was delivered to seat 'role=orchestration;workspace=wG788;pane=wG788:p2' at '2026-08-01T12:00:00.0000000+00:00', but the recipient is idle after the configured 300s execution-start window. Source-derived execution evidence counts: pending-ledger=0; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0. Checked sources: pending-ledger:/tmp/g788-evidence/pair-no-evidence/.intent-cli/notify/intent-cli/intent-cli-dev/pending.jsonl; report-outbox:/tmp/g788-evidence/pair-no-evidence/.intent-cli/notify/intent-cli/intent-cli-dev/report-outbox.jsonl; notification-events:/tmp/g788-evidence/pair-no-evidence/.intent-cli/events/intent-cli-dev.jsonl; queue-state:/tmp/g788-evidence/pair-no-evidence/.intent-cli/queue-state.json; continuation-chain:/tmp/g788-evidence/pair-no-evidence/.intent-cli/continuation-chains/intent-cli/intent-cli-dev/chains.jsonl; expected-artifact:/tmp/g788-evidence/base/work/parent/expected-artifact.txt. This observation is observation-only; it sends no keys, answers no dialog, and restarts no seat; the finding routes to the delegation owner role."
    }
  ],
  "recovery_records": [
    {
      "kind": "delegation-delivered-never-executed",
      "key": "delegation-delivered-never-executed:G788-start:g788-parent-nonce",
      "cleared_at": null,
      "repeat_count": 1
    }
  ]
}
```

Otherwise-identical fixture with recipient `orchestration` issuing the
post-delivery `G788-implementation` delegation:

```json
{
  "silent": true,
  "findings": [],
  "recovery_records": [],
  "cycle_evidence": 0
}
```

The persisted second-cycle audit from that same output is:

```json
{
  "delegation_execution_evidence": [
    "delegation-execution-evidence: task_id=G788-start; unit=G788; pending-ledger=1; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0",
    "pending-ledger:count=1; source=/tmp/g788-evidence/pair-ledger/.intent-cli/notify/intent-cli/intent-cli-dev/pending.jsonl",
    "pending-ledger:task_id=G788-implementation; delegating_role=orchestration; dispatched_at=2026-08-01T12:05:00.0000000+00:00; source=/tmp/g788-evidence/pair-ledger/.intent-cli/notify/intent-cli/intent-cli-dev/pending.jsonl"
  ]
}
```

### Child-report and queue evidence

Each second-cycle command response had `"findings": []`; the corresponding
persisted cycle outputs were:

```text
child-outbox:
delegation-execution-evidence: task_id=G788-start; unit=G788; pending-ledger=0; report-outbox=1; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0
report-outbox:task_id=G788-child-report; from_role=implementation; created_at=2026-08-01T12:05:00.0000000+00:00; source=/tmp/g788-evidence/child-outbox/.intent-cli/notify/intent-cli/intent-cli-dev/report-outbox.jsonl

child-event:
delegation-execution-evidence: task_id=G788-start; unit=G788; pending-ledger=0; report-outbox=0; notification-events=1; queue-state=0; continuation-chain=0; expected-artifact=0
notification-events:unit=G788-child-event; kind=report; timestamp=2026-08-01T12:05:00.0000000+00:00; source=/tmp/g788-evidence/child-event/.intent-cli/events/intent-cli/intent-cli-dev.jsonl

queue-transition:
delegation-execution-evidence: task_id=G788-start; unit=G788; pending-ledger=0; report-outbox=0; notification-events=0; queue-state=1; continuation-chain=0; expected-artifact=0
queue-state:execution_unit=G788; state=active; linked_pr=<none>; updated_at=2026-08-01T12:05:00.0000000+00:00; source=/tmp/g788-evidence/queue-transition/.intent-cli/queue-state.json
```

### Informational tier and no re-emission

The tokenless downstream fixture’s second-cycle output:

```json
{
  "kind": "delegation-in-progress-no-direct-report",
  "key": "delegation-in-progress-no-direct-report:G788-start:g788-parent-nonce",
  "wake_attempted": false,
  "wake_delivered": false,
  "wake_class": null,
  "summary": "Delegation task 'G788-start' has downstream activity from recipient seat 'role=orchestration;workspace=wG788;pane=wG788:p2' after delivery, but no downstream task id, objective, or input carries execution-unit token 'G788'. This is informational and has no escalation wake class. Source-derived execution evidence counts: pending-ledger=0; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0. Checked sources: pending-ledger:/tmp/g788-evidence/informational/.intent-cli/notify/intent-cli/intent-cli-dev/pending.jsonl; report-outbox:/tmp/g788-evidence/informational/.intent-cli/notify/intent-cli/intent-cli-dev/report-outbox.jsonl; notification-events:/tmp/g788-evidence/informational/.intent-cli/events/intent-cli-dev.jsonl; queue-state:/tmp/g788-evidence/informational/.intent-cli/queue-state.json; continuation-chain:/tmp/g788-evidence/informational/.intent-cli/continuation-chains/intent-cli/intent-cli-dev/chains.jsonl; expected-artifact:/tmp/g788-evidence/base/work/parent/expected-artifact.txt."
}
```

For the two-cycle case, cycle 2 emitted the existing key and cycle 3, after a
token-carrying child delegation appeared, produced this literal selected output:

```json
{
  "findings": [],
  "recovery_records": [
    {
      "kind": "delegation-delivered-never-executed",
      "key": "delegation-delivered-never-executed:G788-start:g788-parent-nonce",
      "cleared_at": "2026-09-03T00:03:51.696704+00:00",
      "repeat_count": 1
    }
  ]
}
```

This is clearance/no re-emission only; no retraction mechanism was added.

### Shared token table (actual output)

```jsonl
{"input":"G779-start","token":"G779"}
{"input":"design-delegate-SKS-G909-implement-20260902","token":"SKS-G909"}
{"input":"sks-g909-implementation-20260902","token":"SKS-G909"}
{"input":"tokenless-task-id","token":null}
```

## Parent proof for every new G788 test

The new `NotifySupervisionG788Tests.cs` file contains the 15 table-expanded
cases for the pair, all three downstream carriers, both child-report sources,
queue, existing direct event preservation, informational tier, two-cycle
behavior, all four token rows, and EN/JA parity. On parent `f4b01c25`, the
whole new fixture class is absent; this is the actual command output:

**Criterion 8 — Each new test demonstrated failing or absent on the parent commit, actual output pasted.**

```text
$ git show f4b01c25:tests/IntentSystem.Cli.Tests/NotifySupervisionG788Tests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/NotifySupervisionG788Tests.cs' exists on disk, but not in 'f4b01c25'
```

## Validation

**Criterion 9 — Docs (both mirrors of 12): the six sources, the token rule, the informational tier, the summary shape; full Release suite passes with actual counts pasted.**

```text
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter 'FullyQualifiedName~NotifySupervisionG741Tests|FullyQualifiedName~NotifySupervisionG788Tests'
Passed!  - Failed:     0, Passed:    23, Skipped:     0, Total:    23

$ dotnet test IntentSystem.sln --configuration Release --no-restore
Passed!  - Failed:     0, Passed:  5601, Skipped:     1, Total:  5602 - IntentSystem.Cli.Tests.dll
Solution aggregate: Passed 5931, Skipped 1, Total 5932.
```

## Exact-head CI

Observed green for exact head `90cf178fe51dc51a7478e898627b0c0d3b20bcd7`:

```text
Build and test (source contract)       PASS  (2m44s)
npm package dry-run (no publish)       PASS  (1m40s)
GitHub Actions run 33698209439         PASS
```
