### PR TITLE
G791: align host guards and durable state

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -3467,3 +3467,37 @@ This makes duplicate queue items **recoverable, not impossible**. Do not hand
 edit queue-state. The repair is deliberately limited to duplicate reporting
 and strict-dominance reconciliation; concurrent-write prevention, locking,
 CAS, and queue-schema changes remain separate work.
+
+### Host durable-state and foreign nested-pointer drift (G791)
+
+`automation workspace-guard`, `automation durable-state-preflight`, and
+`automation host-sync-preflight` use one durable-host-state path boundary:
+`.intent-cli/**`, `intents/**`, `AGENTS.md`, and `CLAUDE.md`. A path cannot be
+unsafe to stash in one command while being invisible to the command that names
+the recovery route.
+
+`automation durable-state-preflight` recognizes append-only runtime JSONL
+records beneath `.intent-cli/continuation-chains/**`, `.intent-cli/events/**`,
+`.intent-cli/notify/**`, and `.intent-cli/supervision/**`, plus a structurally
+valid generated `.intent-cli/supervision/**/emission-policy.json`. Those
+records are `verified-commit-ready` with their exact paths and a recommended
+commit message. A preflight with no dirty durable paths is `clean`, never an
+empty `needs-operator-review` result. In-place edits, deletions, malformed
+records, and other unrecognized durable content remain fail-closed.
+
+`nested-pointer-drift` is a narrow direct-proceed classification for another
+domain's live submodule checkout. It requires all three facts: the host
+gitlink equals the parent-recorded commit; the owning submodule's
+`git submodule status` reports differing nested gitlinks; and every affected
+nested checkout has an empty `git status --porcelain`. The payload names the
+owning submodule and every untouched nested path. `host-sync-preflight` emits
+this same classification instead of the safe-stash lane; workspace-guard
+represents it as a no-op, with no stash or checkout.
+
+This permission is to leave foreign paths alone. It must not run `git stash`,
+`git checkout`, `git submodule update`, `git add`, or `git commit` against the
+drifted submodules. If any nested checkout carries real uncommitted content,
+both `workspace-guard` and `host-sync-preflight` refuse with
+`submodule-internal-dirty`; neither offers the G306 safe-stash lane. Reconciling
+another domain's nested pointer drift or real nested content is the owning
+domain team's responsibility.

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -3494,6 +3494,11 @@ owning submodule and every untouched nested path. `host-sync-preflight` emits
 this same classification instead of the safe-stash lane; workspace-guard
 represents it as a no-op, with no stash or checkout.
 
+The parent-recorded gitlink is read from `HEAD`, not the index. A staged
+superproject gitlink (for example porcelain `MM owner`) is foreign parent work,
+not clean nested-pointer drift: both commands fail closed and do not offer the
+G306 safe-stash or direct-proceed lane.
+
 This permission is to leave foreign paths alone. It must not run `git stash`,
 `git checkout`, `git submodule update`, `git add`, or `git commit` against the
 drifted submodules. If any nested checkout carries real uncommitted content,

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3521,6 +3521,11 @@ untouched nested path をすべて列挙します。`host-sync-preflight` は sa
 ではなく同じ classification を返し、workspace-guard は stash も checkout も行わない
 no-op として表します。
 
+parent-recorded gitlink は index ではなく `HEAD` から読み取ります。staged な
+superproject gitlink（たとえば porcelain の `MM owner`）は clean nested-pointer
+drift ではなく foreign parent work です。両 command は fail-closed で拒否し、G306
+safe-stash も direct-proceed lane も提示しません。
+
 これは foreign path を触らずに残す permission です。drifted submodule に対して
 `git stash`、`git checkout`、`git submodule update`、`git add`、`git commit` を
 実行してはいけません。nested checkout に real uncommitted content が一つでもあれば、

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3493,3 +3493,37 @@ unit 名と full competing entries を示して mutation を行いません。op
 ではありません**。queue-state を手編集してはいけません。対象は重複の報告と
 strict dominance による安全な整理だけであり、concurrent-write prevention、
 locking、CAS、queue schema の変更は別の作業です。
+
+### host の永続状態と他ドメインの nested-pointer drift (G791)
+
+`automation workspace-guard`、`automation durable-state-preflight`、
+`automation host-sync-preflight` は一つの host の永続状態 path 境界を共有します:
+`.intent-cli/**`、`intents/**`、`AGENTS.md`、`CLAUDE.md` です。ある command では
+stash できない unsafe な path が、recovery route を示す別 command から見えなくなることは
+ありません。
+
+この永続状態 preflight は
+`.intent-cli/continuation-chains/**`、`.intent-cli/events/**`、
+`.intent-cli/notify/**`、`.intent-cli/supervision/**` 配下の append-only runtime
+JSONL record と、構造的に valid な生成済み
+`.intent-cli/supervision/**/emission-policy.json` を認識します。これらの record は
+exact path と recommended commit message を含む `verified-commit-ready` になります。
+dirty な永続 path がない preflight は `clean` であり、空の
+`needs-operator-review` にはなりません。in-place edit、deletion、malformed record、
+その他の認識されない永続 content は従来どおり fail-closed です。
+
+`nested-pointer-drift` は、別 domain の live submodule checkout に対する狭い
+direct-proceed classification です。次の三つがすべて必要です: host gitlink が
+parent-recorded commit と一致すること、owning submodule の `git submodule status` が
+異なる nested gitlink を報告すること、影響を受けるすべての nested checkout の
+`git status --porcelain` が空であることです。payload は owning submodule と
+untouched nested path をすべて列挙します。`host-sync-preflight` は safe-stash lane
+ではなく同じ classification を返し、workspace-guard は stash も checkout も行わない
+no-op として表します。
+
+これは foreign path を触らずに残す permission です。drifted submodule に対して
+`git stash`、`git checkout`、`git submodule update`、`git add`、`git commit` を
+実行してはいけません。nested checkout に real uncommitted content が一つでもあれば、
+`workspace-guard` と `host-sync-preflight` はともに `submodule-internal-dirty` として
+拒否し、G306 safe-stash lane を提示しません。他 domain の nested pointer drift または
+real nested content の reconciliation は owning domain team の責務です。

--- a/src/IntentSystem.Cli/Commands/AutomationDurableStatePreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationDurableStatePreflightCommand.cs
@@ -86,7 +86,8 @@ internal static class AutomationDurableStatePreflightCommand
             WriteMarkdown(writer, result);
         }
 
-        return string.Equals(result.Classification, DurableStatePreflightAnalyzer.ClassificationVerifiedCommitReady, StringComparison.Ordinal)
+        return (string.Equals(result.Classification, DurableStatePreflightAnalyzer.ClassificationVerifiedCommitReady, StringComparison.Ordinal)
+                || string.Equals(result.Classification, DurableStatePreflightAnalyzer.ClassificationClean, StringComparison.Ordinal))
             ? 0
             : 1;
     }
@@ -148,13 +149,14 @@ internal static class AutomationDurableStatePreflightCommand
                 // tree shows up as `?? .intent-cli/`); the per-file
                 // filter below will drop anything outside the durable
                 // surface after expansion.
-                if (!IsDurableStatePath(path) && !IsDurableStateParent(path))
+                if (!DurableHostStatePathClassifier.IsDurableHostStatePath(path)
+                    && !DurableHostStatePathClassifier.IsDurableHostStateParent(path))
                 {
                     continue;
                 }
                 foreach (var expanded in ExpandUntrackedDirectory(repoRoot, path))
                 {
-                    if (!IsDurableStatePath(expanded))
+                    if (!DurableHostStatePathClassifier.IsDurableHostStatePath(expanded))
                     {
                         continue;
                     }
@@ -168,7 +170,7 @@ internal static class AutomationDurableStatePreflightCommand
             // command can be invoked standalone and only durable-state
             // paths are reported. Anything outside the durable surface is
             // ignored — the operator will use safe-stash for it.
-            if (!IsDurableStatePath(path))
+            if (!DurableHostStatePathClassifier.IsDurableHostStatePath(path))
             {
                 continue;
             }
@@ -221,6 +223,7 @@ internal static class AutomationDurableStatePreflightCommand
             RunsJsonlAppendOnlyResult? runsDelta = null;
             PublishYamlCanonicalResult? publishYamlDelta = null;
             PreparedPacketCommitReadyResult? preparedPacketDelta = null;
+            DurableRuntimeRecordDelta? runtimeRecordDelta = null;
 
             if (!isDeleted)
             {
@@ -250,6 +253,10 @@ internal static class AutomationDurableStatePreflightCommand
                     // on the verdict.
                     preparedPacketDelta = sharedVerdict;
                 }
+                else if (DurableRuntimeRecordAnalyzer.IsCandidate(path))
+                {
+                    runtimeRecordDelta = TryRuntimeRecordDelta(repoRoot, path);
+                }
             }
 
             dirtyPaths.Add(new DurableStateDirtyPath
@@ -260,6 +267,7 @@ internal static class AutomationDurableStatePreflightCommand
                 RunsJsonlDelta = runsDelta,
                 PublishYamlDelta = publishYamlDelta,
                 PreparedPacketDelta = preparedPacketDelta,
+                RuntimeRecordDelta = runtimeRecordDelta,
             });
         }
 
@@ -571,6 +579,52 @@ internal static class AutomationDurableStatePreflightCommand
         return RunsJsonlAppendOnlyAnalyzer.Analyze(headBlob, workingBlob);
     }
 
+    private static DurableRuntimeRecordDelta TryRuntimeRecordDelta(string repoRoot, string path)
+    {
+        string headBlob;
+        try
+        {
+            // A newly created runtime record has no HEAD blob. RunGit returns
+            // an empty output for that ordinary git-show miss, which is the
+            // correct empty ledger baseline for the append-only analyzer.
+            headBlob = RunGit(repoRoot, $"show HEAD:{path}");
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            return new DurableRuntimeRecordDelta
+            {
+                Classification = DurableRuntimeRecordAnalyzer.ClassificationInvalid,
+                Summary = $"could not read HEAD blob for '{path}': {exception.Message}",
+                AppendedRecordCount = 0,
+            };
+        }
+
+        var workingPath = Path.Combine(repoRoot, path);
+        if (!File.Exists(workingPath))
+        {
+            return new DurableRuntimeRecordDelta
+            {
+                Classification = DurableRuntimeRecordAnalyzer.ClassificationInvalid,
+                Summary = $"working-tree path '{path}' does not exist on disk.",
+                AppendedRecordCount = 0,
+            };
+        }
+
+        try
+        {
+            return DurableRuntimeRecordAnalyzer.Analyze(path, headBlob, File.ReadAllText(workingPath));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return new DurableRuntimeRecordDelta
+            {
+                Classification = DurableRuntimeRecordAnalyzer.ClassificationInvalid,
+                Summary = $"could not read working-tree '{path}': {exception.Message}",
+                AppendedRecordCount = 0,
+            };
+        }
+    }
+
     /// <summary>
     /// G343: detect <c>.intent-cli/issues/&lt;execution-unit&gt;/publish.yaml</c>
     /// paths and extract the directory-derived execution-unit so the
@@ -630,41 +684,6 @@ internal static class AutomationDurableStatePreflightCommand
         }
 
         return PublishYamlCanonicalAnalyzer.Analyze(content, executionUnit);
-    }
-
-    /// <summary>
-    /// G361: returns true when <paramref name="path"/> is a trailing-slash
-    /// directory entry that could be a PARENT of a durable-state path —
-    /// e.g. <c>.intent-cli/</c> when the entire artifact root is
-    /// untracked. The caller still expands and per-file filters.
-    /// </summary>
-    private static bool IsDurableStateParent(string path)
-    {
-        if (string.IsNullOrEmpty(path)) return false;
-        var normalized = path.Replace('\\', '/').TrimStart('/');
-        // Strip the trailing slash for prefix comparisons.
-        if (normalized.EndsWith('/'))
-        {
-            normalized = normalized[..^1];
-        }
-        return normalized.Equals(".intent-cli", StringComparison.Ordinal)
-            || normalized.StartsWith(".intent-cli/", StringComparison.Ordinal)
-            || normalized.Equals("intents", StringComparison.Ordinal)
-            || normalized.StartsWith("intents/", StringComparison.Ordinal);
-    }
-
-    private static bool IsDurableStatePath(string path)
-    {
-        if (string.IsNullOrEmpty(path)) return false;
-        var normalized = path.Replace('\\', '/').TrimStart('/');
-        return normalized.StartsWith(".intent-cli/queue-state.json", StringComparison.Ordinal)
-            || normalized.StartsWith(".intent-cli/runs.jsonl", StringComparison.Ordinal)
-            || normalized.StartsWith(".intent-cli/issues/", StringComparison.Ordinal)
-            || normalized.StartsWith("intents/", StringComparison.Ordinal)
-            || normalized.Equals("AGENTS.md", StringComparison.Ordinal)
-            || normalized.Equals("CLAUDE.md", StringComparison.Ordinal)
-            || normalized.Equals(".intent-cli/host-binding.toml", StringComparison.Ordinal)
-            || normalized.Equals(".intent-cli/config.toml", StringComparison.Ordinal);
     }
 
     private static string RunGit(string workingDirectory, string arguments)

--- a/src/IntentSystem.Cli/Commands/AutomationHostSyncPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostSyncPreflightCommand.cs
@@ -269,8 +269,23 @@ internal static class AutomationHostSyncPreflightCommand
         var paths = new List<string>();
         foreach (var entry in entries)
         {
-            if (driftPaths.Contains(entry.Path)
-                || !NestedSubmodulePointerDriftDetector.TryGetParentRecordedGitlinkCommit(runner, entry.Path, out _))
+            var parentGitlink = NestedSubmodulePointerDriftDetector.InspectParentGitlink(runner, entry.Path);
+            if (!parentGitlink.IsGitlink)
+            {
+                continue;
+            }
+
+            // G791 repair: a staged parent gitlink (for example porcelain
+            // `MM owner`) is foreign work in the superproject. It is never a
+            // clean pointer-only drift or a safe-stash candidate, even when
+            // the nested checkout itself is clean.
+            if (parentGitlink.HasStagedGitlinkChange)
+            {
+                paths.Add(entry.Path);
+                continue;
+            }
+
+            if (driftPaths.Contains(entry.Path))
             {
                 continue;
             }
@@ -292,7 +307,8 @@ internal static class AutomationHostSyncPreflightCommand
         var drifts = new List<NestedPointerDriftSubmodule>();
         foreach (var entry in entries)
         {
-            if (!NestedSubmodulePointerDriftDetector.TryGetParentRecordedGitlinkCommit(runner, entry.Path, out var parentCommit))
+            var parentGitlink = NestedSubmodulePointerDriftDetector.InspectParentGitlink(runner, entry.Path);
+            if (!parentGitlink.IsAligned)
             {
                 continue;
             }
@@ -302,7 +318,7 @@ internal static class AutomationHostSyncPreflightCommand
                 && NestedSubmodulePointerDriftDetector.TryDetect(
                     runner,
                     entry.Path,
-                    parentCommit,
+                    parentGitlink.HeadRecordedCommit!,
                     owningStatus.StandardOutput,
                     out var drift))
             {

--- a/src/IntentSystem.Cli/Commands/AutomationHostSyncPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostSyncPreflightCommand.cs
@@ -67,7 +67,9 @@ internal static class AutomationHostSyncPreflightCommand
             probe.SubmoduleGitlinkMismatchPaths,
             probe.AheadOriginCommits,
             probe.LocalOnlyCommits,
-            probe.OriginAheadCommits);
+            probe.OriginAheadCommits,
+            probe.NestedPointerDriftSubmodules,
+            probe.SubmoduleInternalDirtyPaths);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -90,6 +92,8 @@ internal static class AutomationHostSyncPreflightCommand
         writer.WriteLine($"- Ahead of origin: {result.AheadOriginCommits} commit(s)");
         writer.WriteLine($"- Dirty durable-state paths: {result.DirtyDurableStatePaths.Count}");
         writer.WriteLine($"- Dirty unrelated paths: {result.DirtyUnrelatedPaths.Count}");
+        writer.WriteLine($"- Clean nested-pointer drift submodules: {result.NestedPointerDriftSubmodules.Count}");
+        writer.WriteLine($"- Submodules with real internal changes: {result.SubmoduleInternalDirtyPaths.Count}");
         writer.WriteLine($"- Proceed allowed: {(result.ProceedAllowed ? "yes" : "**no**")}");
         writer.WriteLine();
         writer.WriteLine(result.Summary);
@@ -144,6 +148,19 @@ internal static class AutomationHostSyncPreflightCommand
             foreach (var path in result.SubmoduleCheckoutMismatchPaths)
             {
                 writer.WriteLine($"- `{path}` — parent gitlink advanced; run `git submodule update --init {path}`");
+            }
+        }
+        if (result.NestedPointerDriftSubmodules.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Clean nested-pointer drift (left untouched)");
+            foreach (var drift in result.NestedPointerDriftSubmodules)
+            {
+                writer.WriteLine($"- owning submodule `{drift.OwningSubmodulePath}` (parent-recorded `{drift.ParentRecordedCommit}`)");
+                foreach (var nestedPath in drift.UntouchedNestedPaths)
+                {
+                    writer.WriteLine($"  - untouched nested path `{nestedPath}`");
+                }
             }
         }
         if (result.NextSteps.Count > 0)
@@ -211,6 +228,14 @@ internal static class AutomationHostSyncPreflightCommand
         // G357: detect submodule gitlink mismatches (parent gitlink advanced after
         // git pull, submodule checkout is stale but the submodule itself is clean).
         var submoduleGitlinkMismatchPaths = DetectSubmoduleGitlinkMismatches(repoRoot, entries);
+        // G791: distinguish another domain's clean nested-pointer drift from
+        // real submodule content work. This detector is read-only and merely
+        // records the foreign paths that this wake must leave untouched.
+        var nestedPointerDriftSubmodules = DetectNestedPointerDriftSubmodules(repoRoot, entries);
+        var submoduleInternalDirtyPaths = DetectSubmoduleInternalDirtyPaths(
+            repoRoot,
+            entries,
+            nestedPointerDriftSubmodules);
 
         return new HostSyncGitProbe
         {
@@ -220,8 +245,71 @@ internal static class AutomationHostSyncPreflightCommand
             LocalOnlyCommits = localOnlyCommits,
             OriginAheadCommits = originAheadCommits,
             WorkingTreeEntries = entries,
-            SubmoduleGitlinkMismatchPaths = submoduleGitlinkMismatchPaths
+            SubmoduleGitlinkMismatchPaths = submoduleGitlinkMismatchPaths,
+            NestedPointerDriftSubmodules = nestedPointerDriftSubmodules,
+            SubmoduleInternalDirtyPaths = submoduleInternalDirtyPaths
         };
+    }
+
+    /// <summary>
+    /// G791: an entry with actual changes inside its checkout must never be
+    /// offered to the G306 safe-stash lane. The narrow clean nested-pointer
+    /// classification is removed first; everything else with non-empty
+    /// submodule porcelain is an owning-team/manual-reconciliation stop.
+    /// </summary>
+    private static IReadOnlyList<string> DetectSubmoduleInternalDirtyPaths(
+        string repoRoot,
+        IReadOnlyList<HostSyncWorkingTreeEntry> entries,
+        IReadOnlyList<NestedPointerDriftSubmodule> nestedPointerDriftSubmodules)
+    {
+        var driftPaths = new HashSet<string>(
+            nestedPointerDriftSubmodules.Select(drift => drift.OwningSubmodulePath),
+            StringComparer.Ordinal);
+        var runner = new ShellGitRunner(repoRoot);
+        var paths = new List<string>();
+        foreach (var entry in entries)
+        {
+            if (driftPaths.Contains(entry.Path)
+                || !NestedSubmodulePointerDriftDetector.TryGetParentRecordedGitlinkCommit(runner, entry.Path, out _))
+            {
+                continue;
+            }
+
+            var submoduleStatus = runner.Run(["-C", entry.Path, "status", "--porcelain"]);
+            if (submoduleStatus.ExitCode == 0 && !string.IsNullOrWhiteSpace(submoduleStatus.StandardOutput))
+            {
+                paths.Add(entry.Path);
+            }
+        }
+        return paths;
+    }
+
+    private static IReadOnlyList<NestedPointerDriftSubmodule> DetectNestedPointerDriftSubmodules(
+        string repoRoot,
+        IReadOnlyList<HostSyncWorkingTreeEntry> entries)
+    {
+        var runner = new ShellGitRunner(repoRoot);
+        var drifts = new List<NestedPointerDriftSubmodule>();
+        foreach (var entry in entries)
+        {
+            if (!NestedSubmodulePointerDriftDetector.TryGetParentRecordedGitlinkCommit(runner, entry.Path, out var parentCommit))
+            {
+                continue;
+            }
+
+            var owningStatus = runner.Run(["-C", entry.Path, "status", "--porcelain"]);
+            if (owningStatus.ExitCode == 0
+                && NestedSubmodulePointerDriftDetector.TryDetect(
+                    runner,
+                    entry.Path,
+                    parentCommit,
+                    owningStatus.StandardOutput,
+                    out var drift))
+            {
+                drifts.Add(drift);
+            }
+        }
+        return drifts;
     }
 
     /// <summary>
@@ -400,4 +488,10 @@ internal sealed record HostSyncGitProbe
     /// <c>git submodule update --init &lt;path&gt;</c> is the safe repair).
     /// </summary>
     public IReadOnlyList<string> SubmoduleGitlinkMismatchPaths { get; init; } = Array.Empty<string>();
+
+    /// <summary>G791: clean nested-pointer drift that must remain untouched by this wake.</summary>
+    public IReadOnlyList<NestedPointerDriftSubmodule> NestedPointerDriftSubmodules { get; init; } = Array.Empty<NestedPointerDriftSubmodule>();
+
+    /// <summary>G791: actual uncommitted content within a submodule checkout; hard-stop rather than G306.</summary>
+    public IReadOnlyList<string> SubmoduleInternalDirtyPaths { get; init; } = Array.Empty<string>();
 }

--- a/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
@@ -84,11 +84,11 @@ internal static class AutomationWorkspaceGuardCommand
     private static int ExecutePlan(IGitRunner runner, CliContext context, string format, TextWriter writer)
     {
         var entries = ScanWorkingTree(runner);
-        var nonDurable = entries.Where(e => !IsDurableStatePath(e.Path)).ToArray();
-        var durable = entries.Where(e => IsDurableStatePath(e.Path)).ToArray();
+        var nonDurable = entries.Where(e => !DurableHostStatePathClassifier.IsDurableHostStatePath(e.Path)).ToArray();
+        var durable = entries.Where(e => DurableHostStatePathClassifier.IsDurableHostStatePath(e.Path)).ToArray();
 
         // G352: classify non-durable entries to surface gitlink vs regular paths in the plan.
-        var (gitlinkOnly, submoduleInternalDirty, regular) = ClassifyNonDurableEntries(runner, nonDurable);
+        var (gitlinkOnly, submoduleInternalDirty, nestedPointerDrift, regular) = ClassifyNonDurableEntries(runner, nonDurable);
 
         var stashMessage = regular.Count > 0 ? BuildStashMessage() : null;
         var totalNonDurable = nonDurable.Length;
@@ -99,6 +99,10 @@ internal static class AutomationWorkspaceGuardCommand
             summary = $"workspace-guard plan: {durable.Length} dirty durable-state path(s) present; safe-stash refused. Reconcile durable host-state through the G304 fail-closed path before re-running.";
         else if (submoduleInternalDirty.Count > 0)
             summary = $"workspace-guard plan: {submoduleInternalDirty.Count} submodule(s) have internal uncommitted changes ({string.Join(", ", submoduleInternalDirty.Select(e => e.Path))}); checkout-lane refused. Manually reconcile submodule internal changes before re-running.";
+        else if (nestedPointerDrift.Count > 0 && regular.Count > 0)
+            summary = $"workspace-guard plan: {nestedPointerDrift.Count} aligned host gitlink(s) contain only clean nested-pointer drift and {regular.Count} regular path(s). Leave the owning and nested submodule paths untouched; only the regular paths use the stash lane on `--mode begin --write`.";
+        else if (nestedPointerDrift.Count > 0)
+            summary = $"workspace-guard plan: {nestedPointerDrift.Count} aligned host gitlink(s) contain only clean nested-pointer drift; leave the owning and nested submodule paths untouched and proceed without stash or checkout.";
         else if (gitlinkOnly.Count > 0 && regular.Count > 0)
             summary = $"workspace-guard plan: {gitlinkOnly.Count} gitlink-only path(s) (checkout lane) + {regular.Count} regular path(s) (stash lane) on `--mode begin --write`.";
         else if (gitlinkOnly.Count > 0)
@@ -114,6 +118,7 @@ internal static class AutomationWorkspaceGuardCommand
             ProceedAllowed = proceedAllowed,
             SafeStashPaths = regular.ToArray(),
             GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
+            NestedPointerDriftSubmodules = nestedPointerDrift,
             DirtyDurableStatePaths = durable,
             StashMessage = stashMessage,
             StashRef = null,
@@ -129,8 +134,8 @@ internal static class AutomationWorkspaceGuardCommand
     private static int ExecuteBegin(IGitRunner runner, CliContext context, string statePath, bool write, string format, TextWriter writer)
     {
         var entries = ScanWorkingTree(runner);
-        var nonDurable = entries.Where(e => !IsDurableStatePath(e.Path)).ToArray();
-        var durable = entries.Where(e => IsDurableStatePath(e.Path)).ToArray();
+        var nonDurable = entries.Where(e => !DurableHostStatePathClassifier.IsDurableHostStatePath(e.Path)).ToArray();
+        var durable = entries.Where(e => DurableHostStatePathClassifier.IsDurableHostStatePath(e.Path)).ToArray();
 
         if (durable.Length > 0)
         {
@@ -151,7 +156,7 @@ internal static class AutomationWorkspaceGuardCommand
         }
 
         // G352: classify non-durable entries: gitlink-only, submodule-internal-dirty, regular.
-        var (gitlinkOnly, submoduleInternalDirty, regularStash) = ClassifyNonDurableEntries(runner, nonDurable);
+        var (gitlinkOnly, submoduleInternalDirty, nestedPointerDrift, regularStash) = ClassifyNonDurableEntries(runner, nonDurable);
 
         // G352: refuse if any submodule has internal uncommitted changes — we cannot safely auto-reset those.
         if (submoduleInternalDirty.Count > 0)
@@ -187,7 +192,10 @@ internal static class AutomationWorkspaceGuardCommand
                 StashRef = null,
                 ConflictPaths = Array.Empty<string>(),
                 StateFilePath = statePath,
-                Summary = "workspace-guard begin: working tree is clean; no stash created."
+                NestedPointerDriftSubmodules = nestedPointerDrift,
+                Summary = nestedPointerDrift.Count == 0
+                    ? "workspace-guard begin: working tree is clean; no stash created."
+                    : $"workspace-guard begin: {nestedPointerDrift.Count} aligned host gitlink(s) have only clean nested-pointer drift; no stash or checkout was run and the foreign paths remain untouched."
             };
             EmitResult(writer, format, noop);
             return 0;
@@ -202,12 +210,13 @@ internal static class AutomationWorkspaceGuardCommand
                 ProceedAllowed = true,
                 SafeStashPaths = regularStash.ToArray(),
                 GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
+                NestedPointerDriftSubmodules = nestedPointerDrift,
                 DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
                 StashMessage = message,
                 StashRef = null,
                 ConflictPaths = Array.Empty<string>(),
                 StateFilePath = statePath,
-                Summary = BuildBeginDryRunSummary(gitlinkOnly.Count, regularStash.Count, message)
+                Summary = BuildBeginDryRunSummary(gitlinkOnly.Count, nestedPointerDrift.Count, regularStash.Count, message)
             };
             EmitResult(writer, format, dryRun);
             return 0;
@@ -229,6 +238,7 @@ internal static class AutomationWorkspaceGuardCommand
                     ProceedAllowed = false,
                     SafeStashPaths = regularStash.ToArray(),
                     GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
+                    NestedPointerDriftSubmodules = nestedPointerDrift,
                     DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
                     StashMessage = message,
                     StashRef = null,
@@ -365,6 +375,7 @@ internal static class AutomationWorkspaceGuardCommand
             ProceedAllowed = true,
             SafeStashPaths = regularStash.ToArray(),
             GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
+            NestedPointerDriftSubmodules = nestedPointerDrift,
             DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
             StashMessage = message,
             StashRef = stashRef,
@@ -376,13 +387,16 @@ internal static class AutomationWorkspaceGuardCommand
         return 0;
     }
 
-    private static string BuildBeginDryRunSummary(int gitlinkCount, int regularCount, string? message)
+    private static string BuildBeginDryRunSummary(int gitlinkCount, int nestedPointerDriftCount, int regularCount, string? message)
     {
+        var nestedSuffix = nestedPointerDriftCount > 0
+            ? $" Leave {nestedPointerDriftCount} clean nested-pointer-drift submodule(s) untouched."
+            : string.Empty;
         if (gitlinkCount > 0 && regularCount > 0)
-            return $"workspace-guard begin (dry-run): would preserve {gitlinkCount} gitlink path(s) via checkout lane and stash {regularCount} regular path(s) under '{message}'. Re-run with --write to apply.";
+            return $"workspace-guard begin (dry-run): would preserve {gitlinkCount} gitlink path(s) via checkout lane and stash {regularCount} regular path(s) under '{message}'.{nestedSuffix} Re-run with --write to apply.";
         if (gitlinkCount > 0)
-            return $"workspace-guard begin (dry-run): would preserve {gitlinkCount} gitlink-only path(s) via checkout lane. Re-run with --write to apply.";
-        return $"workspace-guard begin (dry-run): would stash {regularCount} path(s) under '{message}'. Re-run with --write to apply.";
+            return $"workspace-guard begin (dry-run): would preserve {gitlinkCount} gitlink-only path(s) via checkout lane.{nestedSuffix} Re-run with --write to apply.";
+        return $"workspace-guard begin (dry-run): would stash {regularCount} path(s) under '{message}'.{nestedSuffix} Re-run with --write to apply.";
     }
 
     private static string BuildBeginSuccessSummary(int gitlinkCount, int regularCount, string? stashRef, string statePath)
@@ -556,13 +570,6 @@ internal static class AutomationWorkspaceGuardCommand
         return entries;
     }
 
-    private static bool IsDurableStatePath(string path)
-    {
-        var normalized = path.Replace('\\', '/').TrimStart('/');
-        return normalized.StartsWith(".intent-cli/", StringComparison.Ordinal)
-            || normalized.StartsWith("intents/", StringComparison.Ordinal);
-    }
-
     private static string BuildStashMessage()
     {
         var iso = ResolveNow().ToString("yyyy-MM-ddTHH:mm:ssZ", System.Globalization.CultureInfo.InvariantCulture);
@@ -634,6 +641,7 @@ internal static class AutomationWorkspaceGuardCommand
         }
         writer.WriteLine($"- safe_stash_paths: {result.SafeStashPaths.Count}");
         writer.WriteLine($"- gitlink_paths: {result.GitlinkPaths.Count}");
+        writer.WriteLine($"- nested_pointer_drift_submodules: {result.NestedPointerDriftSubmodules.Count}");
         writer.WriteLine($"- dirty_durable_state_paths: {result.DirtyDurableStatePaths.Count}");
         if (result.ConflictPaths.Count > 0)
         {
@@ -659,6 +667,19 @@ internal static class AutomationWorkspaceGuardCommand
                 writer.WriteLine($"- `{entry.Status}` `{entry.Path}`");
             }
         }
+        if (result.NestedPointerDriftSubmodules.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Clean nested-pointer drift (left untouched)");
+            foreach (var drift in result.NestedPointerDriftSubmodules)
+            {
+                writer.WriteLine($"- owning submodule `{drift.OwningSubmodulePath}` (parent-recorded `{drift.ParentRecordedCommit}`)");
+                foreach (var nestedPath in drift.UntouchedNestedPaths)
+                {
+                    writer.WriteLine($"  - untouched nested path `{nestedPath}`");
+                }
+            }
+        }
         if (result.DirtyDurableStatePaths.Count > 0)
         {
             writer.WriteLine();
@@ -681,40 +702,6 @@ internal static class AutomationWorkspaceGuardCommand
 
     // ------------------------------------------------------------------ G352 helpers
 
-    /// <summary>
-    /// G352: checks whether <paramref name="path"/> is a submodule gitlink (mode 160000)
-    /// in the git index, and returns the parent-recorded commit sha.
-    /// </summary>
-    private static bool TryGetGitlinkCommit(IGitRunner runner, string path, out string parentCommit)
-    {
-        var result = runner.Run(new[] { "ls-files", "--stage", "--", path });
-        if (result.ExitCode != 0 || string.IsNullOrWhiteSpace(result.StandardOutput))
-        {
-            parentCommit = string.Empty;
-            return false;
-        }
-        // Format: "<mode> <sha> <stage>\t<path>"
-        var firstLine = result.StandardOutput.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
-        var parts = firstLine.Split(' ', 3);
-        if (parts.Length < 2 || !string.Equals(parts[0], "160000", StringComparison.Ordinal))
-        {
-            parentCommit = string.Empty;
-            return false;
-        }
-        parentCommit = parts[1].Trim();
-        return true;
-    }
-
-    /// <summary>
-    /// G352: returns true when the submodule at <paramref name="submodulePath"/>
-    /// has no internal uncommitted changes (clean working tree inside the submodule).
-    /// </summary>
-    private static bool IsSubmoduleInternallyClean(IGitRunner runner, string submodulePath)
-    {
-        var result = runner.Run(new[] { "-C", submodulePath, "status", "--short" });
-        return result.ExitCode == 0 && string.IsNullOrWhiteSpace(result.StandardOutput);
-    }
-
     /// <summary>G352: returns the current HEAD sha of the submodule, or null on failure.</summary>
     private static string? GetCurrentSubmoduleHead(IGitRunner runner, string submodulePath)
     {
@@ -723,25 +710,36 @@ internal static class AutomationWorkspaceGuardCommand
     }
 
     /// <summary>
-    /// G352: classifies non-durable dirty entries into gitlink-only,
-    /// submodule-internal-dirty, and regular buckets.
+    /// G791: classifies non-durable dirty entries into gitlink-only,
+    /// clean nested-pointer drift, submodule-internal-dirty, and regular buckets.
     /// </summary>
     private static (
         IReadOnlyList<(HostSyncWorkingTreeEntry Entry, string ParentCommit)> GitlinkOnly,
         IReadOnlyList<HostSyncWorkingTreeEntry> SubmoduleInternalDirty,
+        IReadOnlyList<NestedPointerDriftSubmodule> NestedPointerDrift,
         IReadOnlyList<HostSyncWorkingTreeEntry> Regular)
     ClassifyNonDurableEntries(IGitRunner runner, IReadOnlyList<HostSyncWorkingTreeEntry> nonDurableEntries)
     {
         var gitlinkOnly = new List<(HostSyncWorkingTreeEntry, string)>();
         var submoduleInternalDirty = new List<HostSyncWorkingTreeEntry>();
+        var nestedPointerDrift = new List<NestedPointerDriftSubmodule>();
         var regular = new List<HostSyncWorkingTreeEntry>();
 
         foreach (var entry in nonDurableEntries)
         {
-            if (TryGetGitlinkCommit(runner, entry.Path, out var parentCommit))
+            if (NestedSubmodulePointerDriftDetector.TryGetParentRecordedGitlinkCommit(runner, entry.Path, out var parentCommit))
             {
-                if (IsSubmoduleInternallyClean(runner, entry.Path))
+                var submoduleStatus = runner.Run(["-C", entry.Path, "status", "--porcelain"]);
+                if (submoduleStatus.ExitCode == 0 && string.IsNullOrWhiteSpace(submoduleStatus.StandardOutput))
                     gitlinkOnly.Add((entry, parentCommit));
+                else if (submoduleStatus.ExitCode == 0
+                    && NestedSubmodulePointerDriftDetector.TryDetect(
+                        runner,
+                        entry.Path,
+                        parentCommit,
+                        submoduleStatus.StandardOutput,
+                        out var drift))
+                    nestedPointerDrift.Add(drift);
                 else
                     submoduleInternalDirty.Add(entry);
             }
@@ -750,7 +748,7 @@ internal static class AutomationWorkspaceGuardCommand
                 regular.Add(entry);
             }
         }
-        return (gitlinkOnly, submoduleInternalDirty, regular);
+        return (gitlinkOnly, submoduleInternalDirty, nestedPointerDrift, regular);
     }
 
     // ------------------------------------------------------------------ arg parse
@@ -878,6 +876,13 @@ internal sealed record WorkspaceGuardResult
     /// </summary>
     [JsonPropertyName("gitlink_paths")]
     public IReadOnlyList<HostSyncWorkingTreeEntry> GitlinkPaths { get; init; } = Array.Empty<HostSyncWorkingTreeEntry>();
+
+    /// <summary>
+    /// G791: host gitlink is aligned and the only dirt is clean nested-submodule
+    /// pointer drift. These foreign paths deliberately remain untouched.
+    /// </summary>
+    [JsonPropertyName("nested_pointer_drift_submodules")]
+    public IReadOnlyList<NestedPointerDriftSubmodule> NestedPointerDriftSubmodules { get; init; } = Array.Empty<NestedPointerDriftSubmodule>();
 }
 
 /// <summary>G352: gitlink restore entry recording the original submodule HEAD so

--- a/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
@@ -727,16 +727,24 @@ internal static class AutomationWorkspaceGuardCommand
 
         foreach (var entry in nonDurableEntries)
         {
-            if (NestedSubmodulePointerDriftDetector.TryGetParentRecordedGitlinkCommit(runner, entry.Path, out var parentCommit))
+            var parentGitlink = NestedSubmodulePointerDriftDetector.InspectParentGitlink(runner, entry.Path);
+            if (parentGitlink.HasStagedGitlinkChange)
+            {
+                // G791 repair: an MM parent entry is not clean nested-pointer
+                // drift. Do not let it fall through to G306, and do not
+                // checkout a value that is only present in the index.
+                submoduleInternalDirty.Add(entry);
+            }
+            else if (parentGitlink.IsAligned)
             {
                 var submoduleStatus = runner.Run(["-C", entry.Path, "status", "--porcelain"]);
                 if (submoduleStatus.ExitCode == 0 && string.IsNullOrWhiteSpace(submoduleStatus.StandardOutput))
-                    gitlinkOnly.Add((entry, parentCommit));
+                    gitlinkOnly.Add((entry, parentGitlink.HeadRecordedCommit!));
                 else if (submoduleStatus.ExitCode == 0
                     && NestedSubmodulePointerDriftDetector.TryDetect(
                         runner,
                         entry.Path,
-                        parentCommit,
+                        parentGitlink.HeadRecordedCommit!,
                         submoduleStatus.StandardOutput,
                         out var drift))
                     nestedPointerDrift.Add(drift);

--- a/src/IntentSystem.Cli/Commands/DurableHostStatePathClassifier.cs
+++ b/src/IntentSystem.Cli/Commands/DurableHostStatePathClassifier.cs
@@ -1,0 +1,35 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G791: the one authority for deciding whether a repository-relative path is
+/// durable host state. The workspace guard, host-sync preflight, and durable
+/// state preflight must agree on this boundary: a path cannot be unsafe to
+/// stash in one command and invisible to the command that names the recovery.
+/// </summary>
+internal static class DurableHostStatePathClassifier
+{
+    public static bool IsDurableHostStatePath(string? path)
+    {
+        var normalized = NormalizePath(path);
+        return normalized.Equals(".intent-cli", StringComparison.Ordinal)
+            || normalized.StartsWith(".intent-cli/", StringComparison.Ordinal)
+            || normalized.Equals("intents", StringComparison.Ordinal)
+            || normalized.StartsWith("intents/", StringComparison.Ordinal)
+            || normalized.Equals("AGENTS.md", StringComparison.Ordinal)
+            || normalized.Equals("CLAUDE.md", StringComparison.Ordinal);
+    }
+
+    public static bool IsDurableHostStateParent(string? path)
+    {
+        var normalized = NormalizePath(path).TrimEnd('/');
+        return normalized.Equals(".intent-cli", StringComparison.Ordinal)
+            || normalized.StartsWith(".intent-cli/", StringComparison.Ordinal)
+            || normalized.Equals("intents", StringComparison.Ordinal)
+            || normalized.StartsWith("intents/", StringComparison.Ordinal);
+    }
+
+    public static string NormalizePath(string? path) =>
+        string.IsNullOrWhiteSpace(path)
+            ? string.Empty
+            : path.Replace('\\', '/').TrimStart('/');
+}

--- a/src/IntentSystem.Cli/Commands/DurableRuntimeRecordAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/DurableRuntimeRecordAnalyzer.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G791: validates forward-only host runtime records outside queue-state and
+/// runs.jsonl. JSONL ledgers are accepted only when existing non-empty lines
+/// remain byte-identical and every newly appended line is JSON. The measured
+/// supervision emission policy is accepted only as a structurally valid
+/// generated policy record; all other durable paths still route to review or
+/// unsafe lanes in DurableStatePreflightAnalyzer.
+/// </summary>
+internal static class DurableRuntimeRecordAnalyzer
+{
+    public const string ClassificationAppendOnly = "append-only";
+    public const string ClassificationValidPolicy = "valid-policy";
+    public const string ClassificationNeedsOperatorReview = "needs-operator-review";
+    public const string ClassificationInvalid = "invalid";
+
+    public static bool IsCandidate(string path) =>
+        IsAppendOnlyJsonlPath(path) || IsEmissionPolicyPath(path);
+
+    public static DurableRuntimeRecordDelta Analyze(string path, string headContent, string workingContent)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(headContent);
+        ArgumentNullException.ThrowIfNull(workingContent);
+
+        var normalized = DurableHostStatePathClassifier.NormalizePath(path);
+        if (IsAppendOnlyJsonlPath(normalized))
+        {
+            return AnalyzeAppendOnlyJsonl(normalized, headContent, workingContent);
+        }
+        if (IsEmissionPolicyPath(normalized))
+        {
+            return AnalyzeEmissionPolicy(normalized, workingContent);
+        }
+        return NeedsReview($"'{normalized}' is not a recognized append-only runtime record or generated supervision policy.");
+    }
+
+    private static DurableRuntimeRecordDelta AnalyzeAppendOnlyJsonl(string path, string headContent, string workingContent)
+    {
+        var headLines = SplitNonEmptyLines(headContent);
+        var workingLines = SplitNonEmptyLines(workingContent);
+        if (workingLines.Count < headLines.Count)
+        {
+            return NeedsReview($"'{path}' shrank from {headLines.Count} to {workingLines.Count} records; refuse append-only auto-commit.");
+        }
+
+        for (var index = 0; index < headLines.Count; index++)
+        {
+            if (!string.Equals(headLines[index], workingLines[index], StringComparison.Ordinal))
+            {
+                return NeedsReview($"'{path}' record {index + 1} was modified in place; refuse append-only auto-commit.");
+            }
+        }
+
+        var appended = workingLines.Skip(headLines.Count).ToArray();
+        if (appended.Length == 0)
+        {
+            return NeedsReview($"'{path}' is dirty without a new appended record; refuse auto-commit.");
+        }
+
+        for (var index = 0; index < appended.Length; index++)
+        {
+            try
+            {
+                using var _ = JsonDocument.Parse(appended[index]);
+            }
+            catch (JsonException exception)
+            {
+                return Invalid($"'{path}' appended record {headLines.Count + index + 1} is not valid JSON: {exception.Message}");
+            }
+        }
+
+        return new DurableRuntimeRecordDelta
+        {
+            Classification = ClassificationAppendOnly,
+            Summary = $"'{path}' is append-only with {appended.Length} new runtime record(s).",
+            AppendedRecordCount = appended.Length,
+        };
+    }
+
+    private static DurableRuntimeRecordDelta AnalyzeEmissionPolicy(string path, string workingContent)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(workingContent);
+            if (document.RootElement.ValueKind != JsonValueKind.Object
+                || !HasNonEmptyString(document.RootElement, "domain")
+                || !HasNonEmptyString(document.RootElement, "team")
+                || !HasPositiveInt(document.RootElement, "full_cadence_seconds")
+                || !HasPositiveInt(document.RootElement, "repeat_backoff_seconds")
+                || !HasPositiveInt(document.RootElement, "debounce_consecutive_observations")
+                || !HasNonEmptyString(document.RootElement, "recorded_at"))
+            {
+                return Invalid($"'{path}' is not a complete generated supervision emission policy.");
+            }
+        }
+        catch (JsonException exception)
+        {
+            return Invalid($"'{path}' is not valid JSON: {exception.Message}");
+        }
+
+        return new DurableRuntimeRecordDelta
+        {
+            Classification = ClassificationValidPolicy,
+            Summary = $"'{path}' is a valid generated supervision emission policy record.",
+            AppendedRecordCount = 0,
+        };
+    }
+
+    private static bool IsAppendOnlyJsonlPath(string path) =>
+        path.EndsWith(".jsonl", StringComparison.Ordinal)
+        && (path.StartsWith(".intent-cli/continuation-chains/", StringComparison.Ordinal)
+            || path.StartsWith(".intent-cli/events/", StringComparison.Ordinal)
+            || path.StartsWith(".intent-cli/notify/", StringComparison.Ordinal)
+            || path.StartsWith(".intent-cli/supervision/", StringComparison.Ordinal));
+
+    private static bool IsEmissionPolicyPath(string path) =>
+        path.StartsWith(".intent-cli/supervision/", StringComparison.Ordinal)
+        && path.EndsWith("/emission-policy.json", StringComparison.Ordinal);
+
+    private static IReadOnlyList<string> SplitNonEmptyLines(string content) =>
+        content.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n')
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToArray();
+
+    private static bool HasNonEmptyString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var property)
+        && property.ValueKind == JsonValueKind.String
+        && !string.IsNullOrWhiteSpace(property.GetString());
+
+    private static bool HasPositiveInt(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var property)
+        && property.ValueKind == JsonValueKind.Number
+        && property.TryGetInt32(out var value)
+        && value > 0;
+
+    private static DurableRuntimeRecordDelta NeedsReview(string summary) => new()
+    {
+        Classification = ClassificationNeedsOperatorReview,
+        Summary = summary,
+        AppendedRecordCount = 0,
+    };
+
+    private static DurableRuntimeRecordDelta Invalid(string summary) => new()
+    {
+        Classification = ClassificationInvalid,
+        Summary = summary,
+        AppendedRecordCount = 0,
+    };
+}
+
+internal sealed record DurableRuntimeRecordDelta
+{
+    public required string Classification { get; init; }
+    public required string Summary { get; init; }
+    public required int AppendedRecordCount { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/DurableStatePreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/DurableStatePreflightAnalyzer.cs
@@ -17,6 +17,7 @@ namespace IntentSystem.Cli.Commands;
 /// </summary>
 internal static class DurableStatePreflightAnalyzer
 {
+    public const string ClassificationClean = "clean";
     public const string ClassificationVerifiedCommitReady = "verified-commit-ready";
     public const string ClassificationNeedsOperatorReview = "needs-operator-review";
     public const string ClassificationUnsafe = "unsafe-durable-state";
@@ -129,6 +130,11 @@ internal static class DurableStatePreflightAnalyzer
                             Path = path,
                             Reason = $"`{path}` is dirty inside `{IssuesDirectorySegment}` but is not a recognized canonical publish artifact; host-loop auto-commit must not touch operator-owned issue metadata.",
                         });
+                        break;
+                    }
+                    if (entry.RuntimeRecordDelta is not null)
+                    {
+                        ApplyRuntimeRecordResult(path, entry.RuntimeRecordDelta, verified, review, unsafePaths);
                         break;
                     }
                     // Untracked durable-state path that isn't queue-state or runs.jsonl
@@ -260,6 +266,50 @@ internal static class DurableStatePreflightAnalyzer
                 {
                     Path = path,
                     Reason = $"unrecognized runs.jsonl delta classification `{entry.RunsJsonlDelta.Classification}` for `{path}`.",
+                });
+                break;
+        }
+    }
+
+    private static void ApplyRuntimeRecordResult(
+        string path,
+        DurableRuntimeRecordDelta delta,
+        List<DurableStateVerifiedPath> verified,
+        List<DurableStateReviewPath> review,
+        List<DurableStateUnsafePath> unsafePaths)
+    {
+        switch (delta.Classification)
+        {
+            case DurableRuntimeRecordAnalyzer.ClassificationAppendOnly:
+            case DurableRuntimeRecordAnalyzer.ClassificationValidPolicy:
+                verified.Add(new DurableStateVerifiedPath
+                {
+                    Path = path,
+                    Summary = delta.Summary,
+                });
+                break;
+
+            case DurableRuntimeRecordAnalyzer.ClassificationNeedsOperatorReview:
+                review.Add(new DurableStateReviewPath
+                {
+                    Path = path,
+                    Reason = delta.Summary,
+                });
+                break;
+
+            case DurableRuntimeRecordAnalyzer.ClassificationInvalid:
+                unsafePaths.Add(new DurableStateUnsafePath
+                {
+                    Path = path,
+                    Reason = delta.Summary,
+                });
+                break;
+
+            default:
+                unsafePaths.Add(new DurableStateUnsafePath
+                {
+                    Path = path,
+                    Reason = $"unrecognized runtime durable-state classification '{delta.Classification}' for '{path}'.",
                 });
                 break;
         }
@@ -436,7 +486,7 @@ internal static class DurableStatePreflightAnalyzer
         }
         return verified > 0
             ? ClassificationVerifiedCommitReady
-            : ClassificationNeedsOperatorReview;
+            : ClassificationClean;
     }
 
     private static bool IsAlwaysUnsafe(string normalizedPath)
@@ -470,6 +520,8 @@ internal static class DurableStatePreflightAnalyzer
         {
             ClassificationVerifiedCommitReady =>
                 $"All {verified.Count} dirty durable-state path(s) are deterministic forward-only updates; safe to auto-commit (G312).",
+            ClassificationClean =>
+                "No dirty durable-state paths are present; durable-state preflight is clean (G312).",
             ClassificationNeedsOperatorReview =>
                 $"{review.Count} dirty durable-state path(s) need operator review before commit (G312); auto-commit refused.",
             ClassificationUnsafe =>
@@ -504,6 +556,13 @@ internal sealed record DurableStateDirtyPath
     /// path or when the file could not be read.
     /// </summary>
     public PublishYamlCanonicalResult? PublishYamlDelta { get; init; }
+
+    /// <summary>
+    /// G791: optional verdict for append-only runtime JSONL ledgers and the
+    /// generated supervision emission policy. Null keeps an otherwise
+    /// unrecognized durable path in the operator-review lane.
+    /// </summary>
+    public DurableRuntimeRecordDelta? RuntimeRecordDelta { get; init; }
 
     /// <summary>
     /// G361: optional prepared-packet classification for dirty

--- a/src/IntentSystem.Cli/Commands/HostSyncPreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostSyncPreflightAnalyzer.cs
@@ -22,6 +22,9 @@ namespace IntentSystem.Cli.Commands;
 /// <item><c>submodule-checkout-mismatch</c> — G357: parent gitlink has advanced (typically after git pull)
 ///   but the submodule working tree checkout is still at the old commit; the submodule itself is clean so
 ///   <c>git submodule update --init &lt;path&gt;</c> is the deterministic safe repair.</item>
+/// <item><c>nested-pointer-drift</c> — G791: the host gitlink is aligned, and its only dirt is
+///   clean nested-submodule pointer drift owned by another domain. The wake may proceed while leaving
+///   those foreign paths untouched; it must not enter a stash, checkout, or submodule-update lane.</item>
 /// </list>
 /// </summary>
 internal static class HostSyncPreflightAnalyzer
@@ -46,20 +49,18 @@ internal static class HostSyncPreflightAnalyzer
     public const string ClassificationDirtyUnrelatedSubmodule = "dirty-unrelated-submodule";
     public const string ClassificationDirtyMixed = "dirty-mixed";
 
+    /// <summary>G791: actual content within a submodule checkout; manual owning-team reconciliation is required.</summary>
+    public const string ClassificationSubmoduleInternalDirty = "submodule-internal-dirty";
+
+    /// <summary>G791: aligned host gitlinks whose only dirt is clean nested-pointer drift.</summary>
+    public const string ClassificationNestedPointerDrift = "nested-pointer-drift";
+
     /// <summary>
     /// G357: parent gitlink has advanced but submodule working tree checkout is stale.
     /// All paths in this classification have no local uncommitted changes inside the
     /// submodule, so <c>git submodule update --init &lt;path&gt;</c> is the safe repair.
     /// </summary>
     public const string ClassificationSubmoduleCheckoutMismatch = "submodule-checkout-mismatch";
-
-    private static readonly string[] DurableStatePathPrefixes =
-    [
-        ".intent-cli/queue-state.json",
-        ".intent-cli/runs.jsonl",
-        ".intent-cli/issues/",
-        "intents/"
-    ];
 
     /// <param name="submoduleGitlinkMismatchPaths">
     /// G357: paths where the parent gitlink has advanced but the submodule working tree
@@ -75,7 +76,9 @@ internal static class HostSyncPreflightAnalyzer
         IReadOnlyList<string>? submoduleGitlinkMismatchPaths = null,
         int aheadOriginCommits = 0,
         IReadOnlyList<HostSyncCommitInfo>? localOnlyCommits = null,
-        IReadOnlyList<HostSyncCommitInfo>? originAheadCommits = null)
+        IReadOnlyList<HostSyncCommitInfo>? originAheadCommits = null,
+        IReadOnlyList<NestedPointerDriftSubmodule>? nestedPointerDriftSubmodules = null,
+        IReadOnlyList<string>? submoduleInternalDirtyPaths = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(branch);
         ArgumentNullException.ThrowIfNull(workingTreeEntries);
@@ -94,12 +97,19 @@ internal static class HostSyncPreflightAnalyzer
         var mismatchSet = submoduleGitlinkMismatchPaths is { Count: > 0 }
             ? new HashSet<string>(submoduleGitlinkMismatchPaths, StringComparer.Ordinal)
             : null;
+        var nestedPointerDrift = nestedPointerDriftSubmodules ?? Array.Empty<NestedPointerDriftSubmodule>();
+        var nestedPointerDriftSet = nestedPointerDrift.Count > 0
+            ? new HashSet<string>(nestedPointerDrift.Select(drift => drift.OwningSubmodulePath), StringComparer.Ordinal)
+            : null;
+        var submoduleInternalDirtySet = submoduleInternalDirtyPaths is { Count: > 0 }
+            ? new HashSet<string>(submoduleInternalDirtyPaths, StringComparer.Ordinal)
+            : null;
 
         var dirtyDurable = new List<HostSyncWorkingTreeEntry>();
         var dirtyOther = new List<HostSyncWorkingTreeEntry>();
         foreach (var entry in workingTreeEntries)
         {
-            if (IsDurableStatePath(entry.Path))
+            if (DurableHostStatePathClassifier.IsDurableHostStatePath(entry.Path))
             {
                 dirtyDurable.Add(entry);
             }
@@ -114,10 +124,21 @@ internal static class HostSyncPreflightAnalyzer
         var allOtherAreGitlinkMismatches = mismatchSet is not null
             && dirtyOther.Count > 0
             && dirtyOther.All(e => mismatchSet.Contains(e.Path));
+        var allOtherAreNestedPointerDrift = nestedPointerDriftSet is not null
+            && dirtyOther.Count > 0
+            && dirtyOther.All(e => nestedPointerDriftSet.Contains(e.Path));
+        var hasSubmoduleInternalDirty = submoduleInternalDirtySet is not null
+            && dirtyOther.Any(e => submoduleInternalDirtySet.Contains(e.Path));
 
         var clean = behindOriginCommits == 0 && dirtyDurable.Count == 0 && dirtyOther.Count == 0;
         var classification = ClassifyTerminal(
-            behindOriginCommits, aheadOriginCommits, dirtyDurable.Count, dirtyOther.Count, allOtherAreGitlinkMismatches);
+            behindOriginCommits,
+            aheadOriginCommits,
+            dirtyDurable.Count,
+            dirtyOther.Count,
+            allOtherAreGitlinkMismatches,
+            allOtherAreNestedPointerDrift,
+            hasSubmoduleInternalDirty);
 
         // G306: when ONLY unrelated dirty paths are present (no dirty
         // durable host-state, no `dirty-mixed`, no submodule-checkout-mismatch),
@@ -127,10 +148,15 @@ internal static class HostSyncPreflightAnalyzer
         // `dirty-mixed` remain hard stops because automation cannot safely stash files
         // it might also be about to mutate. G357 submodule-checkout-mismatch uses the
         // `git submodule update --init` lane instead — NOT the safe-stash lane.
-        var safeStashAllowed = dirtyDurable.Count == 0
-            && dirtyOther.Count > 0
-            && !allOtherAreGitlinkMismatches;
-        var proceedAllowed = clean || safeStashAllowed;
+        var safeStashPaths = dirtyDurable.Count == 0
+            ? dirtyOther.Where(entry => (nestedPointerDriftSet is null || !nestedPointerDriftSet.Contains(entry.Path))
+                && (submoduleInternalDirtySet is null || !submoduleInternalDirtySet.Contains(entry.Path))).ToArray()
+            : Array.Empty<HostSyncWorkingTreeEntry>();
+        var safeStashAllowed = safeStashPaths.Length > 0
+            && !allOtherAreGitlinkMismatches
+            && !hasSubmoduleInternalDirty;
+        var nestedPointerDriftAllowed = dirtyDurable.Count == 0 && allOtherAreNestedPointerDrift;
+        var proceedAllowed = clean || safeStashAllowed || nestedPointerDriftAllowed;
 
         // SubmoduleCheckoutMismatchPaths is only populated for the
         // submodule-checkout-mismatch classification; dirty-mixed and other
@@ -138,10 +164,25 @@ internal static class HostSyncPreflightAnalyzer
         var mismatchPathsList = string.Equals(classification, ClassificationSubmoduleCheckoutMismatch, StringComparison.Ordinal)
             ? dirtyOther.Select(e => e.Path).ToArray()
             : Array.Empty<string>();
+        var nestedPointerDriftList = string.Equals(classification, ClassificationNestedPointerDrift, StringComparison.Ordinal)
+            ? nestedPointerDrift
+            : Array.Empty<NestedPointerDriftSubmodule>();
+        var submoduleInternalDirtyList = string.Equals(classification, ClassificationSubmoduleInternalDirty, StringComparison.Ordinal)
+            ? dirtyOther.Where(entry => submoduleInternalDirtySet!.Contains(entry.Path)).Select(entry => entry.Path).ToArray()
+            : Array.Empty<string>();
 
         var isFfBlocked = string.Equals(classification, ClassificationFfBlocked, StringComparison.Ordinal);
         var nextSteps = BuildNextSteps(
-            classification, behindOriginCommits, aheadOriginCommits, dirtyDurable, dirtyOther, mismatchPathsList, localOnly, originAhead);
+            classification,
+            behindOriginCommits,
+            aheadOriginCommits,
+            dirtyDurable,
+            dirtyOther,
+            mismatchPathsList,
+            nestedPointerDriftList,
+            submoduleInternalDirtyList,
+            localOnly,
+            originAhead);
 
         return new HostSyncPreflightResult
         {
@@ -160,33 +201,26 @@ internal static class HostSyncPreflightAnalyzer
             SafeStashRequired = safeStashAllowed,
             // G306: SafeStashPaths only populated when the safe-stash lane is active.
             // G357: submodule-checkout-mismatch uses the update lane, not safe-stash.
-            SafeStashPaths = safeStashAllowed ? dirtyOther : Array.Empty<HostSyncWorkingTreeEntry>(),
+            SafeStashPaths = safeStashAllowed ? safeStashPaths : Array.Empty<HostSyncWorkingTreeEntry>(),
             DirtyDurableStatePaths = dirtyDurable,
             DirtyUnrelatedPaths = dirtyOther,
             SubmoduleCheckoutMismatchPaths = mismatchPathsList,
+            NestedPointerDriftSubmodules = nestedPointerDriftList,
+            SubmoduleInternalDirtyPaths = submoduleInternalDirtyList,
             LocalOnlyCommits = localOnly,
             OriginAheadCommits = originAhead,
             Summary = BuildSummary(
-                classification, branch, behindOriginCommits, aheadOriginCommits, dirtyDurable.Count, dirtyOther.Count, mismatchPathsList),
+                classification,
+                branch,
+                behindOriginCommits,
+                aheadOriginCommits,
+                dirtyDurable.Count,
+                dirtyOther.Count,
+                mismatchPathsList,
+                nestedPointerDriftList,
+                submoduleInternalDirtyList),
             NextSteps = nextSteps
         };
-    }
-
-    private static bool IsDurableStatePath(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-        var normalized = path.Replace('\\', '/').TrimStart('/');
-        foreach (var prefix in DurableStatePathPrefixes)
-        {
-            if (normalized.StartsWith(prefix, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static string ClassifyTerminal(
@@ -194,7 +228,9 @@ internal static class HostSyncPreflightAnalyzer
         int aheadOriginCommits,
         int dirtyDurableCount,
         int dirtyOtherCount,
-        bool allOtherAreGitlinkMismatches)
+        bool allOtherAreGitlinkMismatches,
+        bool allOtherAreNestedPointerDrift,
+        bool hasSubmoduleInternalDirty)
     {
         if (dirtyDurableCount > 0 && dirtyOtherCount > 0)
         {
@@ -206,6 +242,14 @@ internal static class HostSyncPreflightAnalyzer
         }
         if (dirtyOtherCount > 0)
         {
+            if (hasSubmoduleInternalDirty)
+            {
+                return ClassificationSubmoduleInternalDirty;
+            }
+            if (allOtherAreNestedPointerDrift)
+            {
+                return ClassificationNestedPointerDrift;
+            }
             // G357: all dirty-other paths are submodule gitlink mismatches whose
             // submodules themselves are clean → deterministic safe-update lane.
             return allOtherAreGitlinkMismatches
@@ -235,7 +279,9 @@ internal static class HostSyncPreflightAnalyzer
         int aheadCount,
         int dirtyDurableCount,
         int dirtyOtherCount,
-        IReadOnlyList<string> mismatchPaths)
+        IReadOnlyList<string> mismatchPaths,
+        IReadOnlyList<NestedPointerDriftSubmodule> nestedPointerDriftSubmodules,
+        IReadOnlyList<string> submoduleInternalDirtyPaths)
     {
         return classification switch
         {
@@ -251,8 +297,12 @@ internal static class HostSyncPreflightAnalyzer
                 $"Host repo on `{branch}` has {dirtyOtherCount} uncommitted change(s) outside durable host-state. Use the G306 safe-stash lane (`automation workspace-guard --mode begin --write` before the wake, `--mode end --write` after) to preserve and restore the unrelated changes; durable host-state remains untouched.",
             ClassificationDirtyMixed =>
                 $"Host repo on `{branch}` has {dirtyDurableCount} dirty durable-state path(s) AND {dirtyOtherCount} unrelated dirty path(s). Refusing to proceed (G304); both buckets must be reconciled before the wake.",
+            ClassificationSubmoduleInternalDirty =>
+                $"Host repo on `{branch}` has uncommitted content inside submodule checkout(s): {string.Join(", ", submoduleInternalDirtyPaths)}. Refusing to proceed: do not enter the G306 safe-stash lane because workspace-guard would refuse; the owning team must reconcile those paths manually.",
             ClassificationSubmoduleCheckoutMismatch =>
                 $"Host repo on `{branch}` has {mismatchPaths.Count} submodule gitlink mismatch(es): the parent gitlink has advanced but the submodule checkout is stale (G357). Run `git submodule update --init {string.Join(" ", mismatchPaths)}` to update the submodule checkout(s) to the parent-recorded commit, then re-run `automation host-sync-preflight` to confirm clean.",
+            ClassificationNestedPointerDrift =>
+                $"Host repo on `{branch}` has {nestedPointerDriftSubmodules.Count} aligned host gitlink(s) with only clean nested-pointer drift (G791). The wake may proceed, but leave the owning and nested submodule paths untouched: do not stash, checkout, update, add, or commit another domain's paths.",
             _ => throw new InvalidOperationException($"Unknown host-sync classification '{classification}'.")
         };
     }
@@ -264,6 +314,8 @@ internal static class HostSyncPreflightAnalyzer
         IReadOnlyList<HostSyncWorkingTreeEntry> dirtyDurable,
         IReadOnlyList<HostSyncWorkingTreeEntry> dirtyOther,
         IReadOnlyList<string> mismatchPaths,
+        IReadOnlyList<NestedPointerDriftSubmodule> nestedPointerDriftSubmodules,
+        IReadOnlyList<string> submoduleInternalDirtyPaths,
         IReadOnlyList<HostSyncCommitInfo> localOnlyCommits,
         IReadOnlyList<HostSyncCommitInfo> originAheadCommits)
     {
@@ -290,7 +342,9 @@ internal static class HostSyncPreflightAnalyzer
             {
                 "Also reconcile the unrelated dirty paths: " + string.Join(", ", dirtyOther.Select(e => "`" + e.Path + "`"))
             }).ToArray(),
+            ClassificationSubmoduleInternalDirty => BuildSubmoduleInternalDirtySteps(submoduleInternalDirtyPaths),
             ClassificationSubmoduleCheckoutMismatch => BuildSubmoduleMismatchSteps(mismatchPaths),
+            ClassificationNestedPointerDrift => BuildNestedPointerDriftSteps(nestedPointerDriftSubmodules),
             _ => throw new InvalidOperationException($"Unknown host-sync classification '{classification}'.")
         };
     }
@@ -304,6 +358,29 @@ internal static class HostSyncPreflightAnalyzer
             $"Run `git submodule update --init {pathArgs}` to update the submodule checkout(s) to the parent-recorded commit (G357). " +
             $"This is safe because the submodule(s) have no local uncommitted changes (verified by host-sync preflight). Mismatch path(s): {pathList}.",
             "Re-run `intent-cli automation host-sync-preflight --format json` after the update to confirm `classification: clean`."
+        };
+    }
+
+    private static IReadOnlyList<string> BuildNestedPointerDriftSteps(IReadOnlyList<NestedPointerDriftSubmodule> nestedPointerDriftSubmodules)
+    {
+        var ownerPaths = string.Join(", ", nestedPointerDriftSubmodules.Select(drift => $"`{drift.OwningSubmodulePath}`"));
+        var nestedPaths = string.Join(", ", nestedPointerDriftSubmodules.SelectMany(drift => drift.UntouchedNestedPaths).Select(path => $"`{path}`"));
+        return new[]
+        {
+            $"Proceed with the host wake while leaving the foreign owning submodule path(s) untouched: {ownerPaths}.",
+            $"Do NOT run workspace-guard, git stash, git checkout, git submodule update, git add, or git commit against the drifted paths. Clean nested checkout path(s): {nestedPaths}.",
+            "The pointer reconciliation belongs to the owning domain's team. Re-run `intent-cli automation host-sync-preflight --format json` after that team reconciles it."
+        };
+    }
+
+    private static IReadOnlyList<string> BuildSubmoduleInternalDirtySteps(IReadOnlyList<string> paths)
+    {
+        var pathList = string.Join(", ", paths.Select(path => $"`{path}`"));
+        return new[]
+        {
+            $"STOP: uncommitted content exists inside submodule checkout(s): {pathList}. The owning team must reconcile it manually before this wake can continue.",
+            "Do NOT run the G306 safe-stash lane, git stash, git checkout, git submodule update, git add, or git commit against those foreign paths.",
+            "Re-run `intent-cli automation host-sync-preflight --format json` only after the owning team has reconciled the submodule content."
         };
     }
 
@@ -432,6 +509,18 @@ internal sealed record HostSyncPreflightResult
     /// </summary>
     [JsonPropertyName("submodule_checkout_mismatch_paths")]
     public IReadOnlyList<string> SubmoduleCheckoutMismatchPaths { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// G791: aligned host gitlinks whose only dirt is clean nested-submodule pointer
+    /// drift. The host wake may proceed, but every listed path remains untouched.
+    /// Empty unless <see cref="Classification"/> is <c>nested-pointer-drift</c>.
+    /// </summary>
+    [JsonPropertyName("nested_pointer_drift_submodules")]
+    public IReadOnlyList<NestedPointerDriftSubmodule> NestedPointerDriftSubmodules { get; init; } = Array.Empty<NestedPointerDriftSubmodule>();
+
+    /// <summary>G791: submodule paths with real dirty content; never sent through G306.</summary>
+    [JsonPropertyName("submodule_internal_dirty_paths")]
+    public IReadOnlyList<string> SubmoduleInternalDirtyPaths { get; init; } = Array.Empty<string>();
 
     /// <summary>G400: local-only commits (origin/&lt;branch&gt;..HEAD) when ff-blocked. Empty otherwise.</summary>
     [JsonPropertyName("local_only_commits")]

--- a/src/IntentSystem.Cli/Commands/NestedSubmodulePointerDriftDetector.cs
+++ b/src/IntentSystem.Cli/Commands/NestedSubmodulePointerDriftDetector.cs
@@ -10,25 +10,58 @@ namespace IntentSystem.Cli.Commands;
 /// </summary>
 internal static class NestedSubmodulePointerDriftDetector
 {
-    public static bool TryGetParentRecordedGitlinkCommit(IGitRunner runner, string path, out string parentCommit)
+    /// <summary>
+    /// Inspects the gitlink that the parent commit actually records for a
+    /// submodule path. The index is intentionally not trusted here: an index
+    /// modification means the host is no longer in the narrow G791 "aligned
+    /// parent gitlink" state, even if the checkout happens to match the staged
+    /// value. An unreadable staged comparison is likewise fail-closed.
+    /// </summary>
+    public static ParentGitlinkInspection InspectParentGitlink(IGitRunner runner, string path)
     {
-        var result = runner.Run(["ls-files", "--stage", "--", path]);
-        if (result.ExitCode != 0 || string.IsNullOrWhiteSpace(result.StandardOutput))
+        var headResult = runner.Run(["ls-tree", "HEAD", "--", path]);
+        if (headResult.ExitCode != 0 || string.IsNullOrWhiteSpace(headResult.StandardOutput))
         {
-            parentCommit = string.Empty;
-            return false;
+            return ParentGitlinkInspection.NotGitlink;
         }
 
-        var firstLine = result.StandardOutput.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
-        var parts = firstLine.Split(' ', 3);
+        var firstLine = headResult.StandardOutput.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        var parts = firstLine.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length < 2 || !string.Equals(parts[0], "160000", StringComparison.Ordinal))
         {
-            parentCommit = string.Empty;
-            return false;
+            return ParentGitlinkInspection.NotGitlink;
+        }
+        // `git ls-tree` prints "<mode> commit <sha>\t<path>". The fallback
+        // form keeps the parser compatible with older lightweight test runners
+        // that modeled just "<mode> <sha>".
+        var commitIndex = parts.Length >= 3 && string.Equals(parts[1], "commit", StringComparison.Ordinal)
+            ? 2
+            : 1;
+        if (parts.Length <= commitIndex || string.IsNullOrWhiteSpace(parts[commitIndex]))
+        {
+            return ParentGitlinkInspection.NotGitlink;
         }
 
-        parentCommit = parts[1].Trim();
-        return true;
+        // `git diff --cached --quiet` exits 1 for a staged change. Any other
+        // nonzero exit is also unsafe to treat as aligned: a read failure must
+        // never become a direct-proceed decision.
+        var stagedResult = runner.Run(["diff", "--cached", "--quiet", "--", path]);
+        return new ParentGitlinkInspection
+        {
+            HeadRecordedCommit = parts[commitIndex].Trim(),
+            HasStagedGitlinkChange = stagedResult.ExitCode != 0,
+        };
+    }
+
+    /// <summary>
+    /// Compatibility helper for callers that only need an aligned parent
+    /// gitlink. The commit is read from <c>HEAD</c>, never from the index.
+    /// </summary>
+    public static bool TryGetParentRecordedGitlinkCommit(IGitRunner runner, string path, out string parentCommit)
+    {
+        var inspection = InspectParentGitlink(runner, path);
+        parentCommit = inspection.HeadRecordedCommit ?? string.Empty;
+        return inspection.IsAligned;
     }
 
     public static string? GetCurrentHead(IGitRunner runner, string submodulePath)
@@ -156,6 +189,25 @@ internal static class NestedSubmodulePointerDriftDetector
         }
         return paths;
     }
+}
+
+/// <summary>
+/// The parent gitlink inspection used by both G791 callers. A gitlink with a
+/// staged replacement is deliberately distinct from a non-gitlink path: it is
+/// a known unsafe host state that must not fall through to a safe-stash or
+/// direct-proceed lane.
+/// </summary>
+internal sealed record ParentGitlinkInspection
+{
+    public static ParentGitlinkInspection NotGitlink { get; } = new();
+
+    public string? HeadRecordedCommit { get; init; }
+
+    public bool HasStagedGitlinkChange { get; init; }
+
+    public bool IsGitlink => !string.IsNullOrWhiteSpace(HeadRecordedCommit);
+
+    public bool IsAligned => IsGitlink && !HasStagedGitlinkChange;
 }
 
 internal sealed record NestedPointerDriftSubmodule

--- a/src/IntentSystem.Cli/Commands/NestedSubmodulePointerDriftDetector.cs
+++ b/src/IntentSystem.Cli/Commands/NestedSubmodulePointerDriftDetector.cs
@@ -1,0 +1,171 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G791: recognizes the narrow safe case where a host submodule's own gitlink
+/// is aligned, while only clean nested checkouts point at commits different
+/// from that submodule's recorded gitlinks. This detector never repairs the
+/// drift; it records the paths that must remain untouched by this wake.
+/// </summary>
+internal static class NestedSubmodulePointerDriftDetector
+{
+    public static bool TryGetParentRecordedGitlinkCommit(IGitRunner runner, string path, out string parentCommit)
+    {
+        var result = runner.Run(["ls-files", "--stage", "--", path]);
+        if (result.ExitCode != 0 || string.IsNullOrWhiteSpace(result.StandardOutput))
+        {
+            parentCommit = string.Empty;
+            return false;
+        }
+
+        var firstLine = result.StandardOutput.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        var parts = firstLine.Split(' ', 3);
+        if (parts.Length < 2 || !string.Equals(parts[0], "160000", StringComparison.Ordinal))
+        {
+            parentCommit = string.Empty;
+            return false;
+        }
+
+        parentCommit = parts[1].Trim();
+        return true;
+    }
+
+    public static string? GetCurrentHead(IGitRunner runner, string submodulePath)
+    {
+        var result = runner.Run(["-C", submodulePath, "rev-parse", "HEAD"]);
+        return result.ExitCode == 0 ? result.StandardOutput.Trim() : null;
+    }
+
+    public static bool TryDetect(
+        IGitRunner runner,
+        string owningSubmodulePath,
+        string parentRecordedCommit,
+        string owningSubmodulePorcelain,
+        out NestedPointerDriftSubmodule drift)
+    {
+        drift = default!;
+        if (string.IsNullOrWhiteSpace(owningSubmodulePorcelain))
+        {
+            return false;
+        }
+
+        // Fact 1: the host's gitlink is already aligned. A stale host checkout
+        // belongs to G357's deterministic submodule-update lane, not this
+        // leave-it-alone classification.
+        var currentHead = GetCurrentHead(runner, owningSubmodulePath);
+        if (!string.Equals(currentHead, parentRecordedCommit, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Fact 2: the owning submodule itself reports nested gitlinks that
+        // differ from its recorded values (the plus marker from submodule
+        // status). We deliberately do not infer this from porcelain alone.
+        var nestedStatus = runner.Run(["-C", owningSubmodulePath, "submodule", "status"]);
+        if (nestedStatus.ExitCode != 0)
+        {
+            return false;
+        }
+
+        var nestedPointerPaths = ParseDifferingNestedSubmodulePaths(nestedStatus.StandardOutput);
+        if (nestedPointerPaths.Count == 0)
+        {
+            return false;
+        }
+
+        // The owning submodule may be dirty only because of exactly those
+        // nested pointer entries. Any regular file change, untracked file, or
+        // another kind of nested status remains a refusal.
+        var dirtyOwningPaths = ParsePorcelainPaths(owningSubmodulePorcelain);
+        if (dirtyOwningPaths.Count == 0
+            || dirtyOwningPaths.Any(path => !nestedPointerPaths.Contains(path, StringComparer.Ordinal)))
+        {
+            return false;
+        }
+
+        // Fact 3: every nested checkout is clean. A pointer difference is safe
+        // to leave untouched only when there is no content edit inside it.
+        var untouchedPaths = new List<string>();
+        foreach (var nestedPath in nestedPointerPaths)
+        {
+            var fullPath = $"{owningSubmodulePath.TrimEnd('/')}/{nestedPath}";
+            var nestedCheckoutStatus = runner.Run(["-C", fullPath, "status", "--porcelain"]);
+            if (nestedCheckoutStatus.ExitCode != 0 || !string.IsNullOrWhiteSpace(nestedCheckoutStatus.StandardOutput))
+            {
+                return false;
+            }
+            untouchedPaths.Add(fullPath);
+        }
+
+        drift = new NestedPointerDriftSubmodule
+        {
+            OwningSubmodulePath = owningSubmodulePath,
+            ParentRecordedCommit = parentRecordedCommit,
+            UntouchedNestedPaths = untouchedPaths,
+        };
+        return true;
+    }
+
+    private static IReadOnlyList<string> ParseDifferingNestedSubmodulePaths(string output)
+    {
+        var paths = new List<string>();
+        foreach (var rawLine in output.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (rawLine.Length < 3 || rawLine[0] != '+')
+            {
+                continue;
+            }
+
+            var rest = rawLine[1..].TrimStart();
+            var firstSpace = rest.IndexOf(' ');
+            if (firstSpace <= 0)
+            {
+                continue;
+            }
+            var pathAndDescription = rest[(firstSpace + 1)..].Trim();
+            var pathEnd = pathAndDescription.IndexOf(' ');
+            var path = pathEnd >= 0 ? pathAndDescription[..pathEnd] : pathAndDescription;
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                paths.Add(path);
+            }
+        }
+        return paths;
+    }
+
+    private static IReadOnlyList<string> ParsePorcelainPaths(string output)
+    {
+        var paths = new List<string>();
+        foreach (var rawLine in output.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (rawLine.Length < 4)
+            {
+                continue;
+            }
+            var path = rawLine[3..].Trim();
+            var arrowIndex = path.IndexOf(" -> ", StringComparison.Ordinal);
+            if (arrowIndex >= 0)
+            {
+                path = path[(arrowIndex + 4)..].Trim();
+            }
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                paths.Add(path);
+            }
+        }
+        return paths;
+    }
+}
+
+internal sealed record NestedPointerDriftSubmodule
+{
+    [JsonPropertyName("owning_submodule_path")]
+    public required string OwningSubmodulePath { get; init; }
+
+    [JsonPropertyName("parent_recorded_commit")]
+    public required string ParentRecordedCommit { get; init; }
+
+    [JsonPropertyName("untouched_nested_paths")]
+    public required IReadOnlyList<string> UntouchedNestedPaths { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationDurableStatePreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationDurableStatePreflightCommandTests.cs
@@ -211,12 +211,82 @@ public sealed class AutomationDurableStatePreflightCommandTests : IDisposable
             },
             writer);
 
-        // Empty bundle classifies as needs-operator-review per the analyzer.
-        Assert.Equal(1, exitCode);
+        // G791: an empty durable bundle is a successful clean preflight,
+        // never an empty needs-operator-review result.
+        Assert.Equal(0, exitCode);
         using var doc = JsonDocument.Parse(writer.ToString());
         Assert.Equal(
-            DurableStatePreflightAnalyzer.ClassificationNeedsOperatorReview,
+            DurableStatePreflightAnalyzer.ClassificationClean,
             doc.RootElement.GetProperty("classification").GetString());
+        Assert.Contains("No dirty durable-state paths", doc.RootElement.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G791_RuntimeRecords_AgreeWithWorkspaceGuardAndAreCommitReady()
+    {
+        // One real git fixture feeds both commands. The shared classifier must
+        // name exactly the same measured durable paths that the guard refuses,
+        // while durable-state preflight supplies the actionable commit-ready
+        // route for those append-only/generated records.
+        AutomationDurableStatePreflightCommand.ProbeFactory = null;
+        using var workspace = new DurableStateGitWorkspace();
+        workspace.WriteAndModifyG791RuntimeRecords();
+
+        using var durableWriter = new StringWriter();
+        var durableExitCode = AutomationDurableStatePreflightCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            durableWriter);
+
+        using var guardWriter = new StringWriter();
+        var guardExitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "plan", "--format", "json"],
+            guardWriter);
+
+        Assert.Equal(0, durableExitCode);
+        Assert.Equal(1, guardExitCode);
+        using var durableDocument = JsonDocument.Parse(durableWriter.ToString());
+        using var guardDocument = JsonDocument.Parse(guardWriter.ToString());
+        Assert.Equal(DurableStatePreflightAnalyzer.ClassificationVerifiedCommitReady,
+            durableDocument.RootElement.GetProperty("classification").GetString());
+        Assert.NotNull(durableDocument.RootElement.GetProperty("recommended_commit_message").GetString());
+        Assert.False(guardDocument.RootElement.GetProperty("proceed_allowed").GetBoolean());
+
+        var preflightPaths = durableDocument.RootElement.GetProperty("verified_paths")
+            .EnumerateArray()
+            .Select(entry => entry.GetProperty("path").GetString()!)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        var guardPaths = guardDocument.RootElement.GetProperty("dirty_durable_state_paths")
+            .EnumerateArray()
+            .Select(entry => entry.GetProperty("path").GetString()!)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(G791RuntimeRecordPaths, preflightPaths);
+        Assert.Equal(preflightPaths, guardPaths);
+    }
+
+    [Fact]
+    public void Execute_G791_CleanGitWorkspace_PrintsCleanAndExitsZero()
+    {
+        AutomationDurableStatePreflightCommand.ProbeFactory = null;
+        using var workspace = new DurableStateGitWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationDurableStatePreflightCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(DurableStatePreflightAnalyzer.ClassificationClean,
+            document.RootElement.GetProperty("classification").GetString());
+        Assert.Empty(document.RootElement.GetProperty("verified_paths").EnumerateArray());
+        Assert.Empty(document.RootElement.GetProperty("review_paths").EnumerateArray());
+        Assert.Contains("No dirty durable-state paths", document.RootElement.GetProperty("summary").GetString()!, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -493,6 +563,24 @@ public sealed class AutomationDurableStatePreflightCommandTests : IDisposable
             RunGit("commit -q -m bindings");
         }
 
+        public void WriteAndModifyG791RuntimeRecords()
+        {
+            foreach (var path in G791RuntimeRecordPaths)
+            {
+                var absolutePath = Path.Combine(RepoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(absolutePath)!);
+                File.WriteAllText(absolutePath, InitialG791RuntimeContent(path));
+            }
+            RunGit("add .intent-cli");
+            RunGit("commit -q -m g791-runtime-baseline");
+
+            foreach (var path in G791RuntimeRecordPaths)
+            {
+                var absolutePath = Path.Combine(RepoRoot, path.Replace('/', Path.DirectorySeparatorChar));
+                File.WriteAllText(absolutePath, ModifiedG791RuntimeContent(path));
+            }
+        }
+
         public void Dispose()
         {
             if (Directory.Exists(RepoRoot)) Directory.Delete(RepoRoot, recursive: true);
@@ -514,4 +602,23 @@ public sealed class AutomationDurableStatePreflightCommandTests : IDisposable
             process.WaitForExit();
         }
     }
+
+    private static readonly string[] G791RuntimeRecordPaths =
+    [
+        ".intent-cli/continuation-chains/intent-cli/intent-cli-dev/chains.jsonl",
+        ".intent-cli/events/intent-cli/intent-cli-dev.jsonl",
+        ".intent-cli/notify/intent-cli/intent-cli-dev/pending.jsonl",
+        ".intent-cli/notify/intent-cli/intent-cli-dev/report-outbox.jsonl",
+        ".intent-cli/supervision/intent-cli/intent-cli-dev/emission-policy.json",
+    ];
+
+    private static string InitialG791RuntimeContent(string path) =>
+        path.EndsWith("emission-policy.json", StringComparison.Ordinal)
+            ? "{\"domain\":\"intent-cli\",\"team\":\"intent-cli-dev\",\"full_cadence_seconds\":300,\"repeat_backoff_seconds\":600,\"debounce_consecutive_observations\":2,\"recorded_at\":\"2026-09-03T00:00:00Z\"}\n"
+            : "{\"kind\":\"baseline\"}\n";
+
+    private static string ModifiedG791RuntimeContent(string path) =>
+        path.EndsWith("emission-policy.json", StringComparison.Ordinal)
+            ? "{\"domain\":\"intent-cli\",\"team\":\"intent-cli-dev\",\"full_cadence_seconds\":300,\"repeat_backoff_seconds\":600,\"debounce_consecutive_observations\":2,\"recorded_at\":\"2026-09-03T00:05:00Z\"}\n"
+            : "{\"kind\":\"baseline\"}\n{\"kind\":\"append\"}\n";
 }

--- a/tests/IntentSystem.Cli.Tests/AutomationHostSyncPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostSyncPreflightCommandTests.cs
@@ -10,6 +10,7 @@ namespace IntentSystem.Cli.Tests;
 /// ahead-count and diverged-commit details from the git probe into the analyzer
 /// and surfaces the ff-blocked pre-mutation operator stop in its JSON + exit code.
 /// </summary>
+[Collection(AutomationSubmoduleSafetySharedStateCollection.Name)]
 public sealed class AutomationHostSyncPreflightCommandTests : IDisposable
 {
     public void Dispose() => AutomationHostSyncPreflightCommand.GitProbeFactory = null;

--- a/tests/IntentSystem.Cli.Tests/AutomationHostSyncPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostSyncPreflightCommandTests.cs
@@ -75,6 +75,71 @@ public sealed class AutomationHostSyncPreflightCommandTests : IDisposable
         Assert.True(root.GetProperty("durable_runs_summary_allowed").GetBoolean());
     }
 
+    [Fact]
+    public void Execute_G791_CleanNestedPointerDrift_EmitsProceedWithoutSafeStash()
+    {
+        AutomationHostSyncPreflightCommand.GitProbeFactory = _ => new HostSyncGitProbe
+        {
+            Branch = "main",
+            BehindOriginCommits = 0,
+            WorkingTreeEntries = new[]
+            {
+                new HostSyncWorkingTreeEntry { Path = "submodules/SekibanAsAService", Status = " m" }
+            },
+            NestedPointerDriftSubmodules = new[]
+            {
+                new NestedPointerDriftSubmodule
+                {
+                    OwningSubmodulePath = "submodules/SekibanAsAService",
+                    ParentRecordedCommit = "a111111111111111111111111111111111111111",
+                    UntouchedNestedPaths = new[] { "submodules/SekibanAsAService/Sekiban" }
+                }
+            }
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostSyncPreflightCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("nested-pointer-drift", root.GetProperty("classification").GetString());
+        Assert.True(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.False(root.GetProperty("safe_stash_required").GetBoolean());
+        Assert.Equal(0, root.GetProperty("safe_stash_paths").GetArrayLength());
+        var drift = Assert.Single(root.GetProperty("nested_pointer_drift_submodules").EnumerateArray());
+        Assert.Equal("submodules/SekibanAsAService", drift.GetProperty("owning_submodule_path").GetString());
+        Assert.Contains("leave the owning and nested submodule paths untouched", root.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G791_RealNestedContent_RefusesInsteadOfOfferingTheG306Lane()
+    {
+        AutomationHostSyncPreflightCommand.GitProbeFactory = _ => new HostSyncGitProbe
+        {
+            Branch = "main",
+            BehindOriginCommits = 0,
+            WorkingTreeEntries = new[]
+            {
+                new HostSyncWorkingTreeEntry { Path = "submodules/SekibanAsAService", Status = " M" }
+            },
+            SubmoduleInternalDirtyPaths = new[] { "submodules/SekibanAsAService" }
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostSyncPreflightCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("submodule-internal-dirty", root.GetProperty("classification").GetString());
+        Assert.False(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.False(root.GetProperty("safe_stash_required").GetBoolean());
+        Assert.Empty(root.GetProperty("safe_stash_paths").EnumerateArray());
+        Assert.Equal("submodules/SekibanAsAService", Assert.Single(root.GetProperty("submodule_internal_dirty_paths").EnumerateArray()).GetString());
+        Assert.Contains("do not enter the G306 safe-stash lane", root.GetProperty("summary").GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/AutomationSubmoduleSafetySharedStateCollection.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationSubmoduleSafetySharedStateCollection.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// Serializes the command tests that replace the process-global Git seams used
+/// by the G306/G791 host safety commands. The G791 production topology tests
+/// intentionally exercise the real shell runners, so they must not overlap a
+/// synthetic test that has installed a fake runner or probe.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class AutomationSubmoduleSafetySharedStateCollection
+{
+    public const string Name = "AutomationSubmoduleSafetySharedState";
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationWorkspaceGuardCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationWorkspaceGuardCommandTests.cs
@@ -5,6 +5,7 @@ using IntentSystem.Cli.Models;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(AutomationSubmoduleSafetySharedStateCollection.Name)]
 public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
 {
     public AutomationWorkspaceGuardCommandTests()
@@ -266,9 +267,9 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         // should appear in gitlink_paths, not safe_stash_paths.
         using var workspace = new GuardWorkspace();
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
-        // ls-files returns mode 160000 → gitlink
-        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
-            stdout: "160000 abc1234567890abcdef 0\tsubmodules/SekibanAsAService\n");
+        // ls-tree HEAD returns mode 160000 → gitlink.
+        fake.QueueResponse("ls-tree HEAD -- submodules/SekibanAsAService",
+            stdout: "160000 commit abc1234567890abcdef\tsubmodules/SekibanAsAService\n");
         // Internal status → empty (clean)
         fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
         AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
@@ -296,8 +297,8 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         // A submodule that has internal uncommitted changes must be refused.
         using var workspace = new GuardWorkspace();
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
-        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
-            stdout: "160000 abc1234567890abcdef 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("ls-tree HEAD -- submodules/SekibanAsAService",
+            stdout: "160000 commit abc1234567890abcdef\tsubmodules/SekibanAsAService\n");
         // Internal status → non-empty (dirty inside submodule)
         fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain",
             stdout: " M src/SomeFile.cs\n");
@@ -326,9 +327,9 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         AutomationWorkspaceGuardCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 13, 0, 0, 0, TimeSpan.Zero);
 
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
-        // Classification: ls-files → 160000 (gitlink), internal status → clean
-        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
-            stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
+        // Classification: HEAD gitlink → 160000, internal status → clean.
+        fake.QueueResponse("ls-tree HEAD -- submodules/SekibanAsAService",
+            stdout: "160000 commit parentcommit1234\tsubmodules/SekibanAsAService\n");
         fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
         // Begin write: get current submodule HEAD
         fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
@@ -379,8 +380,8 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         // A submodule with internal uncommitted changes must refuse begin.
         using var workspace = new GuardWorkspace();
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
-        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
-            stdout: "160000 abc1234567890 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("ls-tree HEAD -- submodules/SekibanAsAService",
+            stdout: "160000 commit abc1234567890\tsubmodules/SekibanAsAService\n");
         fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain",
             stdout: " M src/SomeFile.cs\n");
         AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
@@ -492,13 +493,13 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         AutomationWorkspaceGuardCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 13, 0, 0, 0, TimeSpan.Zero);
 
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n M scratch.txt\n");
-        // For submodules/SekibanAsAService: ls-files → gitlink, internal → clean
-        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
-            stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
+        // For submodules/SekibanAsAService: HEAD gitlink, internal clean.
+        fake.QueueResponse("ls-tree HEAD -- submodules/SekibanAsAService",
+            stdout: "160000 commit parentcommit1234\tsubmodules/SekibanAsAService\n");
         fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
-        // For scratch.txt: ls-files → regular file (not 160000)
-        fake.QueueResponse("ls-files --stage -- scratch.txt",
-            stdout: "100644 abc123 0\tscratch.txt\n");
+        // For scratch.txt: regular file (not 160000).
+        fake.QueueResponse("ls-tree HEAD -- scratch.txt",
+            stdout: "100644 blob abc123\tscratch.txt\n");
         // Gitlink begin: rev-parse HEAD and checkout
         fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
             stdout: "originalhead5678\n");
@@ -544,12 +545,12 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
 
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n M scratch.txt\n");
         // Classification: gitlink + internal clean
-        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
-            stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("ls-tree HEAD -- submodules/SekibanAsAService",
+            stdout: "160000 commit parentcommit1234\tsubmodules/SekibanAsAService\n");
         fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
         // scratch.txt is regular
-        fake.QueueResponse("ls-files --stage -- scratch.txt",
-            stdout: "100644 abc456 0\tscratch.txt\n");
+        fake.QueueResponse("ls-tree HEAD -- scratch.txt",
+            stdout: "100644 blob abc456\tscratch.txt\n");
         // Collect original HEAD (read-only, before any mutation)
         fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
             stdout: "originalhead5678\n");
@@ -595,11 +596,11 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         AutomationWorkspaceGuardCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 13, 12, 0, 0, TimeSpan.Zero);
 
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n M scratch.txt\n");
-        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
-            stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("ls-tree HEAD -- submodules/SekibanAsAService",
+            stdout: "160000 commit parentcommit1234\tsubmodules/SekibanAsAService\n");
         fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
-        fake.QueueResponse("ls-files --stage -- scratch.txt",
-            stdout: "100644 abc456 0\tscratch.txt\n");
+        fake.QueueResponse("ls-tree HEAD -- scratch.txt",
+            stdout: "100644 blob abc456\tscratch.txt\n");
         fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
             stdout: "originalhead5678\n");
         fake.QueueResponse("-C submodules/SekibanAsAService checkout parentcommit1234", stdout: "");
@@ -658,7 +659,8 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
 
         // The three discriminating facts are read, and the proceed lane never
         // mutates another domain's owning or nested checkout.
-        Assert.Contains(fake.Invocations, args => args.SequenceEqual(["ls-files", "--stage", "--", "submodules/SekibanAsAService"]));
+        Assert.Contains(fake.Invocations, args => args.SequenceEqual(["ls-tree", "HEAD", "--", "submodules/SekibanAsAService"]));
+        Assert.Contains(fake.Invocations, args => args.SequenceEqual(["diff", "--cached", "--quiet", "--", "submodules/SekibanAsAService"]));
         Assert.Contains(fake.Invocations, args => args.SequenceEqual(["-C", "submodules/SekibanAsAService", "rev-parse", "HEAD"]));
         Assert.Contains(fake.Invocations, args => args.SequenceEqual(["-C", "submodules/SekibanAsAService", "submodule", "status"]));
         Assert.Contains(fake.Invocations, args => args.SequenceEqual(["-C", "submodules/SekibanAsAService/Sekiban", "status", "--porcelain"]));
@@ -697,7 +699,7 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         const string owner = "submodules/SekibanAsAService";
         const string parentCommit = "a111111111111111111111111111111111111111";
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
-        fake.QueueResponse($"ls-files --stage -- {owner}", stdout: $"160000 {parentCommit} 0\t{owner}\n");
+        fake.QueueResponse($"ls-tree HEAD -- {owner}", stdout: $"160000 commit {parentCommit}\t{owner}\n");
         fake.QueueResponse($"-C {owner} status --porcelain", stdout: " M Sekiban\n");
         fake.QueueResponse($"-C {owner} rev-parse HEAD", stdout: parentCommit + "\n");
         fake.QueueResponse($"-C {owner} submodule status", stdout: "+4e086ad8 Sekiban (heads/main)\n");

--- a/tests/IntentSystem.Cli.Tests/AutomationWorkspaceGuardCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationWorkspaceGuardCommandTests.cs
@@ -270,7 +270,7 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
             stdout: "160000 abc1234567890abcdef 0\tsubmodules/SekibanAsAService\n");
         // Internal status → empty (clean)
-        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
         AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
 
         using var writer = new StringWriter();
@@ -299,7 +299,7 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
             stdout: "160000 abc1234567890abcdef 0\tsubmodules/SekibanAsAService\n");
         // Internal status → non-empty (dirty inside submodule)
-        fake.QueueResponse("-C submodules/SekibanAsAService status --short",
+        fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain",
             stdout: " M src/SomeFile.cs\n");
         AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
 
@@ -329,7 +329,7 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         // Classification: ls-files → 160000 (gitlink), internal status → clean
         fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
             stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
-        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
         // Begin write: get current submodule HEAD
         fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
             stdout: "originalhead5678\n");
@@ -381,7 +381,7 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
         fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
             stdout: "160000 abc1234567890 0\tsubmodules/SekibanAsAService\n");
-        fake.QueueResponse("-C submodules/SekibanAsAService status --short",
+        fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain",
             stdout: " M src/SomeFile.cs\n");
         AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
 
@@ -495,7 +495,7 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         // For submodules/SekibanAsAService: ls-files → gitlink, internal → clean
         fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
             stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
-        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
         // For scratch.txt: ls-files → regular file (not 160000)
         fake.QueueResponse("ls-files --stage -- scratch.txt",
             stdout: "100644 abc123 0\tscratch.txt\n");
@@ -546,7 +546,7 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         // Classification: gitlink + internal clean
         fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
             stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
-        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
         // scratch.txt is regular
         fake.QueueResponse("ls-files --stage -- scratch.txt",
             stdout: "100644 abc456 0\tscratch.txt\n");
@@ -597,7 +597,7 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n M scratch.txt\n");
         fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
             stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
-        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --porcelain", stdout: "");
         fake.QueueResponse("ls-files --stage -- scratch.txt",
             stdout: "100644 abc456 0\tscratch.txt\n");
         fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
@@ -625,6 +625,85 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         Assert.Equal(1, stateDoc.RootElement.GetProperty("gitlink_restore_paths").GetArrayLength());
         Assert.Equal("originalhead5678",
             stateDoc.RootElement.GetProperty("gitlink_restore_paths")[0].GetProperty("original_head").GetString());
+    }
+
+    // ======================================================================
+    // G791 — clean nested-pointer drift is a leave-untouched proceed lane
+    // ======================================================================
+
+    [Fact]
+    public void Begin_G791_CleanNestedPointerDrift_ProceedsWithoutTouchingForeignSubmodules()
+    {
+        using var workspace = new GuardWorkspace();
+        var fake = CreateG791NestedPointerDriftRunner(nestedCheckoutHasContent: false);
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "begin", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Equal(0, root.GetProperty("safe_stash_paths").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("gitlink_paths").GetArrayLength());
+        var drift = Assert.Single(root.GetProperty("nested_pointer_drift_submodules").EnumerateArray());
+        Assert.Equal("submodules/SekibanAsAService", drift.GetProperty("owning_submodule_path").GetString());
+        Assert.Equal("submodules/SekibanAsAService/Sekiban", drift.GetProperty("untouched_nested_paths")[0].GetString());
+        Assert.Contains("no stash or checkout was run", root.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json")));
+
+        // The three discriminating facts are read, and the proceed lane never
+        // mutates another domain's owning or nested checkout.
+        Assert.Contains(fake.Invocations, args => args.SequenceEqual(["ls-files", "--stage", "--", "submodules/SekibanAsAService"]));
+        Assert.Contains(fake.Invocations, args => args.SequenceEqual(["-C", "submodules/SekibanAsAService", "rev-parse", "HEAD"]));
+        Assert.Contains(fake.Invocations, args => args.SequenceEqual(["-C", "submodules/SekibanAsAService", "submodule", "status"]));
+        Assert.Contains(fake.Invocations, args => args.SequenceEqual(["-C", "submodules/SekibanAsAService/Sekiban", "status", "--porcelain"]));
+        Assert.DoesNotContain(fake.Invocations, args =>
+            args.Contains("stash")
+            || args.Contains("checkout")
+            || (args.Contains("submodule") && args.Contains("update"))
+            || args.Contains("add")
+            || args.Contains("commit"));
+    }
+
+    [Fact]
+    public void Begin_G791_NestedCheckoutWithRealContent_RefusesAndNamesInternalChanges()
+    {
+        using var workspace = new GuardWorkspace();
+        var fake = CreateG791NestedPointerDriftRunner(nestedCheckoutHasContent: true);
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "begin", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Equal(0, root.GetProperty("nested_pointer_drift_submodules").GetArrayLength());
+        Assert.Contains("internal uncommitted changes", root.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json")));
+    }
+
+    private static FakeGitRunner CreateG791NestedPointerDriftRunner(bool nestedCheckoutHasContent)
+    {
+        const string owner = "submodules/SekibanAsAService";
+        const string parentCommit = "a111111111111111111111111111111111111111";
+        var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
+        fake.QueueResponse($"ls-files --stage -- {owner}", stdout: $"160000 {parentCommit} 0\t{owner}\n");
+        fake.QueueResponse($"-C {owner} status --porcelain", stdout: " M Sekiban\n");
+        fake.QueueResponse($"-C {owner} rev-parse HEAD", stdout: parentCommit + "\n");
+        fake.QueueResponse($"-C {owner} submodule status", stdout: "+4e086ad8 Sekiban (heads/main)\n");
+        fake.QueueResponse($"-C {owner}/Sekiban status --porcelain",
+            stdout: nestedCheckoutHasContent ? " M src/real-content.cs\n" : "");
+        return fake;
     }
 
     private sealed class FakeGitRunner : IGitRunner

--- a/tests/IntentSystem.Cli.Tests/DurableStatePreflightAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DurableStatePreflightAnalyzerTests.cs
@@ -374,7 +374,7 @@ public sealed class DurableStatePreflightAnalyzerTests
     }
 
     [Fact]
-    public void Analyze_EmptyDirtyPaths_ReturnsNeedsOperatorReview()
+    public void Analyze_G791_EmptyDirtyPaths_ReturnsClean()
     {
         var input = new DurableStatePreflightInput
         {
@@ -383,10 +383,12 @@ public sealed class DurableStatePreflightAnalyzerTests
 
         var result = DurableStatePreflightAnalyzer.Analyze(input);
 
-        // No verified paths and no unsafe paths — classification is
-        // needs-operator-review (the host loop should never call this
-        // with an empty bundle, but the analyzer must be deterministic).
-        Assert.Equal(DurableStatePreflightAnalyzer.ClassificationNeedsOperatorReview, result.Classification);
+        Assert.Equal(DurableStatePreflightAnalyzer.ClassificationClean, result.Classification);
+        Assert.Empty(result.VerifiedPaths);
+        Assert.Empty(result.ReviewPaths);
+        Assert.Empty(result.UnsafePaths);
+        Assert.Null(result.RecommendedCommitMessage);
+        Assert.Contains("No dirty durable-state paths", result.Summary, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/G791NestedSubmoduleProductionFixtureTests.cs
+++ b/tests/IntentSystem.Cli.Tests/G791NestedSubmoduleProductionFixtureTests.cs
@@ -1,0 +1,356 @@
+using System.Diagnostics;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G791 repair: production-path coverage for the host -> owning submodule ->
+/// nested submodule boundary. These fixtures deliberately use real Git
+/// repositories and leave the command factories unset, so parser and index vs
+/// HEAD mistakes cannot be hidden by a synthetic probe.
+/// </summary>
+[Collection(AutomationSubmoduleSafetySharedStateCollection.Name)]
+public sealed class G791NestedSubmoduleProductionFixtureTests : IDisposable
+{
+    public G791NestedSubmoduleProductionFixtureTests()
+    {
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = null;
+        AutomationWorkspaceGuardCommand.UtcNowFactory = null;
+        AutomationHostSyncPreflightCommand.GitProbeFactory = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = null;
+        AutomationWorkspaceGuardCommand.UtcNowFactory = null;
+        AutomationHostSyncPreflightCommand.GitProbeFactory = null;
+    }
+
+    [Fact]
+    public void Execute_G791_ProductionTopology_CleanNestedPointerDrift_ProceedsWithoutTouchingForeignPaths()
+    {
+        using var topology = RealNestedTopology.Create(TopologyState.CleanNestedPointerDrift);
+        var before = topology.CaptureBoundary();
+
+        var plan = ExecuteWorkspaceGuard(topology.Context, ["--mode", "plan", "--format", "json"]);
+        Assert.True(plan.ExitCode == 0, plan.Output + Environment.NewLine + before);
+        AssertWorkspaceGuardProceedingNestedPointerDrift(plan.Output);
+
+        var begin = ExecuteWorkspaceGuard(topology.Context, ["--mode", "begin", "--write", "--format", "json"]);
+        Assert.Equal(0, begin.ExitCode);
+        AssertWorkspaceGuardProceedingNestedPointerDrift(begin.Output);
+        Assert.False(File.Exists(Path.Combine(topology.HostRoot, ".intent-cli", "workspace-guard.json")));
+
+        var preflight = ExecuteHostSyncPreflight(topology.Context);
+        Assert.Equal(0, preflight.ExitCode);
+        AssertHostSyncProceedingNestedPointerDrift(preflight.Output);
+
+        Assert.Equal(before, topology.CaptureBoundary());
+    }
+
+    [Fact]
+    public void Execute_G791_ProductionTopology_NestedUncommittedContent_HardStopsWithoutSafeStash()
+    {
+        using var topology = RealNestedTopology.Create(TopologyState.NestedUncommittedContent);
+        var before = topology.CaptureBoundary();
+
+        var plan = ExecuteWorkspaceGuard(topology.Context, ["--mode", "plan", "--format", "json"]);
+        Assert.Equal(1, plan.ExitCode);
+        AssertWorkspaceGuardHardStop(plan.Output);
+
+        var begin = ExecuteWorkspaceGuard(topology.Context, ["--mode", "begin", "--write", "--format", "json"]);
+        Assert.Equal(1, begin.ExitCode);
+        AssertWorkspaceGuardHardStop(begin.Output);
+        Assert.False(File.Exists(Path.Combine(topology.HostRoot, ".intent-cli", "workspace-guard.json")));
+
+        var preflight = ExecuteHostSyncPreflight(topology.Context);
+        Assert.Equal(1, preflight.ExitCode);
+        AssertHostSyncHardStop(preflight.Output, topology.OwningSubmodulePath);
+
+        Assert.Equal(before, topology.CaptureBoundary());
+        Assert.True(File.Exists(Path.Combine(topology.NestedSubmoduleRoot, "foreign-content.txt")));
+    }
+
+    [Fact]
+    public void Execute_G791_ProductionTopology_StagedParentGitlink_HardStopsWithoutDirectProceed()
+    {
+        using var topology = RealNestedTopology.Create(TopologyState.StagedParentGitlinkWithCleanNestedDrift);
+        var before = topology.CaptureBoundary();
+        Assert.Contains("MM owner", before.HostPorcelain, StringComparison.Ordinal);
+
+        var plan = ExecuteWorkspaceGuard(topology.Context, ["--mode", "plan", "--format", "json"]);
+        Assert.Equal(1, plan.ExitCode);
+        AssertWorkspaceGuardHardStop(plan.Output);
+        Assert.DoesNotContain("nested-pointer-drift", plan.Output, StringComparison.Ordinal);
+
+        var begin = ExecuteWorkspaceGuard(topology.Context, ["--mode", "begin", "--write", "--format", "json"]);
+        Assert.Equal(1, begin.ExitCode);
+        AssertWorkspaceGuardHardStop(begin.Output);
+        Assert.False(File.Exists(Path.Combine(topology.HostRoot, ".intent-cli", "workspace-guard.json")));
+
+        var preflight = ExecuteHostSyncPreflight(topology.Context);
+        Assert.Equal(1, preflight.ExitCode);
+        AssertHostSyncHardStop(preflight.Output, topology.OwningSubmodulePath);
+        Assert.DoesNotContain("nested-pointer-drift", preflight.Output, StringComparison.Ordinal);
+
+        Assert.Equal(before, topology.CaptureBoundary());
+    }
+
+    private static (int ExitCode, string Output) ExecuteWorkspaceGuard(CliContext context, string[] args)
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(context, args, writer);
+        return (exitCode, writer.ToString());
+    }
+
+    private static (int ExitCode, string Output) ExecuteHostSyncPreflight(CliContext context)
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostSyncPreflightCommand.Execute(context, ["--format", "json"], writer);
+        return (exitCode, writer.ToString());
+    }
+
+    private static void AssertWorkspaceGuardProceedingNestedPointerDrift(string output)
+    {
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Empty(root.GetProperty("safe_stash_paths").EnumerateArray());
+        Assert.Single(root.GetProperty("nested_pointer_drift_submodules").EnumerateArray());
+    }
+
+    private static void AssertHostSyncProceedingNestedPointerDrift(string output)
+    {
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.Equal("nested-pointer-drift", root.GetProperty("classification").GetString());
+        Assert.True(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.False(root.GetProperty("safe_stash_required").GetBoolean());
+        Assert.Empty(root.GetProperty("safe_stash_paths").EnumerateArray());
+        Assert.Single(root.GetProperty("nested_pointer_drift_submodules").EnumerateArray());
+    }
+
+    private static void AssertWorkspaceGuardHardStop(string output)
+    {
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Empty(root.GetProperty("safe_stash_paths").EnumerateArray());
+        Assert.Empty(root.GetProperty("nested_pointer_drift_submodules").EnumerateArray());
+        Assert.Contains("internal uncommitted changes", root.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+    }
+
+    private static void AssertHostSyncHardStop(string output, string owningPath)
+    {
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.Equal("submodule-internal-dirty", root.GetProperty("classification").GetString());
+        Assert.False(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.False(root.GetProperty("safe_stash_required").GetBoolean());
+        Assert.Empty(root.GetProperty("safe_stash_paths").EnumerateArray());
+        Assert.Equal(owningPath, Assert.Single(root.GetProperty("submodule_internal_dirty_paths").EnumerateArray()).GetString());
+    }
+
+    private enum TopologyState
+    {
+        CleanNestedPointerDrift,
+        NestedUncommittedContent,
+        StagedParentGitlinkWithCleanNestedDrift,
+    }
+
+    private sealed class RealNestedTopology : IDisposable
+    {
+        private readonly string root;
+
+        private RealNestedTopology(string root, string hostRoot, string ownerCommitAtHostHead, string ownerSecondCommit, string nestedPointerCommit)
+        {
+            this.root = root;
+            HostRoot = hostRoot;
+            OwnerCommitAtHostHead = ownerCommitAtHostHead;
+            OwnerSecondCommit = ownerSecondCommit;
+            NestedPointerCommit = nestedPointerCommit;
+            OwningSubmodulePath = "owner";
+            OwningSubmoduleRoot = Path.Combine(HostRoot, OwningSubmodulePath);
+            NestedSubmoduleRoot = Path.Combine(OwningSubmoduleRoot, "nested");
+            Context = new CliContext
+            {
+                RepoRoot = HostRoot,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    }
+                }
+            };
+        }
+
+        public string HostRoot { get; }
+
+        public string OwningSubmodulePath { get; }
+
+        public string OwningSubmoduleRoot { get; }
+
+        public string NestedSubmoduleRoot { get; }
+
+        public string OwnerCommitAtHostHead { get; }
+
+        public string OwnerSecondCommit { get; }
+
+        public string NestedPointerCommit { get; }
+
+        public CliContext Context { get; }
+
+        public static RealNestedTopology Create(TopologyState state)
+        {
+            var root = Directory.CreateTempSubdirectory("g791-real-nested-topology-").FullName;
+            var nestedSeed = Path.Combine(root, "nested-seed");
+            var nestedRemote = Path.Combine(root, "nested-remote.git");
+            var ownerSeed = Path.Combine(root, "owner-seed");
+            var ownerRemote = Path.Combine(root, "owner-remote.git");
+            var hostRoot = Path.Combine(root, "host");
+            var hostRemote = Path.Combine(root, "host-remote.git");
+
+            InitializeRepository(nestedSeed);
+            File.WriteAllText(Path.Combine(nestedSeed, "nested.txt"), "nested A\n");
+            CommitAll(nestedSeed, "nested A");
+            var nestedAtA = RunGit(nestedSeed, "rev-parse", "HEAD").Trim();
+            InitializeBareRepository(nestedRemote);
+            RunGit(nestedSeed, "remote", "add", "origin", nestedRemote);
+            RunGit(nestedSeed, "push", "-u", "origin", "main");
+
+            InitializeRepository(ownerSeed);
+            File.WriteAllText(Path.Combine(ownerSeed, "owner.txt"), "owner A\n");
+            RunGit(ownerSeed, "-c", "protocol.file.allow=always", "submodule", "add", nestedRemote, "nested");
+            CommitAll(ownerSeed, "owner with nested A");
+            var ownerAtA = RunGit(ownerSeed, "rev-parse", "HEAD").Trim();
+            File.WriteAllText(Path.Combine(ownerSeed, "owner.txt"), "owner C\n");
+            CommitAll(ownerSeed, "owner second commit");
+            var ownerAtC = RunGit(ownerSeed, "rev-parse", "HEAD").Trim();
+            InitializeBareRepository(ownerRemote);
+            RunGit(ownerSeed, "remote", "add", "origin", ownerRemote);
+            RunGit(ownerSeed, "push", "-u", "origin", "main");
+
+            File.WriteAllText(Path.Combine(nestedSeed, "nested.txt"), "nested B\n");
+            CommitAll(nestedSeed, "nested B");
+            var nestedAtB = RunGit(nestedSeed, "rev-parse", "HEAD").Trim();
+            RunGit(nestedSeed, "push", "origin", "main");
+
+            InitializeRepository(hostRoot);
+            RunGit(hostRoot, "-c", "protocol.file.allow=always", "submodule", "add", ownerRemote, "owner");
+            var ownerRoot = Path.Combine(hostRoot, "owner");
+            RunGit(ownerRoot, "checkout", ownerAtA);
+            RunGit(ownerRoot, "-c", "protocol.file.allow=always", "submodule", "update", "--init", "nested");
+            RunGit(hostRoot, "add", "owner", ".gitmodules");
+            CommitAll(hostRoot, "host records owner A");
+            InitializeBareRepository(hostRemote);
+            RunGit(hostRoot, "remote", "add", "origin", hostRemote);
+            RunGit(hostRoot, "push", "-u", "origin", "main");
+
+            var topology = new RealNestedTopology(root, hostRoot, ownerAtA, ownerAtC, nestedAtB);
+            RunGit(topology.NestedSubmoduleRoot, "fetch", "origin");
+            RunGit(topology.NestedSubmoduleRoot, "checkout", nestedAtB);
+
+            switch (state)
+            {
+                case TopologyState.CleanNestedPointerDrift:
+                    break;
+                case TopologyState.NestedUncommittedContent:
+                    File.WriteAllText(Path.Combine(topology.NestedSubmoduleRoot, "foreign-content.txt"), "owned elsewhere\n");
+                    break;
+                case TopologyState.StagedParentGitlinkWithCleanNestedDrift:
+                    RunGit(topology.OwningSubmoduleRoot, "fetch", "origin");
+                    RunGit(topology.OwningSubmoduleRoot, "checkout", ownerAtC);
+                    RunGit(hostRoot, "add", topology.OwningSubmodulePath);
+                    RunGit(topology.NestedSubmoduleRoot, "checkout", nestedAtB);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(state), state, null);
+            }
+
+            Assert.Equal(ownerAtA, RunGit(hostRoot, "rev-parse", "HEAD:owner").Trim());
+            Assert.Equal(nestedAtB, RunGit(topology.NestedSubmoduleRoot, "rev-parse", "HEAD").Trim());
+            return topology;
+        }
+
+        public TopologyBoundary CaptureBoundary() => new(
+            RunGit(HostRoot, "status", "--porcelain"),
+            RunGit(HostRoot, "stash", "list"),
+            RunGit(OwningSubmoduleRoot, "rev-parse", "HEAD").Trim(),
+            RunGit(NestedSubmoduleRoot, "rev-parse", "HEAD").Trim(),
+            RunGit(HostRoot, "submodule", "status"),
+            RunGit(OwningSubmoduleRoot, "status", "--porcelain"),
+            RunGit(OwningSubmoduleRoot, "submodule", "status"),
+            RunGit(NestedSubmoduleRoot, "status", "--porcelain"),
+            RunGit(HostRoot, "diff", "--cached", "--raw", "--", OwningSubmodulePath),
+            RunGit(HostRoot, "ls-tree", "HEAD", "--", OwningSubmodulePath));
+
+        public void Dispose()
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        private static void InitializeRepository(string path)
+        {
+            Directory.CreateDirectory(path);
+            RunGit(path, "init", "--initial-branch", "main");
+            RunGit(path, "config", "user.email", "g791-fixture@example.test");
+            RunGit(path, "config", "user.name", "G791 fixture");
+        }
+
+        private static void InitializeBareRepository(string path)
+        {
+            Directory.CreateDirectory(path);
+            RunGit(path, "init", "--bare", "--initial-branch", "main");
+        }
+
+        private static void CommitAll(string path, string message)
+        {
+            RunGit(path, "add", "--all");
+            RunGit(path, "commit", "-m", message);
+        }
+
+        private static string RunGit(string workingDirectory, params string[] arguments)
+        {
+            var startInfo = new ProcessStartInfo("git")
+            {
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            foreach (var argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using var process = Process.Start(startInfo)!;
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            Assert.True(process.ExitCode == 0,
+                $"git {string.Join(' ', arguments)} failed in '{workingDirectory}' with exit {process.ExitCode}: {error}");
+            return output;
+        }
+    }
+
+    private sealed record TopologyBoundary(
+        string HostPorcelain,
+        string HostStashList,
+        string OwnerHead,
+        string NestedHead,
+        string HostSubmoduleStatus,
+        string OwnerPorcelain,
+        string OwnerSubmoduleStatus,
+        string NestedPorcelain,
+        string StagedRaw,
+        string HeadGitlink);
+}

--- a/tests/IntentSystem.Cli.Tests/HostSyncPreflightAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/HostSyncPreflightAnalyzerTests.cs
@@ -260,6 +260,56 @@ public sealed class HostSyncPreflightAnalyzerTests
         Assert.Empty(result.SubmoduleCheckoutMismatchPaths);
     }
 
+    // ── G791 clean nested-pointer drift ─────────────────────────────────
+
+    [Fact]
+    public void Analyze_G791_AllDirtyPathsAreCleanNestedPointerDrift_ProceedsWithoutSafeStash()
+    {
+        var result = HostSyncPreflightAnalyzer.Analyze(
+            "main",
+            behindOriginCommits: 0,
+            workingTreeEntries: new[] { Entry("submodules/SekibanAsAService", " m") },
+            nestedPointerDriftSubmodules: new[]
+            {
+                new NestedPointerDriftSubmodule
+                {
+                    OwningSubmodulePath = "submodules/SekibanAsAService",
+                    ParentRecordedCommit = "a111111111111111111111111111111111111111",
+                    UntouchedNestedPaths = new[] { "submodules/SekibanAsAService/Sekiban" }
+                }
+            });
+
+        Assert.Equal(HostSyncPreflightAnalyzer.ClassificationNestedPointerDrift, result.Classification);
+        Assert.True(result.ProceedAllowed);
+        Assert.False(result.SafeStashRequired);
+        Assert.Empty(result.SafeStashPaths);
+        var drift = Assert.Single(result.NestedPointerDriftSubmodules);
+        Assert.Equal("submodules/SekibanAsAService", drift.OwningSubmodulePath);
+        Assert.Equal("submodules/SekibanAsAService/Sekiban", Assert.Single(drift.UntouchedNestedPaths));
+        Assert.Contains("leave the owning and nested submodule paths untouched", result.Summary, StringComparison.Ordinal);
+        Assert.DoesNotContain(result.NextSteps, step => step.Contains("--mode begin --write", StringComparison.Ordinal));
+        Assert.Contains(result.NextSteps, step => step.Contains("Do NOT run workspace-guard", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyze_G791_RealNestedCheckoutContent_IsHardStopNotSafeStash()
+    {
+        var result = HostSyncPreflightAnalyzer.Analyze(
+            "main",
+            behindOriginCommits: 0,
+            workingTreeEntries: new[] { Entry("submodules/SekibanAsAService", " M") },
+            submoduleInternalDirtyPaths: new[] { "submodules/SekibanAsAService" });
+
+        Assert.Equal(HostSyncPreflightAnalyzer.ClassificationSubmoduleInternalDirty, result.Classification);
+        Assert.False(result.ProceedAllowed);
+        Assert.False(result.SafeStashRequired);
+        Assert.Empty(result.SafeStashPaths);
+        Assert.Equal("submodules/SekibanAsAService", Assert.Single(result.SubmoduleInternalDirtyPaths));
+        Assert.Contains("do not enter the G306 safe-stash lane", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(result.NextSteps, step => step.Contains("STOP", StringComparison.Ordinal));
+        Assert.Contains(result.NextSteps, step => step.Contains("Do NOT run the G306 safe-stash lane", StringComparison.Ordinal));
+    }
+
     // ── G400 ff-blocked (diverged) pre-mutation operator stop ───────────
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/JapaneseTerminologyGuardG613Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/JapaneseTerminologyGuardG613Tests.cs
@@ -95,8 +95,8 @@ public sealed class JapaneseTerminologyGuardG613Tests
     [Fact]
     public void DeveloperReferenceG616_LeavesDurableOnlyAsGlossedConceptOrIdentifiers_G616()
     {
-        const int measuredOccurrences = 25;
-        const int keptOccurrences = 8;
+        const int measuredOccurrences = 26;
+        const int keptOccurrences = 9;
         const int translatedOccurrences = 17;
         var path = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", "ja", "09-developer-reference.md");
         var content = File.ReadAllText(path);


### PR DESCRIPTION
Closes #1727

# G791 repair v1 — staged parent gitlink safety and production topology proof

This repair addresses the two request-update findings without changing G791's
durable-state boundary or the leave-foreign-paths-alone contract.

- `NestedSubmodulePointerDriftDetector` now reads the parent gitlink from
  `git ls-tree HEAD -- <path>` and verifies `git diff --cached --quiet -- <path>`.
  A staged parent gitlink is therefore never mistaken for an aligned one.
- Both production callers use that one inspection. A porcelain `MM owner`
  parent entry is a hard stop: it cannot enter the direct-proceed or G306
  safe-stash lane, and workspace-guard creates no state file.
- New production-path tests create real `host -> owner -> nested` Git topology;
  they use neither `FakeGitRunner` nor `HostSyncGitProbe` injection.

The existing G791 durable classifier remains shared by workspace-guard,
durable-state-preflight, and host-sync-preflight. Append-only runtime records
remain commit-ready, an empty durable bundle remains `clean`, and the EN/JA
guidance continues to require leaving another domain's clean nested drift
untouched.

## Criterion 7 — Each new test demonstrated failing or absent on the parent commit, actual output pasted

Repair parent: `208cb2484e7a93aed58321df04d3433dc295201b`.

```text
Criterion 7: Each new test demonstrated failing or absent on the parent commit, actual output pasted.
$ git grep -n -e 'Execute_G791_ProductionTopology_CleanNestedPointerDrift_ProceedsWithoutTouchingForeignPaths' \
    -e 'Execute_G791_ProductionTopology_NestedUncommittedContent_HardStopsWithoutSafeStash' \
    -e 'Execute_G791_ProductionTopology_StagedParentGitlink_HardStopsWithoutDirectProceed' \
    208cb2484e7a93aed58321df04d3433dc295201b -- tests/IntentSystem.Cli.Tests
G791_REPAIR_PARENT_NEW_TESTS_GREP_EXIT=1

$ git show 208cb2484e7a93aed58321df04d3433dc295201b:src/IntentSystem.Cli/Commands/NestedSubmodulePointerDriftDetector.cs | rg -n 'ls-files|ls-tree|diff --cached'
15:        var result = runner.Run(["ls-files", "--stage", "--", path]);
```

The parent therefore had neither the three real-topology regressions nor the
HEAD-vs-index guard. Its index lookup accepted the reviewer-proved staged
`MM owner` fixture as clean nested-pointer drift.

## Production-path pair evidence — both commands, real three-level Git topology

`G791NestedSubmoduleProductionFixtureTests` builds a host repository containing
an owning `owner` submodule that contains a `nested` submodule. It runs
`automation workspace-guard --mode plan`, `--mode begin --write`, and
`automation host-sync-preflight` through their default shell runners.

| Real fixture | workspace-guard plan / begin | host-sync-preflight | Boundary proof |
| --- | --- | --- | --- |
| Host `HEAD:owner` aligned; owner has only clean nested pointer drift | `0` / `0`, `proceed_allowed=true`, one `nested_pointer_drift_submodules` entry | `0`, `classification=nested-pointer-drift`, `safe_stash_required=false` | owner and nested HEADs, host porcelain/submodule status, and `git stash list` are unchanged; no guard state file |
| Same topology plus actual uncommitted `owner/nested/foreign-content.txt` | `1` / `1`, no safe-stash paths, no drift entry | `1`, `classification=submodule-internal-dirty`, no safe-stash lane | foreign file remains and no guard state file is created |
| Clean nested pointer drift plus staged parent gitlink (`MM owner`) | `1` / `1`, no direct-proceed or safe-stash path | `1`, `classification=submodule-internal-dirty`, `proceed_allowed=false` | parent `HEAD` remains the original gitlink while the index differs; no guard state file |

The clean case proves the no-touch contract by checking the complete host
porcelain, `git stash list`, owner/nested HEADs, and host submodule status
before and after both commands. The two refusal cases prove that neither real
nested content nor a staged superproject pointer is reclassified into G306.

## Criterion 8 — DOCS: both mirrors state the HEAD-aligned nested-pointer rule, staged-parent refusal, and owning-domain boundary; full Release suite passes with actual counts pasted

`docs/en/09-developer-reference.md` and
`docs/ja/09-developer-reference.md` now state that the parent gitlink comes
from `HEAD`, not the index, and that staged `MM` parent work fails closed
without direct-proceed or G306.

```text
Criterion 8: **Docs**: both mirrors state the HEAD-aligned nested-pointer rule, staged-parent refusal, and owning-domain boundary; full Release suite passes with actual counts pasted.
focused command + production-topology tests: 28 passed, 0 failed, 0 skipped
broader G791 durable/analyzer/docs tests: 59 passed, 0 failed, 0 skipped
exact commit `19375b2ed38210ac9fd75ee9ffd71026fb0ee2fd` full Release command:
  `dotnet test IntentSystem.sln --configuration Release --no-restore --settings /tmp/g791-release.runsettings`
  persisted exit: 0; 11 TRX files: 5,955 passed, 0 failed, 1 skipped (5,956 total)
  CLI assembly: 5,625 passed, 0 failed, 1 skipped (5,626 total)
exact-head CI: GitHub Actions run 33741734262, attempt 2, `19375b2e`:
  Build and test (source contract)=SUCCESS; npm package dry-run (no publish)=SUCCESS
git diff --check: exit=0
```
