### PR TITLE
G789: render Orca setup and mixed-kind review-seat guidance

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -326,6 +326,41 @@ or manages the command.
 > orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}
 > ```
 
+> **Non-normative Orca operating order (G789).** Before any seat message,
+> create or bind the Run, share its identifier, and have each sender provide
+> its own handle in this order:
+>
+> ```text
+> orca orchestration run-create --objective <text> [--from <handle>]
+> orca orchestration run-use --id <run-id> [--from <handle>]
+> ```
+>
+> 1. Use exactly one of the create-or-bind forms, then share the resulting
+>    `<run-id>` with every sender before anyone addresses `run:<run-id>`.
+> 2. Each sender supplies its own `--from <role>` handle. Use the declared
+>    wake send form unchanged, then use the bounded check:
+>
+>    ```text
+>    orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}
+>    orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json
+>    ```
+>
+> The same Orca channel carries herdr seats' courtesy wakes and
+> design-to-design messages. Neither is durable workflow evidence: canonical
+> `intent-cli notify` remains the durable record. This is non-normative setup
+> only; intent-cli adds no option and neither launches nor manages Orca.
+
+**Mixed-kind review-seat selection (G789).** The recorded topology fields
+decide: use `kind` for a herdr seat and `frontend` for an external seat; do
+not infer a kind from role name, model, residence, or co-location. When those
+recorded kinds differ, the review seat with a different recorded
+kind/frontend from design reviews design output as well as PRs. When all
+recorded kinds are the same, design↔orchestration cross-review is acceptable;
+the review seat still reviews PRs. `guide design-thread` renders this under
+`team_and_duty_split.review_seat_selection`, and `guide review` renders the
+same topology-specific rule under `review_standing_policy` when one recorded
+team is unambiguous.
+
 ### Role-contract precedence (G672 — preview-through-1.x)
 
 When `guide next` or `guide onboarding` is invoked with `--role`, the role's

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -293,6 +293,38 @@ operator が渡した text を render するだけで、shell を起動して実
 > orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}
 > ```
 
+> **非規範的な Orca の操作順序（G789）。** seat message の前に Run を create または
+> 接続し、id を共有し、各 sender が自身の handle を与えます。順序は次のとおりです。
+>
+> ```text
+> orca orchestration run-create --objective <text> [--from <handle>]
+> orca orchestration run-use --id <run-id> [--from <handle>]
+> ```
+>
+> 1. create-or-bind form のどちらか一つを使い、誰かが `run:<run-id>` を宛先にする前に、
+>    得られた `<run-id>` を全 sender と共有します。
+> 2. 各 sender は自身の `--from <role>` handle を渡します。宣言済みの wake send form を
+>    変更せずに使い、続けて bounded check を行います。
+>
+>    ```text
+>    orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}
+>    orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json
+>    ```
+>
+> 同じ Orca channel が herdr seat の courtesy wake と design-to-design message を運びます。
+> どちらも永続的な workflow evidence ではありません。canonical な `intent-cli notify` が
+> 永続的な記録のままです。これは非規範的な setup だけであり、intent-cli は option を
+> 追加せず、Orca を起動も管理もしません。
+
+**mixed-kind review-seat selection（G789）。** recorded topology field が決定します。herdr
+seat には `kind`、external seat には `frontend` を使い、role name、model、residence、
+co-location から kind を推測しません。recorded kind が異なるときは、design と異なる
+recorded kind/frontend を持つ review seat が design output と PR の両方を査読します。
+すべての recorded kind が同じなら、design↔orchestration の cross-review は許容され、
+review seat は引き続き PR を査読します。`guide design-thread` はこれを
+`team_and_duty_split.review_seat_selection` に、記録済み team が一意なら `guide review` は
+同じ topology-specific rule を `review_standing_policy` に表示します。
+
 ### role contract の precedence（G672 — preview-through-1.x）
 
 `guide next` または `guide onboarding` を `--role` 付きで呼ぶと、contract を持つ role の

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -71,9 +71,7 @@ internal static class GuideDesignThreadCommand
             team,
             routingRoot,
             topology is null ? null : ReviewSeatSelectionGuidanceResolver.Create(topology),
-            topology is not null && ReviewSeatSelectionGuidanceResolver.IsExternalDesign(topology)
-                ? CreateOrcaOperatingBlock()
-                : null);
+            CreateOrcaOperatingBlock());
         if (string.Equals(format, "json", StringComparison.Ordinal))
         {
             writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
@@ -93,6 +91,12 @@ internal static class GuideDesignThreadCommand
         ReviewSeatSelectionGuidance? reviewSeatSelection = null,
         DesignThreadOrcaOperatingBlock? orcaOperatingBlock = null)
     {
+        // G789: the static rule and non-normative Orca operating block are
+        // always reachable. Readable topology only enriches the rule with
+        // recorded team/kind-specific resolution; it must never gate the
+        // baseline guidance.
+        reviewSeatSelection ??= ReviewSeatSelectionGuidanceResolver.CreateStatic();
+        orcaOperatingBlock ??= CreateOrcaOperatingBlock();
         var root = string.IsNullOrWhiteSpace(routingRoot) ? "<routing-root>" : routingRoot!;
         var domainArg = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain.Trim();
         var teamArg = string.IsNullOrWhiteSpace(team) ? "<team>" : team.Trim();
@@ -308,8 +312,11 @@ internal static class GuideDesignThreadCommand
             writer.WriteLine("- **review-seat selection (G789):** " + reviewSeatSelection.MixedKindRule);
             writer.WriteLine("  - " + reviewSeatSelection.SingleKindAllowance);
             writer.WriteLine("  - " + reviewSeatSelection.RecordedFieldsDecide);
-            writer.WriteLine("  - recorded topology: " + string.Join(", ", reviewSeatSelection.RecordedSeatKinds));
-            writer.WriteLine("  - selection: " + reviewSeatSelection.Selection);
+            if (reviewSeatSelection.RecordedSeatKinds is { } recordedSeatKinds)
+            {
+                writer.WriteLine("  - recorded topology: " + string.Join(", ", recordedSeatKinds));
+                writer.WriteLine("  - selection: " + reviewSeatSelection.Selection);
+            }
         }
         writer.WriteLine($"- {result.Monitoring.Separation}");
         writer.WriteLine($"- {result.Monitoring.ResidualDesignCheck}");

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -13,6 +13,8 @@ namespace IntentSystem.Cli.Commands;
 internal static class GuideDesignThreadCommand
 {
     public const string CommandName = "intent-cli guide design-thread";
+    internal const string OrcaWakeSendForm = "orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}";
+    internal const string OrcaCheckForm = "orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json";
     private const string UsageLine =
         "Usage: intent-cli guide design-thread [--domain <name>] [--team <team>] [--routing-root <path>] [--format markdown|json]";
 
@@ -63,7 +65,15 @@ internal static class GuideDesignThreadCommand
             return 1;
         }
 
-        var result = BuildResult(domain, team, routingRoot);
+        var topology = ReviewSeatSelectionGuidanceResolver.ResolveTopology(routingRoot ?? string.Empty, domain, team);
+        var result = BuildResult(
+            domain,
+            team,
+            routingRoot,
+            topology is null ? null : ReviewSeatSelectionGuidanceResolver.Create(topology),
+            topology is not null && ReviewSeatSelectionGuidanceResolver.IsExternalDesign(topology)
+                ? CreateOrcaOperatingBlock()
+                : null);
         if (string.Equals(format, "json", StringComparison.Ordinal))
         {
             writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
@@ -76,7 +86,12 @@ internal static class GuideDesignThreadCommand
         return 0;
     }
 
-    internal static DesignThreadGuideResult BuildResult(string? domain, string? team, string? routingRoot)
+    internal static DesignThreadGuideResult BuildResult(
+        string? domain,
+        string? team,
+        string? routingRoot,
+        ReviewSeatSelectionGuidance? reviewSeatSelection = null,
+        DesignThreadOrcaOperatingBlock? orcaOperatingBlock = null)
     {
         var root = string.IsNullOrWhiteSpace(routingRoot) ? "<routing-root>" : routingRoot!;
         var domainArg = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain.Trim();
@@ -156,6 +171,7 @@ internal static class GuideDesignThreadCommand
                 OrchestrationOwnership = "Orchestration owns detection, classification, and authorized recovery for every stall class, including review wedges.",
                 DesignMode = "Design is event-driven and receives only the agreed escalation set.",
                 DesignEscalations = DesignEscalations,
+                ReviewSeatSelection = reviewSeatSelection,
             },
             Monitoring = new DesignThreadMonitoring
             {
@@ -201,13 +217,29 @@ internal static class GuideDesignThreadCommand
                 RoutingRootMust = "Routing-root MUST: every notify send and receive uses the canonical routing root. A wrong root strands notify records outside canonical state while the sender still returns `delivered: true`.",
                 CollectLoop = $"Collect loop: `intent-cli notify collect --domain {domainArg} --team {teamArg} --role design --since <cursor> --wait --timeout-ms <timeout-ms> --routing-root {root} --format json`; the caller holds the cursor, consumes the returned next cursor, and omits `--since` only for the first receive.",
                 WakeChannelPattern = "Wake-channel pattern: canonical `intent-cli notify` is the durable record; a wake channel is a courtesy-only signal; dual-send is the practiced form. Bind durable wake addresses before reading and never substitute a terminal-only address for a durable bound address.",
-                WakeChannelDeclaration = $"Declared external wake: an operator may record one literal one-line `--wake-command` template on an external role, for example `orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {{task_id}} --body {{summary}}`. On an existing external role, set or clear that label only with `intent-cli session-layer topology update-field --domain {domainArg} --team {teamArg} --role <role> --field wake_command --current <value|absent> --new <value|absent> --confirm-update-field --write --format json`. `notify delegate` renders `{{task_id}}` and `{{summary}}` only as text, leaves unknown placeholders untouched, and never executes, validates, health-checks, launches, or manages the command. The canonical notify write always comes first; the rendered declared wake is courtesy-only and never substitutes for that durable record.",
-                OrcaWorkedExample = "Non-normative Orca example: bind the design coordinator terminal before reading with `orca orchestration run-use --id <run-id>`, then use the blocking check `orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json`. Orca is only a courtesy wake receiver alongside canonical `intent-cli notify`; intent-cli neither launches nor manages Orca.",
+                WakeChannelDeclaration = $"Declared external wake: an operator may record one literal one-line `--wake-command` template on an external role, for example `{OrcaWakeSendForm}`. On an existing external role, set or clear that label only with `intent-cli session-layer topology update-field --domain {domainArg} --team {teamArg} --role <role> --field wake_command --current <value|absent> --new <value|absent> --confirm-update-field --write --format json`. `notify delegate` renders `{{task_id}}` and `{{summary}}` only as text, leaves unknown placeholders untouched, and never executes, validates, health-checks, launches, or manages the command. The canonical notify write always comes first; the rendered declared wake is courtesy-only and never substitutes for that durable record.",
+                OrcaWorkedExample = $"Non-normative Orca example: bind the design coordinator terminal before reading with `orca orchestration run-use --id <run-id>`, then use the blocking check `{OrcaCheckForm}`. Orca is only a courtesy wake receiver alongside canonical `intent-cli notify`; intent-cli neither launches nor manages Orca.",
+                OrcaOperatingBlock = orcaOperatingBlock,
                 ResidenceTransition = $"A herdr↔external residence change is a different operation from an external-to-external frontend relabel: `intent-cli session-layer topology update-residence --domain {domainArg} --team {teamArg} --role design --current-resident <herdr|external> --new-resident <herdr|external> [destination fields] --confirm-update-residence --write --format json`.",
             },
             UnreadableRepairResponse = "When liveness reports a non-zero `unreadable_record_count`, the sanctioned response is `intent-cli notify supervise repair-unreadable`: run `--dry-run` first, inspect the evidence, and use `--write` only second; it is never automatic and never performed on read. The repair quarantines unreadable lines verbatim as evidence and makes no reconstruction claim.",
         };
     }
+
+    private static DesignThreadOrcaOperatingBlock CreateOrcaOperatingBlock() => new()
+    {
+        Label = "Non-normative Orca operating block",
+        SetupOrder =
+        [
+            "Create or bind a Run before seat messages: `orca orchestration run-create --objective <text> [--from <handle>]` or `orca orchestration run-use --id <run-id> [--from <handle>]`.",
+            "Share the resulting `<run-id>` with every sender before anyone addresses `run:<run-id>`.",
+            "Each sender supplies its own `--from <role>` handle; it is a sender handle, not a routing identity.",
+        ],
+        SendForm = OrcaWakeSendForm,
+        CheckForm = OrcaCheckForm,
+        SharedChannel = "The same Orca channel carries herdr seats' courtesy wakes and design-to-design messages; neither replaces the canonical notify record.",
+        DurableRecord = "Canonical `intent-cli notify` remains durable. This non-normative block adds no intent-cli option, and intent-cli neither launches nor manages Orca.",
+    };
 
     private static void WriteMarkdown(TextWriter writer, DesignThreadGuideResult result)
     {
@@ -271,6 +303,14 @@ internal static class GuideDesignThreadCommand
         writer.WriteLine($"- {result.TeamAndDutySplit.OrchestrationOwnership}");
         writer.WriteLine($"- {result.TeamAndDutySplit.DesignMode}");
         foreach (var item in result.TeamAndDutySplit.DesignEscalations) writer.WriteLine($"  - {item}");
+        if (result.TeamAndDutySplit.ReviewSeatSelection is { } reviewSeatSelection)
+        {
+            writer.WriteLine("- **review-seat selection (G789):** " + reviewSeatSelection.MixedKindRule);
+            writer.WriteLine("  - " + reviewSeatSelection.SingleKindAllowance);
+            writer.WriteLine("  - " + reviewSeatSelection.RecordedFieldsDecide);
+            writer.WriteLine("  - recorded topology: " + string.Join(", ", reviewSeatSelection.RecordedSeatKinds));
+            writer.WriteLine("  - selection: " + reviewSeatSelection.Selection);
+        }
         writer.WriteLine($"- {result.Monitoring.Separation}");
         writer.WriteLine($"- {result.Monitoring.ResidualDesignCheck}");
         writer.WriteLine($"- **unreadable-record response (G777):** {result.UnreadableRepairResponse}");
@@ -298,6 +338,15 @@ internal static class GuideDesignThreadCommand
         writer.WriteLine($"- **wake channel:** {result.ExternalResidenceOperatingContract.WakeChannelPattern}");
         writer.WriteLine($"- **declared wake:** {result.ExternalResidenceOperatingContract.WakeChannelDeclaration}");
         writer.WriteLine($"- **worked example:** {result.ExternalResidenceOperatingContract.OrcaWorkedExample}");
+        if (result.ExternalResidenceOperatingContract.OrcaOperatingBlock is { } orcaOperatingBlock)
+        {
+            writer.WriteLine($"- **{orcaOperatingBlock.Label}:**");
+            foreach (var step in orcaOperatingBlock.SetupOrder) writer.WriteLine($"  - {step}");
+            writer.WriteLine($"  - send: `{orcaOperatingBlock.SendForm}`");
+            writer.WriteLine($"  - check: `{orcaOperatingBlock.CheckForm}`");
+            writer.WriteLine($"  - {orcaOperatingBlock.SharedChannel}");
+            writer.WriteLine($"  - {orcaOperatingBlock.DurableRecord}");
+        }
         writer.WriteLine($"- **different transition:** {result.ExternalResidenceOperatingContract.ResidenceTransition}");
         WriteList(writer, "## Negative invariants", result.NegativeInvariants);
     }
@@ -408,7 +457,17 @@ internal sealed record DesignThreadObservationBoundary
     public required string FallbackRoute { get; init; }
     public required string KeystrokeBoundary { get; init; }
 }
-internal sealed record DesignThreadTeamAndDutySplit { public required string Formula { get; init; } public required string MonitoringRule { get; init; } public required string OrchestrationOwnership { get; init; } public required string DesignMode { get; init; } public required IReadOnlyList<string> DesignEscalations { get; init; } }
+internal sealed record DesignThreadTeamAndDutySplit
+{
+    public required string Formula { get; init; }
+    public required string MonitoringRule { get; init; }
+    public required string OrchestrationOwnership { get; init; }
+    public required string DesignMode { get; init; }
+    public required IReadOnlyList<string> DesignEscalations { get; init; }
+    [JsonPropertyName("review_seat_selection")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ReviewSeatSelectionGuidance? ReviewSeatSelection { get; init; }
+}
 internal sealed record DesignThreadMonitoring { public required string Separation { get; init; } public required string ResidualDesignCheck { get; init; } public required string BoundRule { get; init; } public required string GuideRefreshRule { get; init; } public required string DeploymentRule { get; init; } }
 internal sealed record DesignThreadReporting { public required string Rule { get; init; } public required string HumanActionRule { get; init; } }
 internal sealed record DesignThreadPacketAuthoringCheck
@@ -430,5 +489,18 @@ internal sealed record DesignThreadExternalResidenceOperatingContract
     public required string WakeChannelPattern { get; init; }
     public required string WakeChannelDeclaration { get; init; }
     public required string OrcaWorkedExample { get; init; }
+    [JsonPropertyName("orca_operating_block")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DesignThreadOrcaOperatingBlock? OrcaOperatingBlock { get; init; }
     public required string ResidenceTransition { get; init; }
+}
+
+internal sealed record DesignThreadOrcaOperatingBlock
+{
+    public required string Label { get; init; }
+    public required IReadOnlyList<string> SetupOrder { get; init; }
+    public required string SendForm { get; init; }
+    public required string CheckForm { get; init; }
+    public required string SharedChannel { get; init; }
+    public required string DurableRecord { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
@@ -744,7 +744,8 @@ internal static class GuideReviewCommand
                 if (reviewSeatSelection.RecordedSeatKinds is { } recordedSeatKinds)
                 {
                     writer.WriteLine($"- recorded topology ({reviewSeatSelection.TopologyTeam}): {string.Join(", ", recordedSeatKinds)}");
-                    writer.WriteLine($"- design: {reviewSeatSelection.DesignSeat}; review: {reviewSeatSelection.ReviewSeat}; selected review seat: {reviewSeatSelection.SelectedReviewSeat}");
+                    var selectedReviewSeat = reviewSeatSelection.SelectedReviewSeat ?? "unresolved";
+                    writer.WriteLine($"- design: {reviewSeatSelection.DesignSeat}; review: {reviewSeatSelection.ReviewSeat}; selected review seat: {selectedReviewSeat}");
                     writer.WriteLine($"- selection: {reviewSeatSelection.Selection}");
                 }
             }

--- a/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
@@ -252,11 +252,12 @@ internal static class GuideReviewCommand
         // G451: resolve the domain standing-policy registry (optional file,
         // safe defaults when absent/invalid). Fail-closed and read-only.
         var standingPolicy = ReviewStandingPolicyRegistry.Resolve(context, domain);
-        var reviewSeatSelection = ReviewSeatSelectionGuidanceResolver.ResolveUniqueTeam(context.RepoRoot, domain);
-        if (reviewSeatSelection is not null)
-        {
-            standingPolicy = standingPolicy with { ReviewSeatSelection = reviewSeatSelection };
-        }
+        // G789: keep the static review-seat rule reachable even when there is
+        // no readable, uniquely identifiable topology. A readable topology
+        // only enriches that rule with the recorded team/kind resolution.
+        var reviewSeatSelection = ReviewSeatSelectionGuidanceResolver.ResolveUniqueTeam(context.RepoRoot, domain)
+            ?? ReviewSeatSelectionGuidanceResolver.CreateStatic();
+        standingPolicy = standingPolicy with { ReviewSeatSelection = reviewSeatSelection };
 
         var queueStatePath = context.GetQueueStatePath();
         var gaps = new List<string>();
@@ -740,9 +741,12 @@ internal static class GuideReviewCommand
                 writer.WriteLine($"- {reviewSeatSelection.MixedKindRule}");
                 writer.WriteLine($"- {reviewSeatSelection.SingleKindAllowance}");
                 writer.WriteLine($"- {reviewSeatSelection.RecordedFieldsDecide}");
-                writer.WriteLine($"- recorded topology ({reviewSeatSelection.TopologyTeam}): {string.Join(", ", reviewSeatSelection.RecordedSeatKinds)}");
-                writer.WriteLine($"- design: {reviewSeatSelection.DesignSeat}; review: {reviewSeatSelection.ReviewSeat}; selected review seat: {reviewSeatSelection.SelectedReviewSeat}");
-                writer.WriteLine($"- selection: {reviewSeatSelection.Selection}");
+                if (reviewSeatSelection.RecordedSeatKinds is { } recordedSeatKinds)
+                {
+                    writer.WriteLine($"- recorded topology ({reviewSeatSelection.TopologyTeam}): {string.Join(", ", recordedSeatKinds)}");
+                    writer.WriteLine($"- design: {reviewSeatSelection.DesignSeat}; review: {reviewSeatSelection.ReviewSeat}; selected review seat: {reviewSeatSelection.SelectedReviewSeat}");
+                    writer.WriteLine($"- selection: {reviewSeatSelection.Selection}");
+                }
             }
             writer.WriteLine();
         }

--- a/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
@@ -252,6 +252,11 @@ internal static class GuideReviewCommand
         // G451: resolve the domain standing-policy registry (optional file,
         // safe defaults when absent/invalid). Fail-closed and read-only.
         var standingPolicy = ReviewStandingPolicyRegistry.Resolve(context, domain);
+        var reviewSeatSelection = ReviewSeatSelectionGuidanceResolver.ResolveUniqueTeam(context.RepoRoot, domain);
+        if (reviewSeatSelection is not null)
+        {
+            standingPolicy = standingPolicy with { ReviewSeatSelection = reviewSeatSelection };
+        }
 
         var queueStatePath = context.GetQueueStatePath();
         var gaps = new List<string>();
@@ -729,6 +734,16 @@ internal static class GuideReviewCommand
             WritePolicySection(writer, "External artifact intake", policy.ExternalArtifactIntake.Rules);
             WritePolicySection(writer, "Test-evidence sufficiency", policy.TestEvidenceSufficiency.Rules);
             WritePolicySection(writer, "Follow-up tracking", policy.FollowUpTracking.Rules);
+            if (policy.ReviewSeatSelection is { } reviewSeatSelection)
+            {
+                writer.WriteLine("### Review-seat selection (G789)");
+                writer.WriteLine($"- {reviewSeatSelection.MixedKindRule}");
+                writer.WriteLine($"- {reviewSeatSelection.SingleKindAllowance}");
+                writer.WriteLine($"- {reviewSeatSelection.RecordedFieldsDecide}");
+                writer.WriteLine($"- recorded topology ({reviewSeatSelection.TopologyTeam}): {string.Join(", ", reviewSeatSelection.RecordedSeatKinds)}");
+                writer.WriteLine($"- design: {reviewSeatSelection.DesignSeat}; review: {reviewSeatSelection.ReviewSeat}; selected review seat: {reviewSeatSelection.SelectedReviewSeat}");
+                writer.WriteLine($"- selection: {reviewSeatSelection.Selection}");
+            }
             writer.WriteLine();
         }
 

--- a/src/IntentSystem.Cli/Commands/ReviewSeatSelectionGuidance.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewSeatSelectionGuidance.cs
@@ -1,0 +1,200 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G789: renders the review-seat rule from recorded topology only. The
+/// resident-specific record fields are deliberately the sole input: herdr
+/// seats contribute <c>kind</c>, while external seats contribute
+/// <c>frontend</c>. Role names, models, and co-location never infer a kind.
+/// </summary>
+internal sealed record ReviewSeatSelectionGuidance
+{
+    [JsonPropertyName("mixed_kind_rule")]
+    public required string MixedKindRule { get; init; }
+
+    [JsonPropertyName("single_kind_allowance")]
+    public required string SingleKindAllowance { get; init; }
+
+    [JsonPropertyName("recorded_fields_decide")]
+    public required string RecordedFieldsDecide { get; init; }
+
+    [JsonPropertyName("topology_team")]
+    public required string TopologyTeam { get; init; }
+
+    [JsonPropertyName("recorded_seat_kinds")]
+    public required IReadOnlyList<string> RecordedSeatKinds { get; init; }
+
+    [JsonPropertyName("design_seat")]
+    public required string DesignSeat { get; init; }
+
+    [JsonPropertyName("review_seat")]
+    public required string ReviewSeat { get; init; }
+
+    [JsonPropertyName("selected_review_seat")]
+    public required string SelectedReviewSeat { get; init; }
+
+    [JsonPropertyName("selection")]
+    public required string Selection { get; init; }
+}
+
+internal static class ReviewSeatSelectionGuidanceResolver
+{
+    private const string DesignRole = "design";
+    private const string ReviewRole = "review";
+
+    public static ReviewSeatSelectionGuidance? Resolve(
+        string routingRoot,
+        string? domain,
+        string? team)
+    {
+        var topology = ResolveTopology(routingRoot, domain, team);
+        return topology is null ? null : Create(topology);
+    }
+
+    public static NotifyTeamTopology? ResolveTopology(
+        string routingRoot,
+        string? domain,
+        string? team)
+    {
+        if (string.IsNullOrWhiteSpace(routingRoot)
+            || string.IsNullOrWhiteSpace(domain)
+            || string.IsNullOrWhiteSpace(team))
+        {
+            return null;
+        }
+
+        var resolution = NotifyRoleTopologyStore.Resolve(routingRoot, domain.Trim(), team.Trim());
+        return resolution.Resolved ? resolution.Topology : null;
+    }
+
+    /// <summary>
+    /// Guide review intentionally has no team argument. It can render the
+    /// topology-specific rule only when exactly one recorded team exists for
+    /// the selected domain; otherwise it leaves the existing standing policy
+    /// unchanged rather than guessing a team.
+    /// </summary>
+    public static ReviewSeatSelectionGuidance? ResolveUniqueTeam(string routingRoot, string? domain)
+    {
+        if (string.IsNullOrWhiteSpace(routingRoot) || string.IsNullOrWhiteSpace(domain))
+        {
+            return null;
+        }
+
+        var directory = Path.Combine(
+            routingRoot,
+            NotifyRoleTopologyStore.TopologyDirectoryRelativePath.Replace('/', Path.DirectorySeparatorChar),
+            domain.Trim());
+        if (!Directory.Exists(directory))
+        {
+            return null;
+        }
+
+        var candidates = Directory
+            .EnumerateFiles(directory, "*.json", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        if (candidates.Length != 1)
+        {
+            return null;
+        }
+
+        var team = Path.GetFileNameWithoutExtension(candidates[0]);
+        return Resolve(routingRoot, domain, team);
+    }
+
+    public static ReviewSeatSelectionGuidance? Create(NotifyTeamTopology topology)
+    {
+        if (!TryGetRecordedKind(topology, DesignRole, out var design)
+            || !TryGetRecordedKind(topology, ReviewRole, out var review))
+        {
+            return null;
+        }
+
+        var seats = topology.Roles
+            .OrderBy(pair => SeatOrder(pair.Key))
+            .ThenBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => TryGetRecordedKind(topology, pair.Key, out var seat) ? seat.Display : null)
+            .Where(value => value is not null)
+            .Cast<string>()
+            .ToArray();
+        if (seats.Length == 0)
+        {
+            return null;
+        }
+
+        var recordedKinds = topology.Roles
+            .Select(pair => TryGetRecordedKind(topology, pair.Key, out var seat) ? seat.Identity : null)
+            .Where(value => value is not null)
+            .Cast<string>()
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var mixedKinds = recordedKinds.Length > 1;
+        var reviewDiffersFromDesign = !string.Equals(
+            design.Identity,
+            review.Identity,
+            StringComparison.OrdinalIgnoreCase);
+        var selection = mixedKinds
+            ? reviewDiffersFromDesign
+                ? "Mixed recorded kinds: review has a different recorded kind/frontend from design, so review reviews design output and PRs."
+                : "Mixed recorded kinds: review does not have a different recorded kind/frontend from design; select a recorded different-kind review seat before it reviews design output, while review still reviews PRs."
+            : "Single recorded kind: design↔orchestration cross-review is acceptable; review continues to review PRs.";
+
+        return new ReviewSeatSelectionGuidance
+        {
+            MixedKindRule = "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
+            SingleKindAllowance = "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
+            RecordedFieldsDecide = "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.",
+            TopologyTeam = topology.Team,
+            RecordedSeatKinds = seats,
+            DesignSeat = design.Display,
+            ReviewSeat = review.Display,
+            SelectedReviewSeat = ReviewRole,
+            Selection = selection,
+        };
+    }
+
+    public static bool IsExternalDesign(NotifyTeamTopology topology) =>
+        topology.Roles.TryGetValue(DesignRole, out var design)
+        && string.Equals(design.Resident, NotifyRecordedRole.ExternalResident, StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryGetRecordedKind(
+        NotifyTeamTopology topology,
+        string role,
+        out RecordedSeatKind seat)
+    {
+        seat = default;
+        if (!topology.Roles.TryGetValue(role, out var recorded))
+        {
+            return false;
+        }
+
+        var value = string.Equals(recorded.Resident, NotifyRecordedRole.HerdrResident, StringComparison.OrdinalIgnoreCase)
+            ? recorded.Kind
+            : string.Equals(recorded.Resident, NotifyRecordedRole.ExternalResident, StringComparison.OrdinalIgnoreCase)
+                ? recorded.Frontend
+                : null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var field = string.Equals(recorded.Resident, NotifyRecordedRole.HerdrResident, StringComparison.OrdinalIgnoreCase)
+            ? "kind"
+            : "frontend";
+        var normalized = value.Trim();
+        seat = new RecordedSeatKind(normalized, $"{role} ({field}:{normalized})");
+        return true;
+    }
+
+    private static int SeatOrder(string role) => role switch
+    {
+        DesignRole => 0,
+        "implementation" => 1,
+        "orchestration" => 2,
+        ReviewRole => 3,
+        _ => 4,
+    };
+
+    private readonly record struct RecordedSeatKind(string Identity, string Display);
+}

--- a/src/IntentSystem.Cli/Commands/ReviewSeatSelectionGuidance.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewSeatSelectionGuidance.cs
@@ -3,10 +3,11 @@ using System.Text.Json.Serialization;
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G789: renders the review-seat rule from recorded topology only. The
-/// resident-specific record fields are deliberately the sole input: herdr
-/// seats contribute <c>kind</c>, while external seats contribute
-/// <c>frontend</c>. Role names, models, and co-location never infer a kind.
+/// G789: renders the static review-seat rule on every guide surface. The
+/// resident-specific record fields are deliberately the sole input for the
+/// optional topology resolution: herdr seats contribute <c>kind</c>, while
+/// external seats contribute <c>frontend</c>. Role names, models, and
+/// co-location never infer a kind.
 /// </summary>
 internal sealed record ReviewSeatSelectionGuidance
 {
@@ -20,22 +21,28 @@ internal sealed record ReviewSeatSelectionGuidance
     public required string RecordedFieldsDecide { get; init; }
 
     [JsonPropertyName("topology_team")]
-    public required string TopologyTeam { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TopologyTeam { get; init; }
 
     [JsonPropertyName("recorded_seat_kinds")]
-    public required IReadOnlyList<string> RecordedSeatKinds { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? RecordedSeatKinds { get; init; }
 
     [JsonPropertyName("design_seat")]
-    public required string DesignSeat { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DesignSeat { get; init; }
 
     [JsonPropertyName("review_seat")]
-    public required string ReviewSeat { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReviewSeat { get; init; }
 
     [JsonPropertyName("selected_review_seat")]
-    public required string SelectedReviewSeat { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SelectedReviewSeat { get; init; }
 
     [JsonPropertyName("selection")]
-    public required string Selection { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Selection { get; init; }
 }
 
 internal static class ReviewSeatSelectionGuidanceResolver
@@ -51,6 +58,13 @@ internal static class ReviewSeatSelectionGuidanceResolver
         var topology = ResolveTopology(routingRoot, domain, team);
         return topology is null ? null : Create(topology);
     }
+
+    public static ReviewSeatSelectionGuidance CreateStatic() => new()
+    {
+        MixedKindRule = "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
+        SingleKindAllowance = "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
+        RecordedFieldsDecide = "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.",
+    };
 
     public static NotifyTeamTopology? ResolveTopology(
         string routingRoot,
@@ -85,15 +99,26 @@ internal static class ReviewSeatSelectionGuidanceResolver
             routingRoot,
             NotifyRoleTopologyStore.TopologyDirectoryRelativePath.Replace('/', Path.DirectorySeparatorChar),
             domain.Trim());
-        if (!Directory.Exists(directory))
+        string[] candidates;
+        try
         {
+            if (!Directory.Exists(directory))
+            {
+                return null;
+            }
+
+            candidates = Directory
+                .EnumerateFiles(directory, "*.json", SearchOption.TopDirectoryOnly)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // A directory that cannot be inspected is just as unsuitable for
+            // topology-specific selection as a malformed record. Callers keep
+            // the static rule and never guess a team.
             return null;
         }
-
-        var candidates = Directory
-            .EnumerateFiles(directory, "*.json", SearchOption.TopDirectoryOnly)
-            .OrderBy(path => path, StringComparer.Ordinal)
-            .ToArray();
         if (candidates.Length != 1)
         {
             return null;
@@ -140,11 +165,8 @@ internal static class ReviewSeatSelectionGuidanceResolver
                 : "Mixed recorded kinds: review does not have a different recorded kind/frontend from design; select a recorded different-kind review seat before it reviews design output, while review still reviews PRs."
             : "Single recorded kind: design↔orchestration cross-review is acceptable; review continues to review PRs.";
 
-        return new ReviewSeatSelectionGuidance
+        return CreateStatic() with
         {
-            MixedKindRule = "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
-            SingleKindAllowance = "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
-            RecordedFieldsDecide = "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.",
             TopologyTeam = topology.Team,
             RecordedSeatKinds = seats,
             DesignSeat = design.Display,

--- a/src/IntentSystem.Cli/Commands/ReviewSeatSelectionGuidance.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewSeatSelectionGuidance.cs
@@ -162,7 +162,7 @@ internal static class ReviewSeatSelectionGuidanceResolver
         var selection = mixedKinds
             ? reviewDiffersFromDesign
                 ? "Mixed recorded kinds: review has a different recorded kind/frontend from design, so review reviews design output and PRs."
-                : "Mixed recorded kinds: review does not have a different recorded kind/frontend from design; select a recorded different-kind review seat before it reviews design output, while review still reviews PRs."
+                : "Mixed recorded kinds: review does not have a different recorded kind/frontend from design; no distinct-kind review seat is resolved for design output. Select a recorded different-kind review seat before it reviews design output, while review still reviews PRs."
             : "Single recorded kind: design↔orchestration cross-review is acceptable; review continues to review PRs.";
 
         return CreateStatic() with
@@ -171,7 +171,7 @@ internal static class ReviewSeatSelectionGuidanceResolver
             RecordedSeatKinds = seats,
             DesignSeat = design.Display,
             ReviewSeat = review.Display,
-            SelectedReviewSeat = ReviewRole,
+            SelectedReviewSeat = mixedKinds && !reviewDiffersFromDesign ? null : ReviewRole,
             Selection = selection,
         };
     }

--- a/src/IntentSystem.Cli/Commands/ReviewStandingPolicy.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewStandingPolicy.cs
@@ -45,6 +45,15 @@ internal sealed record ReviewStandingPolicy
     public required ReviewPolicySection FollowUpTracking { get; init; }
 
     /// <summary>
+    /// G789: topology-specific review-seat selection is rendered only when a
+    /// single readable recorded team is available for the requested domain.
+    /// Omitting it preserves the pre-G789 standing-policy payload exactly.
+    /// </summary>
+    [JsonPropertyName("review_seat_selection")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ReviewSeatSelectionGuidance? ReviewSeatSelection { get; init; }
+
+    /// <summary>
     /// G451: the safe built-in default policy. Reproduces the prior G445
     /// device-gated evidence rules verbatim plus conservative defaults for the
     /// other recurring decisions, so a host with no policy file keeps today's

--- a/src/IntentSystem.Cli/Commands/ReviewStandingPolicy.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewStandingPolicy.cs
@@ -45,9 +45,9 @@ internal sealed record ReviewStandingPolicy
     public required ReviewPolicySection FollowUpTracking { get; init; }
 
     /// <summary>
-    /// G789: topology-specific review-seat selection is rendered only when a
-    /// single readable recorded team is available for the requested domain.
-    /// Omitting it preserves the pre-G789 standing-policy payload exactly.
+    /// G789: the static review-seat rule is always rendered. A single readable
+    /// recorded team may enrich it with the topology-specific resolution;
+    /// missing, unreadable, or ambiguous topology leaves those fields absent.
     /// </summary>
     [JsonPropertyName("review_seat_selection")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
@@ -37,13 +37,16 @@ public sealed class GuideDesignThreadG654Tests
     // order. Only the separately asserted packet_authoring_check block may
     // differ; changing any parent value, nesting, or field order changes this
     // oracle rather than weakening a full-payload assertion.
-    private const string ParentPayloadOracleHash = "c43e27f362c39d9c737fc2269b1979bdf8ad9b7ecb07f3dd0491ba1325d0c54f";
+    // G789 adds the always-reachable static review-seat rule inside the
+    // existing team_and_duty_split object, so the parent hash includes that
+    // additive nested payload.
+    private const string ParentPayloadOracleHash = "0af4402fa1b72909c2b79712b1a25f3bf1af08aa16d534b8632d510bf8c05082";
     private static readonly string[] G774BaselinePayloadFieldNames =
         ParentPayloadFieldNames.Append("packet_authoring_check").ToArray();
-    private const string G774BaselinePayloadOracleHash = "8110a6150605810aaa609fc2c34668341b939e58bc0dc35085c7290e6c72b136";
+    private const string G774BaselinePayloadOracleHash = "a559d7abddaee47e05fc688e811e7edbc0bb8bde54b486c4e32334c53f058592";
     // G776 may append exactly one declaration field. The existing G775
     // operating-contract fields remain a raw-value and rendered-order oracle.
-    private const string G775ExternalResidenceContractOracleHash = "1c297f028c3e8ea5e1901b84ff962e542d864aa1139130ea9c1092539789cbe4";
+    private const string G775ExternalResidenceContractOracleHash = "01c68d8acd2aa420a7597838ef4ac85ed7ba72797ae820030405be9c16cbbf5a";
 
     [Theory]
     [InlineData("agmsg", false)]
@@ -204,6 +207,7 @@ public sealed class GuideDesignThreadG654Tests
                 "wake_channel_pattern",
                 "wake_channel_declaration",
                 "orca_worked_example",
+                "orca_operating_block",
                 "residence_transition",
             },
             contract.EnumerateObject().Select(field => field.Name));
@@ -220,6 +224,7 @@ public sealed class GuideDesignThreadG654Tests
                 "collect_loop",
                 "wake_channel_pattern",
                 "orca_worked_example",
+                "orca_operating_block",
                 "residence_transition",
             },
             g775Fields.Select(field => field.Name));

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG654Tests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
@@ -37,16 +38,16 @@ public sealed class GuideDesignThreadG654Tests
     // order. Only the separately asserted packet_authoring_check block may
     // differ; changing any parent value, nesting, or field order changes this
     // oracle rather than weakening a full-payload assertion.
-    // G789 adds the always-reachable static review-seat rule inside the
-    // existing team_and_duty_split object, so the parent hash includes that
-    // additive nested payload.
-    private const string ParentPayloadOracleHash = "0af4402fa1b72909c2b79712b1a25f3bf1af08aa16d534b8632d510bf8c05082";
+    // G789 is additive: these immutable hashes remain the parent values from
+    // cfdacb4a657d9a60ab82fea3faa435ff732f389f after the new nested keys are
+    // removed from the rendered head.
+    private const string ParentPayloadOracleHash = "c43e27f362c39d9c737fc2269b1979bdf8ad9b7ecb07f3dd0491ba1325d0c54f";
     private static readonly string[] G774BaselinePayloadFieldNames =
         ParentPayloadFieldNames.Append("packet_authoring_check").ToArray();
-    private const string G774BaselinePayloadOracleHash = "a559d7abddaee47e05fc688e811e7edbc0bb8bde54b486c4e32334c53f058592";
+    private const string G774BaselinePayloadOracleHash = "8110a6150605810aaa609fc2c34668341b939e58bc0dc35085c7290e6c72b136";
     // G776 may append exactly one declaration field. The existing G775
     // operating-contract fields remain a raw-value and rendered-order oracle.
-    private const string G775ExternalResidenceContractOracleHash = "01c68d8acd2aa420a7597838ef4ac85ed7ba72797ae820030405be9c16cbbf5a";
+    private const string G775ExternalResidenceContractOracleHash = "1c297f028c3e8ea5e1901b84ff962e542d864aa1139130ea9c1092539789cbe4";
 
     [Theory]
     [InlineData("agmsg", false)]
@@ -132,8 +133,10 @@ public sealed class GuideDesignThreadG654Tests
         using var document = JsonDocument.Parse(writer.ToString());
         var root = document.RootElement;
         var fields = root.EnumerateObject().ToArray();
+        using var projected = JsonDocument.Parse(RemoveG789Additions(root));
+        var projectedFields = projected.RootElement.EnumerateObject().ToArray();
 
-        var g774BaselineFields = fields
+        var g774BaselineFields = projectedFields
             .Where(field => field.Name is not "external_residence_operating_contract" and not "unreadable_repair_response")
             .ToArray();
         Assert.Equal(G774BaselinePayloadFieldNames, g774BaselineFields.Select(field => field.Name));
@@ -141,10 +144,11 @@ public sealed class GuideDesignThreadG654Tests
         Assert.True(
             string.Equals(G774BaselinePayloadOracleHash, g774BaselineOracle, StringComparison.Ordinal),
             $"G774 baseline payload oracle changed. Expected '{G774BaselinePayloadOracleHash}', actual '{g774BaselineOracle}'.");
-        var parentPayloadOracle = ComputePayloadOracle(fields.Where(field => field.Name is not "packet_authoring_check" and not "external_residence_operating_contract" and not "unreadable_repair_response"));
+        var parentPayloadOracle = ComputePayloadOracle(projectedFields.Where(field => field.Name is not "packet_authoring_check" and not "external_residence_operating_contract" and not "unreadable_repair_response"));
         Assert.True(
             string.Equals(ParentPayloadOracleHash, parentPayloadOracle, StringComparison.Ordinal),
             $"G654 parent payload oracle changed. Expected '{ParentPayloadOracleHash}', actual '{parentPayloadOracle}'.");
+        Console.WriteLine($"G789 guide design-thread parent remainder oracle: expected={ParentPayloadOracleHash}; actual={parentPayloadOracle}; removed=team_and_duty_split.review_seat_selection,external_residence_operating_contract.orca_operating_block");
 
         var check = root.GetProperty("packet_authoring_check");
         Assert.Equal(
@@ -185,8 +189,10 @@ public sealed class GuideDesignThreadG654Tests
         using var document = JsonDocument.Parse(writer.ToString());
         var root = document.RootElement;
         var fields = root.EnumerateObject().ToArray();
+        using var projected = JsonDocument.Parse(RemoveG789Additions(root));
+        var projectedFields = projected.RootElement.EnumerateObject().ToArray();
 
-        var g775BaselineFields = fields
+        var g775BaselineFields = projectedFields
             .Where(field => field.Name != "unreadable_repair_response")
             .ToArray();
         Assert.Equal(
@@ -212,7 +218,8 @@ public sealed class GuideDesignThreadG654Tests
             },
             contract.EnumerateObject().Select(field => field.Name));
 
-        var g775Fields = contract
+        var projectedContract = projected.RootElement.GetProperty("external_residence_operating_contract");
+        var g775Fields = projectedContract
             .EnumerateObject()
             .Where(field => field.Name != "wake_channel_declaration")
             .ToArray();
@@ -224,7 +231,6 @@ public sealed class GuideDesignThreadG654Tests
                 "collect_loop",
                 "wake_channel_pattern",
                 "orca_worked_example",
-                "orca_operating_block",
                 "residence_transition",
             },
             g775Fields.Select(field => field.Name));
@@ -232,6 +238,7 @@ public sealed class GuideDesignThreadG654Tests
         Assert.True(
             string.Equals(G775ExternalResidenceContractOracleHash, g775Oracle, StringComparison.Ordinal),
             $"G775 operating-contract oracle changed. Expected '{G775ExternalResidenceContractOracleHash}', actual '{g775Oracle}'.");
+        Console.WriteLine($"G789 guide design-thread G775 remainder oracle: expected={G775ExternalResidenceContractOracleHash}; actual={g775Oracle}; removed=external_residence_operating_contract.orca_operating_block");
 
         var frontendRelabel = contract.GetProperty("frontend_relabel").GetString()!;
         Assert.StartsWith("External-to-external frontend relabel:", frontendRelabel);
@@ -499,6 +506,14 @@ public sealed class GuideDesignThreadG654Tests
             "\u001E",
             fields.Select(field => field.Name + "\u001F" + field.Value.GetRawText()));
         return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+    }
+
+    private static string RemoveG789Additions(JsonElement root)
+    {
+        var projected = JsonNode.Parse(root.GetRawText())!.AsObject();
+        projected["team_and_duty_split"]?.AsObject().Remove("review_seat_selection");
+        projected["external_residence_operating_contract"]?.AsObject().Remove("orca_operating_block");
+        return projected.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
     }
 
     private static CliContext CreateContext() => new()

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG777Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG777Tests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
@@ -39,9 +40,10 @@ public sealed class GuideDesignThreadG777Tests
         "external_residence_operating_contract",
     ];
 
-    // The full G789 payload, including raw G774/G775/G789 blocks, stays
-    // stable when the one G777 sibling is excluded.
-    private const string G776BaselinePayloadOracleHash = "bfb054d9b5ce9006dbae2764d7ed5648e2dfa736054f0532987ebe857f2712b8";
+    // Immutable G776 parent oracle from cfdacb4a657d9a60ab82fea3faa435ff732f389f.
+    // The current head is projected back to that parent by removing only the
+    // G789 nested additions before this hash is computed.
+    private const string G776BaselinePayloadOracleHash = "5ebb02d016c9afec671e58184f993705d0c6e597ecf334239b19d704bfaf3294";
 
     [Fact]
     public void RenderedLivenessGuidance_NamesTheSanctionedDryRunBeforeWriteResponse_G777()
@@ -68,6 +70,8 @@ public sealed class GuideDesignThreadG777Tests
     {
         using var document = JsonDocument.Parse(RenderJson());
         var fields = document.RootElement.EnumerateObject().ToArray();
+        using var projected = JsonDocument.Parse(RemoveG789Additions(document.RootElement));
+        var projectedFields = projected.RootElement.EnumerateObject().ToArray();
 
         Assert.Equal(
             G776BaselinePayloadFieldNames.Append("unreadable_repair_response"),
@@ -76,11 +80,12 @@ public sealed class GuideDesignThreadG777Tests
         var addition = Assert.Single(fields, field => field.Name == "unreadable_repair_response");
         Assert.Contains("repair-unreadable", addition.Value.GetString()!, StringComparison.Ordinal);
 
-        var baseline = fields.Where(field => field.Name != "unreadable_repair_response").ToArray();
+        var baseline = projectedFields.Where(field => field.Name != "unreadable_repair_response").ToArray();
         var actualOracle = ComputePayloadOracle(baseline);
         Assert.True(
             string.Equals(G776BaselinePayloadOracleHash, actualOracle, StringComparison.Ordinal),
             $"G776 sibling baseline changed. Expected '{G776BaselinePayloadOracleHash}', actual '{actualOracle}'.");
+        Console.WriteLine($"G789 guide design-thread G776 remainder oracle: expected={G776BaselinePayloadOracleHash}; actual={actualOracle}; removed=team_and_duty_split.review_seat_selection,external_residence_operating_contract.orca_operating_block");
     }
 
     [Fact]
@@ -149,6 +154,14 @@ public sealed class GuideDesignThreadG777Tests
             "\u001E",
             fields.Select(field => field.Name + "\u001F" + field.Value.GetRawText()));
         return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+    }
+
+    private static string RemoveG789Additions(JsonElement root)
+    {
+        var projected = JsonNode.Parse(root.GetRawText())!.AsObject();
+        projected["team_and_duty_split"]?.AsObject().Remove("review_seat_selection");
+        projected["external_residence_operating_contract"]?.AsObject().Remove("orca_operating_block");
+        return projected.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
     }
 
     private static CliContext CreateContext() => new()

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG777Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG777Tests.cs
@@ -39,9 +39,9 @@ public sealed class GuideDesignThreadG777Tests
         "external_residence_operating_contract",
     ];
 
-    // The full b766f2d0 payload, including raw G774, G775, and G776 blocks,
-    // stays byte-for-byte stable when the one G777 sibling is excluded.
-    private const string G776BaselinePayloadOracleHash = "5ebb02d016c9afec671e58184f993705d0c6e597ecf334239b19d704bfaf3294";
+    // The full G789 payload, including raw G774/G775/G789 blocks, stays
+    // stable when the one G777 sibling is excluded.
+    private const string G776BaselinePayloadOracleHash = "bfb054d9b5ce9006dbae2764d7ed5648e2dfa736054f0532987ebe857f2712b8";
 
     [Fact]
     public void RenderedLivenessGuidance_NamesTheSanctionedDryRunBeforeWriteResponse_G777()

--- a/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
@@ -19,7 +19,9 @@ public sealed class GuideSeatSelectionG789Tests
 {
     private const string Domain = "intent-cli";
     private const string Repo = "J-Tech-Japan/intent-system";
-    private const string ParentGuideReviewPayloadOracleHash = "8e90346d3975ec83b2c450cbd60fdb8ef47a467c759ec8d6fdce6b4f27670e35";
+    // Immutable parent remainder oracle from cfdacb4a657d9a60ab82fea3faa435ff732f389f,
+    // rendered with the deterministic /tmp fixture root used by this test.
+    private const string ParentGuideReviewPayloadOracleHash = "dcc8a884b71ef40c2567bcd6141ded8c035c2f20fc42632e829bd5e2b875ce8c";
     private static readonly string[] ParentGuideReviewPayloadFieldNames =
     [
         "domain",
@@ -183,7 +185,7 @@ public sealed class GuideSeatSelectionG789Tests
     {
         using var fixture = new TopologyFixture(
             "review-oracle",
-            Path.Combine(Path.GetTempPath(), "g789-guide-review-oracle-root"));
+            "/tmp/g789-guide-review-oracle-root");
         fixture.SeedReviewablePr();
 
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
@@ -1,0 +1,310 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G789: topology-backed guide rendering for the non-normative Orca operating
+/// block and the mixed-kind review-seat rule. The fixtures intentionally use
+/// recorded role fields rather than model or role-name inference.
+/// </summary>
+public sealed class GuideSeatSelectionG789Tests
+{
+    private const string Domain = "intent-cli";
+    private const string Repo = "J-Tech-Japan/intent-system";
+
+    [Fact]
+    public void MixedKindTopology_RendersOrderedOrcaBlockAndDifferentKindReviewSeat_G789()
+    {
+        using var fixture = new TopologyFixture("mixed");
+        fixture.RecordExternal("design", "claude-app");
+        fixture.RecordHerdr("implementation", "codex");
+        fixture.RecordHerdr("orchestration", "codex");
+        fixture.RecordHerdr("review", "codex");
+
+        using var jsonWriter = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(
+            fixture.Context,
+            ["--domain", Domain, "--team", fixture.Team, "--routing-root", fixture.Root, "--format", "json"],
+            jsonWriter));
+        using var designDocument = JsonDocument.Parse(jsonWriter.ToString());
+        var contract = designDocument.RootElement.GetProperty("external_residence_operating_contract");
+        var operatingBlock = contract.GetProperty("orca_operating_block");
+        Assert.Equal(
+            ["label", "setup_order", "send_form", "check_form", "shared_channel", "durable_record"],
+            operatingBlock.EnumerateObject().Select(property => property.Name));
+        Assert.Equal(
+            [
+                "Create or bind a Run before seat messages: `orca orchestration run-create --objective <text> [--from <handle>]` or `orca orchestration run-use --id <run-id> [--from <handle>]`.",
+                "Share the resulting `<run-id>` with every sender before anyone addresses `run:<run-id>`.",
+                "Each sender supplies its own `--from <role>` handle; it is a sender handle, not a routing identity.",
+            ],
+            operatingBlock.GetProperty("setup_order").EnumerateArray().Select(item => item.GetString()));
+        Assert.Equal(GuideDesignThreadCommand.OrcaWakeSendForm, operatingBlock.GetProperty("send_form").GetString());
+        Assert.Equal(GuideDesignThreadCommand.OrcaCheckForm, operatingBlock.GetProperty("check_form").GetString());
+        Assert.Contains("courtesy wakes and design-to-design messages", operatingBlock.GetProperty("shared_channel").GetString(), StringComparison.Ordinal);
+        Assert.Contains("neither launches nor manages Orca", operatingBlock.GetProperty("durable_record").GetString(), StringComparison.Ordinal);
+        Assert.Contains(GuideDesignThreadCommand.OrcaWakeSendForm, contract.GetProperty("wake_channel_declaration").GetString(), StringComparison.Ordinal);
+
+        var selection = designDocument.RootElement.GetProperty("team_and_duty_split").GetProperty("review_seat_selection");
+        Assert.Equal(
+            [
+                "design (frontend:claude-app)",
+                "implementation (kind:codex)",
+                "orchestration (kind:codex)",
+                "review (kind:codex)",
+            ],
+            selection.GetProperty("recorded_seat_kinds").EnumerateArray().Select(item => item.GetString()));
+        Assert.Equal("design (frontend:claude-app)", selection.GetProperty("design_seat").GetString());
+        Assert.Equal("review (kind:codex)", selection.GetProperty("review_seat").GetString());
+        Assert.Equal("review", selection.GetProperty("selected_review_seat").GetString());
+        Assert.Contains("different recorded kind/frontend from design", selection.GetProperty("selection").GetString(), StringComparison.Ordinal);
+        Assert.Contains("Only recorded topology fields decide", selection.GetProperty("recorded_fields_decide").GetString(), StringComparison.Ordinal);
+
+        using var markdownWriter = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(
+            fixture.Context,
+            ["--domain", Domain, "--team", fixture.Team, "--routing-root", fixture.Root, "--format", "markdown"],
+            markdownWriter));
+        var markdown = markdownWriter.ToString();
+        var blockStart = markdown.IndexOf("Non-normative Orca operating block", StringComparison.Ordinal);
+        var createIndex = markdown.IndexOf("run-create --objective <text>", blockStart, StringComparison.Ordinal);
+        var bindIndex = markdown.IndexOf("run-use --id <run-id>", blockStart, StringComparison.Ordinal);
+        var shareIndex = markdown.IndexOf("Share the resulting `<run-id>`", blockStart, StringComparison.Ordinal);
+        var senderIndex = markdown.IndexOf("Each sender supplies its own", blockStart, StringComparison.Ordinal);
+        var sendIndex = markdown.IndexOf(GuideDesignThreadCommand.OrcaWakeSendForm, blockStart, StringComparison.Ordinal);
+        var checkIndex = markdown.IndexOf(GuideDesignThreadCommand.OrcaCheckForm, blockStart, StringComparison.Ordinal);
+        Assert.True(blockStart >= 0 && createIndex >= 0 && bindIndex > createIndex && shareIndex > bindIndex && senderIndex > shareIndex && sendIndex > senderIndex && checkIndex > sendIndex, markdown);
+        Assert.Contains("review-seat selection (G789)", markdown, StringComparison.Ordinal);
+
+        Fixture("mixed design-thread Orca block JSON", operatingBlock.GetRawText());
+        Fixture("mixed design-thread review-seat JSON", selection.GetRawText());
+        Fixture("mixed design-thread Markdown Orca block", Section(
+            markdown,
+            "- **Non-normative Orca operating block:**",
+            "- **different transition:**"));
+    }
+
+    [Fact]
+    public void GuideReview_UsesSameMixedKindSelectionFromTheOnlyRecordedTeam_G789()
+    {
+        using var fixture = new TopologyFixture("review-mixed");
+        fixture.RecordExternal("design", "claude-app");
+        fixture.RecordHerdr("implementation", "codex");
+        fixture.RecordHerdr("orchestration", "codex");
+        fixture.RecordHerdr("review", "codex");
+        fixture.SeedReviewablePr();
+
+        using var jsonWriter = new StringWriter();
+        Assert.Equal(0, GuideReviewCommand.Execute(
+            fixture.Context,
+            ["--repo", Repo, "--pr", "1724", "--domain", Domain, "--format", "json"],
+            jsonWriter));
+        using var document = JsonDocument.Parse(jsonWriter.ToString());
+        var selection = document.RootElement
+            .GetProperty("review_standing_policy")
+            .GetProperty("review_seat_selection");
+        Assert.Equal(fixture.Team, selection.GetProperty("topology_team").GetString());
+        Assert.Equal("review", selection.GetProperty("selected_review_seat").GetString());
+        Assert.Contains("reviews design output and PRs", selection.GetProperty("selection").GetString(), StringComparison.Ordinal);
+
+        using var markdownWriter = new StringWriter();
+        Assert.Equal(0, GuideReviewCommand.Execute(
+            fixture.Context,
+            ["--repo", Repo, "--pr", "1724", "--domain", Domain, "--format", "markdown"],
+            markdownWriter));
+        var markdown = markdownWriter.ToString();
+        Assert.Contains("### Review-seat selection (G789)", markdown, StringComparison.Ordinal);
+        Assert.Contains("design (frontend:claude-app)", markdown, StringComparison.Ordinal);
+        Assert.Contains("review (kind:codex)", markdown, StringComparison.Ordinal);
+
+        Fixture("mixed guide review JSON", selection.GetRawText());
+        Fixture("mixed guide review Markdown", Section(
+            markdown,
+            "### Review-seat selection (G789)",
+            "## Review blocker protocol"));
+    }
+
+    [Fact]
+    public void SingleKindTopology_AllowsDesignOrchestrationCrossReview_G789()
+    {
+        using var fixture = new TopologyFixture("single");
+        fixture.RecordHerdr("design", "codex");
+        fixture.RecordHerdr("implementation", "codex");
+        fixture.RecordHerdr("orchestration", "codex");
+        fixture.RecordHerdr("review", "codex");
+        fixture.SeedReviewablePr();
+
+        using var designWriter = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(
+            fixture.Context,
+            ["--domain", Domain, "--team", fixture.Team, "--routing-root", fixture.Root, "--format", "json"],
+            designWriter));
+        using var designDocument = JsonDocument.Parse(designWriter.ToString());
+        var designSelection = designDocument.RootElement
+            .GetProperty("team_and_duty_split")
+            .GetProperty("review_seat_selection");
+        Assert.False(designDocument.RootElement.GetProperty("external_residence_operating_contract").TryGetProperty("orca_operating_block", out _));
+        Assert.Contains("Single recorded kind", designSelection.GetProperty("selection").GetString(), StringComparison.Ordinal);
+        Assert.Contains("design↔orchestration cross-review is acceptable", designSelection.GetProperty("selection").GetString(), StringComparison.Ordinal);
+
+        using var reviewWriter = new StringWriter();
+        Assert.Equal(0, GuideReviewCommand.Execute(
+            fixture.Context,
+            ["--repo", Repo, "--pr", "1724", "--domain", Domain, "--format", "json"],
+            reviewWriter));
+        using var reviewDocument = JsonDocument.Parse(reviewWriter.ToString());
+        var reviewSelection = reviewDocument.RootElement
+            .GetProperty("review_standing_policy")
+            .GetProperty("review_seat_selection");
+        Assert.Equal(designSelection.GetProperty("selection").GetString(), reviewSelection.GetProperty("selection").GetString());
+
+        Fixture("single-kind design-thread JSON", designSelection.GetRawText());
+        Fixture("single-kind guide review JSON", reviewSelection.GetRawText());
+    }
+
+    [Fact]
+    public void DocumentationMirrors_RenderedOrcaOrderAndReviewSeatRule_G789()
+    {
+        var repoRoot = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(repoRoot, "docs", "en", "12-agent-message-orchestration.md"));
+        var japanese = File.ReadAllText(Path.Combine(repoRoot, "docs", "ja", "12-agent-message-orchestration.md"));
+
+        foreach (var document in new[] { english, japanese })
+        {
+            Assert.Contains("run-create --objective <text> [--from <handle>]", document, StringComparison.Ordinal);
+            Assert.Contains("run-use --id <run-id> [--from <handle>]", document, StringComparison.Ordinal);
+            Assert.Contains(GuideDesignThreadCommand.OrcaWakeSendForm, document, StringComparison.Ordinal);
+            Assert.Contains(GuideDesignThreadCommand.OrcaCheckForm, document, StringComparison.Ordinal);
+            Assert.Contains("review_seat_selection", document, StringComparison.Ordinal);
+            Assert.Contains("review_standing_policy", document, StringComparison.Ordinal);
+            Assert.Contains("kind`", document, StringComparison.Ordinal);
+            Assert.Contains("frontend`", document, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("Mixed-kind review-seat selection (G789)", english, StringComparison.Ordinal);
+        Assert.Contains("mixed-kind review-seat selection（G789）", japanese, StringComparison.Ordinal);
+    }
+
+    private static void Fixture(string name, string value) =>
+        Console.WriteLine($"G789 {name}:\n{value.TrimEnd()}");
+
+    private static string Section(string document, string start, string end)
+    {
+        var startIndex = document.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(startIndex >= 0, $"Missing section start '{start}'.");
+        var endIndex = document.IndexOf(end, startIndex, StringComparison.Ordinal);
+        Assert.True(endIndex > startIndex, $"Missing section end '{end}'.");
+        return document[startIndex..endIndex];
+    }
+
+    private sealed class TopologyFixture : IDisposable
+    {
+        public TopologyFixture(string suffix)
+        {
+            Root = Directory.CreateTempSubdirectory($"guide-g789-{suffix}-").FullName;
+            Team = $"g789-{suffix}";
+            Context = new CliContext
+            {
+                RepoRoot = Root,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = Domain,
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        public string Root { get; }
+        public string Team { get; }
+        public CliContext Context { get; }
+
+        public void RecordExternal(string role, string frontend)
+        {
+            var result = Run(
+            [
+                "session-layer", "topology", "record", "--domain", Domain, "--team", Team,
+                "--role", role, "--resident", "external",
+                "--reader", $".intent-cli/events/{Team}-{role}.jsonl", "--frontend", frontend,
+                "--write", "--format", "json",
+            ]);
+            Assert.Equal(0, result.ExitCode);
+        }
+
+        public void RecordHerdr(string role, string kind)
+        {
+            var result = Run(
+            [
+                "session-layer", "topology", "record", "--domain", Domain, "--team", Team,
+                "--role", role, "--resident", "herdr", "--workspace-id", "wG789",
+                "--pane-id", $"wG789:{role}", "--cwd", "/g789", "--kind", kind,
+                "--delivery-method", "inline", "--write", "--format", "json",
+            ]);
+            Assert.Equal(0, result.ExitCode);
+        }
+
+        public void SeedReviewablePr()
+        {
+            var state = new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = new DateTimeOffset(2026, 9, 2, 0, 0, 0, TimeSpan.Zero),
+                Items =
+                [
+                    new QueueItem
+                    {
+                        ExecutionUnit = "G789",
+                        Title = "Orca guide and review-seat selection",
+                        State = QueueItemState.Review,
+                        Dependencies = Array.Empty<string>(),
+                        BlockedBy = Array.Empty<string>(),
+                        ClarificationReturnPath = string.Empty,
+                        PacketPaths = new PacketPaths
+                        {
+                            Yaml = ".intent-cli/issues/G789/packet.yaml",
+                            Implementation = ".intent-cli/issues/G789/implementation.md",
+                            ReviewContext = ".intent-cli/issues/G789/review-context.md",
+                        },
+                        LinkedIssue = new LinkedIssue
+                        {
+                            Repo = Repo,
+                            Number = 1724,
+                            Url = "https://github.com/J-Tech-Japan/intent-system/issues/1724",
+                        },
+                        LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/1724",
+                        WorkerRole = "implementation",
+                        ReviewRole = "review",
+                        Priority = "normal",
+                    },
+                ],
+            };
+            File.WriteAllText(Context.GetQueueStatePath(), QueueStateSerializer.Serialize(state));
+            var packetDirectory = Path.Combine(Root, ".intent-cli", "issues", "G789");
+            Directory.CreateDirectory(packetDirectory);
+            File.WriteAllText(Path.Combine(packetDirectory, "packet.yaml"), "g789: guide-only");
+        }
+
+        private (int ExitCode, string Output) Run(string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, Context, writer);
+            return (exitCode, writer.ToString());
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
@@ -82,6 +82,7 @@ public sealed class GuideSeatSelectionG789Tests
         Assert.Contains("review-seat selection (G789)", markdown, StringComparison.Ordinal);
 
         Fixture("mixed design-thread Orca block JSON", operatingBlock.GetRawText());
+        Fixture("mixed design-thread wake declaration JSON", contract.GetProperty("wake_channel_declaration").GetRawText());
         Fixture("mixed design-thread review-seat JSON", selection.GetRawText());
         Fixture("mixed design-thread Markdown Orca block", Section(
             markdown,

--- a/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
@@ -149,7 +149,7 @@ public sealed class GuideSeatSelectionG789Tests
         var designSelection = designDocument.RootElement
             .GetProperty("team_and_duty_split")
             .GetProperty("review_seat_selection");
-        Assert.False(designDocument.RootElement.GetProperty("external_residence_operating_contract").TryGetProperty("orca_operating_block", out _));
+        Assert.True(designDocument.RootElement.GetProperty("external_residence_operating_contract").TryGetProperty("orca_operating_block", out _));
         Assert.Contains("Single recorded kind", designSelection.GetProperty("selection").GetString(), StringComparison.Ordinal);
         Assert.Contains("design↔orchestration cross-review is acceptable", designSelection.GetProperty("selection").GetString(), StringComparison.Ordinal);
 
@@ -166,6 +166,90 @@ public sealed class GuideSeatSelectionG789Tests
 
         Fixture("single-kind design-thread JSON", designSelection.GetRawText());
         Fixture("single-kind guide review JSON", reviewSelection.GetRawText());
+    }
+
+    [Theory]
+    [InlineData("missing")]
+    [InlineData("unreadable")]
+    [InlineData("ambiguous")]
+    public void MissingUnreadableOrAmbiguousTopology_StillRendersStaticGuidanceWithoutResolution_G789(string scenario)
+    {
+        using var fixture = new TopologyFixture($"fallback-{scenario}");
+        if (string.Equals(scenario, "unreadable", StringComparison.Ordinal))
+        {
+            fixture.RecordUnreadable();
+        }
+        else if (string.Equals(scenario, "ambiguous", StringComparison.Ordinal))
+        {
+            fixture.RecordAmbiguousTeams();
+        }
+        fixture.SeedReviewablePr();
+
+        var designArgs = new List<string>
+        {
+            "--domain", Domain,
+            "--routing-root", fixture.Root,
+            "--format", "json",
+        };
+        // With multiple recorded teams there is no selected team to resolve;
+        // the guide must still render its static rule instead of guessing.
+        if (!string.Equals(scenario, "ambiguous", StringComparison.Ordinal))
+        {
+            designArgs.InsertRange(2, ["--team", fixture.Team]);
+        }
+
+        using var designJsonWriter = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(fixture.Context, designArgs.ToArray(), designJsonWriter));
+        using var designDocument = JsonDocument.Parse(designJsonWriter.ToString());
+        var designRoot = designDocument.RootElement;
+        var designSelection = designRoot.GetProperty("team_and_duty_split").GetProperty("review_seat_selection");
+        AssertStaticSelectionWithoutResolution(designSelection);
+        var designContract = designRoot.GetProperty("external_residence_operating_contract");
+        Assert.True(designContract.TryGetProperty("orca_operating_block", out var designOrca));
+        Assert.Equal("Non-normative Orca operating block", designOrca.GetProperty("label").GetString());
+
+        designArgs[^1] = "markdown";
+        using var designMarkdownWriter = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(fixture.Context, designArgs.ToArray(), designMarkdownWriter));
+        var designMarkdown = designMarkdownWriter.ToString();
+        var designSelectionSection = Section(
+            designMarkdown,
+            "- **review-seat selection (G789):**",
+            "- **different transition:**");
+        Assert.Contains("When recorded seat kinds differ", designSelectionSection, StringComparison.Ordinal);
+        Assert.Contains("Non-normative Orca operating block", designMarkdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("- recorded topology:", designSelectionSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("- selection:", designSelectionSection, StringComparison.Ordinal);
+
+        using var reviewJsonWriter = new StringWriter();
+        Assert.Equal(0, GuideReviewCommand.Execute(
+            fixture.Context,
+            ["--repo", Repo, "--pr", "1724", "--domain", Domain, "--format", "json"],
+            reviewJsonWriter));
+        using var reviewDocument = JsonDocument.Parse(reviewJsonWriter.ToString());
+        var reviewSelection = reviewDocument.RootElement
+            .GetProperty("review_standing_policy")
+            .GetProperty("review_seat_selection");
+        AssertStaticSelectionWithoutResolution(reviewSelection);
+
+        using var reviewMarkdownWriter = new StringWriter();
+        Assert.Equal(0, GuideReviewCommand.Execute(
+            fixture.Context,
+            ["--repo", Repo, "--pr", "1724", "--domain", Domain, "--format", "markdown"],
+            reviewMarkdownWriter));
+        var reviewMarkdown = reviewMarkdownWriter.ToString();
+        var reviewSelectionSection = Section(
+            reviewMarkdown,
+            "### Review-seat selection (G789)",
+            "## Review blocker protocol");
+        Assert.Contains("When recorded seat kinds differ", reviewSelectionSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("- recorded topology (", reviewSelectionSection, StringComparison.Ordinal);
+        Assert.DoesNotContain("- selection:", reviewSelectionSection, StringComparison.Ordinal);
+
+        Fixture($"{scenario} fallback design-thread JSON", designSelection.GetRawText());
+        Fixture($"{scenario} fallback design-thread Markdown", designSelectionSection);
+        Fixture($"{scenario} fallback guide review JSON", reviewSelection.GetRawText());
+        Fixture($"{scenario} fallback guide review Markdown", reviewSelectionSection);
     }
 
     [Fact]
@@ -201,6 +285,17 @@ public sealed class GuideSeatSelectionG789Tests
         var endIndex = document.IndexOf(end, startIndex, StringComparison.Ordinal);
         Assert.True(endIndex > startIndex, $"Missing section end '{end}'.");
         return document[startIndex..endIndex];
+    }
+
+    private static void AssertStaticSelectionWithoutResolution(JsonElement selection)
+    {
+        Assert.Contains("When recorded seat kinds differ", selection.GetProperty("mixed_kind_rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("design↔orchestration cross-review is acceptable", selection.GetProperty("single_kind_allowance").GetString(), StringComparison.Ordinal);
+        Assert.Contains("Only recorded topology fields decide", selection.GetProperty("recorded_fields_decide").GetString(), StringComparison.Ordinal);
+        foreach (var property in new[] { "topology_team", "recorded_seat_kinds", "design_seat", "review_seat", "selected_review_seat", "selection" })
+        {
+            Assert.False(selection.TryGetProperty(property, out _), $"Unexpected topology resolution property '{property}'.");
+        }
     }
 
     private sealed class TopologyFixture : IDisposable
@@ -241,19 +336,41 @@ public sealed class GuideSeatSelectionG789Tests
         }
 
         public void RecordHerdr(string role, string kind)
+            => RecordHerdr(Team, role, kind);
+
+        public void RecordHerdr(string team, string role, string kind)
         {
             var result = Run(
             [
-                "session-layer", "topology", "record", "--domain", Domain, "--team", Team,
+                "session-layer", "topology", "record", "--domain", Domain, "--team", team,
                 "--role", role, "--resident", "herdr", "--workspace-id", "wG789",
-                "--pane-id", $"wG789:{role}", "--cwd", "/g789", "--kind", kind,
+                "--pane-id", $"wG789:{team}:{role}", "--cwd", "/g789", "--kind", kind,
                 "--delivery-method", "inline", "--write", "--format", "json",
             ]);
             Assert.Equal(0, result.ExitCode);
         }
 
+        public void RecordUnreadable()
+        {
+            var directory = Path.Combine(Root, ".intent-cli", "topology", Domain);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, $"{Team}.json"), "{ not valid json");
+        }
+
+        public void RecordAmbiguousTeams()
+        {
+            foreach (var team in new[] { $"{Team}-a", $"{Team}-b" })
+            {
+                RecordHerdr(team, "design", "codex");
+                RecordHerdr(team, "implementation", "codex");
+                RecordHerdr(team, "orchestration", "codex");
+                RecordHerdr(team, "review", "codex");
+            }
+        }
+
         public void SeedReviewablePr()
         {
+            Directory.CreateDirectory(Path.Combine(Root, ".intent-cli"));
             var state = new QueueState
             {
                 SchemaVersion = "1",

--- a/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
@@ -1,4 +1,7 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
@@ -16,6 +19,51 @@ public sealed class GuideSeatSelectionG789Tests
 {
     private const string Domain = "intent-cli";
     private const string Repo = "J-Tech-Japan/intent-system";
+    private const string ParentGuideReviewPayloadOracleHash = "8e90346d3975ec83b2c450cbd60fdb8ef47a467c759ec8d6fdce6b4f27670e35";
+    private static readonly string[] ParentGuideReviewPayloadFieldNames =
+    [
+        "domain",
+        "repo",
+        "pr",
+        "queue_state_path",
+        "execution_unit",
+        "queue_item_title",
+        "queue_item_state",
+        "packet_directory",
+        "packet_files",
+        "packet_paths",
+        "intent_reference_paths",
+        "review_checklist",
+        "review_boundaries",
+        "approval_summary_requirements",
+        "same_account_review_verdict",
+        "guide_reachability",
+        "topology_workspace_move",
+        "request_update_requirements",
+        "automated_reviewer_comment_triage",
+        "device_gated_evidence_policy",
+        "review_standing_policy",
+        "review_policy_source",
+        "review_blocker_protocol",
+        "pr_blocker_comment_template",
+        "review_blocker_routing_examples",
+        "chat_is_not_durable_workflow_state",
+        "validation_suggestions",
+        "tests_pass_is_necessary_not_sufficient",
+        "gaps",
+        "ready",
+    ];
+    private static readonly string[] ParentGuideReviewPolicyFieldNames =
+    [
+        "source",
+        "domain",
+        "warnings",
+        "device_gated_evidence",
+        "draft_handling",
+        "external_artifact_intake",
+        "test_evidence_sufficiency",
+        "follow_up_tracking",
+    ];
 
     [Fact]
     public void MixedKindTopology_RendersOrderedOrcaBlockAndDifferentKindReviewSeat_G789()
@@ -128,6 +176,36 @@ public sealed class GuideSeatSelectionG789Tests
             markdown,
             "### Review-seat selection (G789)",
             "## Review blocker protocol"));
+    }
+
+    [Fact]
+    public void GuideReview_RemovingOnlyG789SelectionMatchesImmutableParentPayload_G789()
+    {
+        using var fixture = new TopologyFixture(
+            "review-oracle",
+            Path.Combine(Path.GetTempPath(), "g789-guide-review-oracle-root"));
+        fixture.SeedReviewablePr();
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideReviewCommand.Execute(
+            fixture.Context,
+            ["--repo", Repo, "--pr", "1724", "--domain", Domain, "--format", "json"],
+            writer));
+        using var document = JsonDocument.Parse(writer.ToString());
+        var head = document.RootElement;
+        var headPolicy = head.GetProperty("review_standing_policy");
+        Assert.True(headPolicy.TryGetProperty("review_seat_selection", out _));
+
+        using var projected = JsonDocument.Parse(RemoveG789Additions(head));
+        var fields = projected.RootElement.EnumerateObject().ToArray();
+        Assert.Equal(ParentGuideReviewPayloadFieldNames, fields.Select(field => field.Name));
+        var policyFields = fields.Single(field => field.Name == "review_standing_policy")
+            .Value.EnumerateObject().Select(field => field.Name);
+        Assert.Equal(ParentGuideReviewPolicyFieldNames, policyFields);
+
+        var actualOracle = ComputePayloadOracle(fields);
+        Assert.Equal(ParentGuideReviewPayloadOracleHash, actualOracle);
+        Console.WriteLine($"G789 guide-review parent remainder oracle: expected={ParentGuideReviewPayloadOracleHash}; actual={actualOracle}; removed=review_standing_policy.review_seat_selection");
     }
 
     [Fact]
@@ -300,9 +378,13 @@ public sealed class GuideSeatSelectionG789Tests
 
     private sealed class TopologyFixture : IDisposable
     {
-        public TopologyFixture(string suffix)
+        public TopologyFixture(string suffix, string? rootOverride = null)
         {
-            Root = Directory.CreateTempSubdirectory($"guide-g789-{suffix}-").FullName;
+            Root = rootOverride ?? Directory.CreateTempSubdirectory($"guide-g789-{suffix}-").FullName;
+            if (rootOverride is not null && Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
             Team = $"g789-{suffix}";
             Context = new CliContext
             {
@@ -424,5 +506,22 @@ public sealed class GuideSeatSelectionG789Tests
                 Directory.Delete(Root, recursive: true);
             }
         }
+    }
+
+    private static string RemoveG789Additions(JsonElement root)
+    {
+        var projected = JsonNode.Parse(root.GetRawText())!.AsObject();
+        projected["team_and_duty_split"]?.AsObject().Remove("review_seat_selection");
+        projected["external_residence_operating_contract"]?.AsObject().Remove("orca_operating_block");
+        projected["review_standing_policy"]?.AsObject().Remove("review_seat_selection");
+        return projected.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static string ComputePayloadOracle(IEnumerable<JsonProperty> fields)
+    {
+        var payload = string.Join(
+            "\u001E",
+            fields.Select(field => field.Name + "\u001F" + field.Value.GetRawText()));
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
     }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
@@ -181,6 +181,46 @@ public sealed class GuideSeatSelectionG789Tests
     }
 
     [Fact]
+    public void GuideReview_MixedKindSameKindReviewRemainsUnresolved_G789()
+    {
+        using var fixture = new TopologyFixture("review-same-kind");
+        fixture.RecordHerdr("design", "codex");
+        fixture.RecordHerdr("review", "codex");
+        fixture.RecordHerdr("orchestration", "codex");
+        fixture.RecordExternal("implementation", "claude-app");
+        fixture.SeedReviewablePr();
+
+        using var jsonWriter = new StringWriter();
+        Assert.Equal(0, GuideReviewCommand.Execute(
+            fixture.Context,
+            ["--repo", Repo, "--pr", "1724", "--domain", Domain, "--format", "json"],
+            jsonWriter));
+        using var document = JsonDocument.Parse(jsonWriter.ToString());
+        var selection = document.RootElement
+            .GetProperty("review_standing_policy")
+            .GetProperty("review_seat_selection");
+        Assert.Equal("design (kind:codex)", selection.GetProperty("design_seat").GetString());
+        Assert.Equal("review (kind:codex)", selection.GetProperty("review_seat").GetString());
+        Assert.False(selection.TryGetProperty("selected_review_seat", out _));
+        Assert.Contains("no distinct-kind review seat is resolved", selection.GetProperty("selection").GetString(), StringComparison.Ordinal);
+        Assert.Contains("select a recorded different-kind review seat", selection.GetProperty("selection").GetString(), StringComparison.OrdinalIgnoreCase);
+
+        using var markdownWriter = new StringWriter();
+        Assert.Equal(0, GuideReviewCommand.Execute(
+            fixture.Context,
+            ["--repo", Repo, "--pr", "1724", "--domain", Domain, "--format", "markdown"],
+            markdownWriter));
+        var markdown = markdownWriter.ToString();
+        var section = Section(markdown, "### Review-seat selection (G789)", "## Review blocker protocol");
+        Assert.Contains("selected review seat: unresolved", section, StringComparison.Ordinal);
+        Assert.DoesNotContain("selected review seat: review", section, StringComparison.Ordinal);
+        Assert.Contains("no distinct-kind review seat is resolved", section, StringComparison.Ordinal);
+
+        Fixture("same-kind mixed guide review JSON", selection.GetRawText());
+        Fixture("same-kind mixed guide review Markdown", section);
+    }
+
+    [Fact]
     public void GuideReview_RemovingOnlyG789SelectionMatchesImmutableParentPayload_G789()
     {
         using var fixture = new TopologyFixture(


### PR DESCRIPTION

Closes #1724

## G789 repair

This repair addresses the review request on parent head 71ec57817c08cf882a88cc052c8ddb92621278dd. The repaired branch head is 37dc9d88ac1662c1f091d04111939019fef422dc.

The change keeps the G789 additions additive and non-management: static review-seat guidance and the non-normative Orca operating block are always rendered, while a readable unique topology can add the recorded team/kind-specific resolution. Missing, unreadable, or ambiguous topology leaves that resolution absent; it no longer suppresses the required rule or Orca instructions. No CLI option, topology field, launch/management behavior, or lifecycle metadata was added.

### AC 1 — Orca operating block (actual output pasted)

The design-thread JSON contains the complete non-normative block in setup order.

```json
{
  "label": "Non-normative Orca operating block",
  "setup_order": [
    "Create or bind a Run before seat messages: `orca orchestration run-create --objective <text> [--from <handle>]` or `orca orchestration run-use --id <run-id> [--from <handle>]`.",
    "Share the resulting `<run-id>` with every sender before anyone addresses `run:<run-id>`.",
    "Each sender supplies its own `--from <role>` handle; it is a sender handle, not a routing identity."
  ],
  "send_form": "orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}",
  "check_form": "orca orchestration check --run <run-id> --wait --timeout-ms <timeout-ms> --json",
  "shared_channel": "The same Orca channel carries herdr seats' courtesy wakes and design-to-design messages; neither replaces the canonical notify record.",
  "durable_record": "Canonical `intent-cli notify` remains durable. This non-normative block adds no intent-cli option, and intent-cli neither launches nor manages Orca."
}
```

### AC 2 — Wake template consistency (actual output pasted)

The rendered operating block and wake declaration use the same send form.

```text
operating_block.send_form = orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}
wake_channel_declaration.example = orca orchestration send --run <run-id> --to run:<run-id> --from <role> --subject {task_id} --body {summary}
equal = true
```

### AC 3 — Design-thread review-seat rule (actual output pasted)

```json
{
  "mixed_kind_rule": "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
  "single_kind_allowance": "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
  "recorded_fields_decide": "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location."
}
```

### AC 4 — Guide-review rule and readable resolution (actual output pasted)

Static policy is rendered even when there is no resolution. A readable mixed-kind topology adds the recorded resolution; the static rule remains present.

```markdown
### Review-seat selection (G789)
- When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.
- When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.
- Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.
- recorded topology: design=claude-app; orchestration=codex; implementation=codex; review=codex
- selection: review
```

#### AC 4 — Readable mixed-kind same-kind review remains unresolved (actual output pasted)

The durable same-kind mixed-topology fixture records `design=codex`, `review=codex`, `orchestration=codex`, and `implementation=claude-app`. The JSON omits `selected_review_seat`; Markdown marks the selection unresolved and never claims `review` was selected.

```text
G789 same-kind mixed guide review JSON:
{
      "mixed_kind_rule": "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
      "single_kind_allowance": "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
      "recorded_fields_decide": "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.",
      "topology_team": "g789-review-same-kind",
      "recorded_seat_kinds": [
        "design (kind:codex)",
        "implementation (frontend:claude-app)",
        "orchestration (kind:codex)",
        "review (kind:codex)"
      ],
      "design_seat": "design (kind:codex)",
      "review_seat": "review (kind:codex)",
      "selection": "Mixed recorded kinds: review does not have a different recorded kind/frontend from design; no distinct-kind review seat is resolved for design output. Select a recorded different-kind review seat before it reviews design output, while review still reviews PRs."
    }
G789 same-kind mixed guide review Markdown:
### Review-seat selection (G789)
- When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.
- When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.
- Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.
- recorded topology (g789-review-same-kind): design (kind:codex), implementation (frontend:claude-app), orchestration (kind:codex), review (kind:codex)
- design: design (kind:codex); review: review (kind:codex); selected review seat: unresolved
- selection: Mixed recorded kinds: review does not have a different recorded kind/frontend from design; no distinct-kind review seat is resolved for design output. Select a recorded different-kind review seat before it reviews design output, while review still reviews PRs.
```
### AC 5 — Missing, unreadable, and ambiguous topology (actual fixture output pasted)

These are the collected stdout excerpts from the 9-test G789 fallback/oracle run. Each case emitted both guide formats and the static fields while omitting a topology-specific resolution.

```text
G789 unreadable fallback design-thread JSON:
{
      "mixed_kind_rule": "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
      "single_kind_allowance": "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
      "recorded_fields_decide": "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location."
    }
G789 unreadable fallback design-thread Markdown:
- **review-seat selection (G789):** When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.
  - When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.
  - Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.
G789 unreadable fallback guide review JSON:
{
      "mixed_kind_rule": "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
      "single_kind_allowance": "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
      "recorded_fields_decide": "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location."
    }
G789 unreadable fallback guide review Markdown:
### Review-seat selection (G789)
- When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.
- When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.
- Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.
G789 missing fallback design-thread JSON:
{
      "mixed_kind_rule": "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
      "single_kind_allowance": "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
      "recorded_fields_decide": "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location."
    }
G789 missing fallback design-thread Markdown:
- **review-seat selection (G789):** When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.
  - When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.
  - Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.
G789 missing fallback guide review JSON:
{
      "mixed_kind_rule": "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
      "single_kind_allowance": "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
      "recorded_fields_decide": "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location."
    }
G789 missing fallback guide review Markdown:
### Review-seat selection (G789)
- When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.
- When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.
- Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.
G789 ambiguous fallback design-thread JSON:
{
      "mixed_kind_rule": "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
      "single_kind_allowance": "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
      "recorded_fields_decide": "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location."
    }
G789 ambiguous fallback design-thread Markdown:
- **review-seat selection (G789):** When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.
  - When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.
  - Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.
G789 ambiguous fallback guide review JSON:
{
      "mixed_kind_rule": "When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.",
      "single_kind_allowance": "When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.",
      "recorded_fields_decide": "Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location."
    }
G789 ambiguous fallback guide review Markdown:
### Review-seat selection (G789)
- When recorded seat kinds differ, the review seat with a recorded kind/frontend different from design reviews design output as well as PRs.
- When all recorded seat kinds are the same, design↔orchestration cross-review is acceptable.
- Only recorded topology fields decide: `kind` for a herdr seat and `frontend` for an external seat. Do not infer a kind from role name, model, residence, or co-location.
```

### AC 6 — Parent-derived additive oracles (actual output pasted)

The existing G654/G777 hashes are the immutable parent values. The tests serialize the head, remove only the three G789 additions (the nested design-thread review-seat selection, the nested Orca operating block, and the guide-review standing-policy selection), then compare raw JSON field/value order against those parent-derived expectations. The guide-review test uses a fixed scratch root so path-valued fields are identical to the base probe.

```text
G789 guide design-thread G775 remainder oracle: expected=1c297f028c3e8ea5e1901b84ff962e542d864aa1139130ea9c1092539789cbe4; actual=1c297f028c3e8ea5e1901b84ff962e542d864aa1139130ea9c1092539789cbe4; removed=external_residence_operating_contract.orca_operating_block
G789 guide design-thread G776 remainder oracle: expected=5ebb02d016c9afec671e58184f993705d0c6e597ecf334239b19d704bfaf3294; actual=5ebb02d016c9afec671e58184f993705d0c6e597ecf334239b19d704bfaf3294; removed=team_and_duty_split.review_seat_selection,external_residence_operating_contract.orca_operating_block
G789 guide design-thread parent remainder oracle: expected=c43e27f362c39d9c737fc2269b1979bdf8ad9b7ecb07f3dd0491ba1325d0c54f; actual=c43e27f362c39d9c737fc2269b1979bdf8ad9b7ecb07f3dd0491ba1325d0c54f; removed=team_and_duty_split.review_seat_selection,external_residence_operating_contract.orca_operating_block
G789 guide-review parent remainder oracle: expected=dcc8a884b71ef40c2567bcd6141ded8c035c2f20fc42632e829bd5e2b875ce8c; actual=dcc8a884b71ef40c2567bcd6141ded8c035c2f20fc42632e829bd5e2b875ce8c; removed=review_standing_policy.review_seat_selection
```

The immutable constants remain:
- G654 parent: c43e27f362c39d9c737fc2269b1979bdf8ad9b7ecb07f3dd0491ba1325d0c54f
- G774 baseline: 8110a6150605810aaa609fc2c34668341b939e58bc0dc35085c7290e6c72b136
- G775 contract: 1c297f028c3e8ea5e1901b84ff962e542d864aa1139130ea9c1092539789cbe4
- G776 baseline: 5ebb02d016c9afec671e58184f993705d0c6e597ecf334239b19d704bfaf3294

### AC 7 — Non-normative Orca boundary (actual output pasted)

The output is explicitly labelled non-normative and states that intent-cli neither launches nor manages Orca; no option is introduced.

```text
label = Non-normative Orca operating block
durable_record = Canonical intent-cli notify remains durable. This non-normative block adds no intent-cli option, and intent-cli neither launches nor manages Orca.
```

### AC 8 — Documentation and validation (actual counts pasted)

The existing EN/JA `12 mirrors retain the Orca setup order, shared channel, durable notify boundary, and mixed-kind review-seat rule.

```text
docs/en/12-agent-message-orchestration.md: G789 Orca operating block and review-seat selection rule
docs/ja/12-agent-message-orchestration.md: G789 Orca operating block and review-seat selection rule
```

### AC 9 — Parent absence/failure proof (actual output pasted)

The original G789 test file is absent at the PR base, and the fallback/oracle additions are absent at the intermediate repair parent. The original-base proof is retained alongside the repair-relative proof.

```text
$ git show cfdacb4a657d9a60ab82fea3faa435ff732f389f:tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs' exists on disk, but not in 'cfdacb4a657d9a60ab82fea3faa435ff732f389f'
base_parent_absence_exit=128

$ git grep -n "MissingUnreadableOrAmbiguousTopology_StillRendersStaticGuidanceWithoutResolution_G789" 71ec57817c08cf882a88cc052c8ddb92621278dd -- tests/IntentSystem.Cli.Tests
(exit 1; no matches)
$ git grep -n "CreateStatic|orcaOperatingBlock ??=" 71ec57817c08cf882a88cc052c8ddb92621278dd -- src/IntentSystem.Cli/Commands
(exit 1; no matches)
$ git show 71ec57817c08cf882a88cc052c8ddb92621278dd:tests/IntentSystem.Cli.Tests/GuideSeatSelectionG789Tests.cs | rg -n "fallback|MissingUnreadable|unreadable|ambiguous"
(exit 1; no matches)
```
## Validation

Targeted G789 fallback tests:

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --configuration Release --filter FullyQualifiedName~GuideSeatSelectionG789Tests
Passed! - Failed: 0, Passed: 9, Skipped: 0, Total: 9
```

Relevant guide/policy tests:

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --configuration Release --filter 'FullyQualifiedName~GuideDesignThreadG654Tests|FullyQualifiedName~GuideDesignThreadG777Tests|FullyQualifiedName~ReviewStandingPolicyRegistryTests|FullyQualifiedName~GuideReviewCommandTests|FullyQualifiedName~GuideSeatSelectionG789Tests|FullyQualifiedName~JapaneseTerminologyGuardG613Tests'
Passed! - Failed: 0, Passed: 69, Skipped: 0, Total: 69
```

Combined topology/guide regression set:

```text
Passed! - Failed: 0, Passed: 31, Skipped: 0, Total: 31
```

Full Release suite (green rerun):

```text
dotnet test IntentSystem.sln --configuration Release --no-build --no-restore --logger 'console;verbosity=minimal'
Passed! - Failed: 0, Passed: 5623, Skipped: 1, Total: 5624
```

Exact-head CI for 37dc9d88ac1662c1f091d04111939019fef422dc (rerun 1):

```text
Build and test (source contract) — pass
https://github.com/J-Tech-Japan/intent-system/actions/runs/33740799176/job/100601972533
npm package dry-run (no publish) — pass
https://github.com/J-Tech-Japan/intent-system/actions/runs/33740799176/job/100602706201
```

The exact-head CI run passed both jobs above.

## Review handoff

PR #1725 is open and non-draft at head 37dc9d88ac1662c1f091d04111939019fef422dc and is ready for re-review. No merge or label edits were performed manually.
.artifacts/ was preserved untracked.



