### PR TITLE
G792: prepare v0.31.0 release evidence

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2812,7 +2812,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0301)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0311)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -3018,42 +3018,69 @@ rotated by this command; the result and `shrink-audit.jsonl` say so explicitly.
 out of scope. Use `--dry-run` to inspect the measured plan without writing the
 manifest, JSONL files, or audit.
 
-### Next release readiness (v0.30.1)
+### Next release readiness (v0.31.1)
 
 **RELEASE PREPARED / NOT PUBLISHED.**
 
-G787 measured the v0.30.0 preparation from the exact named product base
-`d9dc053dd81f53c3a8be420ee7c6798b808f4521`. With the rolled policy, its
-normal clean Release build reports `intent-cli 0.30.1-d9dc053-G772`; it is the
-new `nextVersion` placeholder identity, not v0.30.0. The same base built with
-explicit `-p:Version=0.30.0` reports `intent-cli 0.30.0-d9dc053-G772`.
-Published v0.30.0 derives `VERSION` from the release tag's `RAW` value in
-`release.yml`; `eng/version.json` governs local builds and dry runs only.
+G792 measured the v0.31.0 preparation from the exact named product base
+`79a245c655e17ac654ac440fda31709ee38e28b8` after the four first-parent merges
+G788, G789, G791, and G790. A normal clean Release build reports
+`intent-cli 0.31.1-79a245c-G791`; this is the new `nextVersion` placeholder
+identity, **not** v0.31.0. The same base with explicit `-p:Version=0.31.0`
+reports `intent-cli 0.31.0-79a245c-G791`. Published v0.31.0 derives `VERSION`
+from the release tag's `RAW` value in `release.yml`; `eng/version.json` governs
+local builds and dry runs only.
 
-The prepared files are `release-notes-v0.30.0.md` and the
-`release-notes-v0.30.1.md` DRAFT stub. The current policy is:
+The prepared files are `release-notes-v0.31.0.md` and the
+`release-notes-v0.31.1.md` DRAFT stub. The current policy is:
 
 ```json
 {
-  "stableVersion": "0.30.0",
-  "nextVersion": "0.30.1"
+  "stableVersion": "0.31.0",
+  "nextVersion": "0.31.1"
 }
 ```
 
-`0.30.1` is a replaceable development placeholder, not the next real release
+`0.31.1` is a replaceable development placeholder, not the next real release
 number. No tag, GitHub Release, package publish, workflow change, or product
 source change belongs to this prepare-only slice.
 
-The active package-policy evidence is `stableVersion 0.30.0`, `nextVersion 0.30.1`,
-and local candidate `JTechJapan.IntentSystem.Cli.0.30.1.nupkg`.
-The host-only release-prep claim boundary is `release-prep:<owner/repo>:0.30.1`;
+The active package-policy evidence is `stableVersion 0.31.0`, `nextVersion 0.31.1`,
+and local candidate `JTechJapan.IntentSystem.Cli.0.31.1.nupkg`.
+The host-only release-prep claim boundary is `release-prep:<owner/repo>:0.31.0`;
 this child release-prep uses supplied authority and does not inspect or mutate host state.
-The eight-unit inventory is G779–G786; its EN/JA tuple and consumer-follow-up
-parity is guarded by `ReleaseNotesV0300DocsTests`, along with the measured
-identity, truthfulness, and placeholder checks.
-G780 changes a declared same-repository host's canonical claim location to
-`metadata_write_branch`. The arc's `--verify`, `--accept-evidence-gap`, and
-`--shell-policy` additions are option-level surfaces, not extra command routes.
+The exact four-unit inventory is G788, G789, G791, and G790; its EN/JA
+unit/PR/issue/merge tuple and consumer-follow-up parity is guarded by
+`ReleaseNotesV0310DocsTests`, alongside measured identities, truthfulness, and
+placeholder checks; `ReleasePackageMetadataTests` continues to guard the
+release-policy shape and demanded next-version note.
+G788's evidence sources, G789's guide blocks, and G791's nested-pointer-drift
+classification are explicitly option/behavior additions, not extra command routes.
+The current readiness record also preserves `metadata_write_branch` topology
+evidence and the `--verify`, `--accept-evidence-gap`, and `--shell-policy`
+option-level surfaces; no GitHub Release exists yet.
+The policy-derived next-version placeholder boundary remains
+`release-prep:<owner/repo>:0.31.1`; the prepared release target above is
+`release-prep:<owner/repo>:0.31.0`.
+
+The measured minor decision uses the v0.28.0 rule: **a command-route addition is
+a minor bump; option-level additions do not count as command routes.** The
+tagged v0.30.0 tool did not expose `session-layer inspect`; the named base adds
+that one read-only command route. G788 evidence sources/informational output,
+G789 guide text, and G791 nested-pointer-drift classification are listed but
+explicitly not counted as routes.
+
+G792 truthfulness is deliberately bounded: the delivered-never-executed finding
+counts a downstream delegation, a child report carrying the same execution-unit
+token, or a queue transition as execution evidence, still fires on a true stall,
+and lists what was checked rather than asserting absence. `session-layer inspect`
+is read-only, resolves targets only from recorded topology or explicit `--role`,
+has no focus default, exits 0 when the session layer is unavailable, and does not
+answer dialogs; `notify adjudicate` remains that path. The host guard proceeds on
+another domain's nested pointer drift only when every nested checkout is clean,
+refuses uncommitted nested content, and writes to no other domain submodule. The
+G789 design-thread Orca block is non-normative; intent-cli neither launches nor
+manages Orca.
 
 ### Previous v0.29.0 release-prep evidence (retained in history only)
 

--- a/docs/en/release-notes-v0.31.0.md
+++ b/docs/en/release-notes-v0.31.0.md
@@ -1,0 +1,183 @@
+# Release Notes — intent-cli v0.31.0
+
+> **PREPARED / NOT PUBLISHED.** This prepare-only note set records the measured
+> G788–G791 chain. It does not create a tag or GitHub Release, publish a package,
+> change a workflow or publish configuration, post a consumer comment, or change
+> product source.
+
+No GitHub Release exists for v0.31.0; these notes are preparation evidence only.
+The matching install query is `JTechJapan.IntentSystem.Cli --version 0.31.0`.
+The policy after this preparation is:
+
+```json
+{
+  "stableVersion": "0.31.0",
+  "nextVersion": "0.31.1"
+}
+```
+
+`0.31.1` is a replaceable development placeholder, not a decision about the
+next real release. The EN and JA v0.31.1 files are planning scaffolds, not
+changelogs.
+
+## Independently measured minor justification
+
+The named product base is `79a245c655e17ac654ac440fda31709ee38e28b8`. The
+installed tagged v0.30.0 tool was measured with an explicit release version:
+
+```text
+$ dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj --configuration Release --no-restore -p:Version=0.30.0 -p:IntentSystemLatestExecutionUnit=G772
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.30.0-f4b01c2-G772
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll session-layer --help
+intent-cli session-layer — group help
+Usage: intent-cli session-layer <subcommand> [--help]
+
+Subcommands (run with --help for details):
+- marker
+- model-resolution
+- set
+- show
+- team-mode
+- topology
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll session-layer inspect --help
+Command 'session-layer inspect' is not yet implemented.
+EXIT:1
+```
+
+The tagged surface has no `inspect` route. The v0.28.0 release rule is the
+auditable distinction: **a command-route addition is a minor bump; option-level
+additions do not count as command routes.** The named base adds exactly one
+command route, the read-only `session-layer inspect`; that decides v0.31.0.
+G788 evidence sources and informational output, G789 guide blocks, and G791's
+nested-pointer-drift classification are listed but explicitly not counted as
+additional routes.
+
+## Measured version identities
+
+The named base was checked with a clean Release build after the policy roll:
+
+```text
+$ git rev-parse HEAD
+79a245c655e17ac654ac440fda31709ee38e28b8
+$ dotnet clean
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet build IntentSystem.sln --configuration Release
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.31.1-79a245c-G791
+```
+
+That normal identity is the `nextVersion` placeholder and is **not** v0.31.0.
+The same base with the explicit release property was measured separately:
+
+```text
+$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.31.0
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.31.0-79a245c-G791
+```
+
+Published versioning is a third identity and is derived by `release.yml`, not
+by the local policy file:
+
+```text
+$ RAW=v0.31.0; VERSION="${RAW#v}"; printf 'RAW=%s\nVERSION=%s\n' "$RAW" "$VERSION"
+RAW=v0.31.0
+VERSION=0.31.0
+```
+
+The release workflow supplies `-p:Version=<tag>` from `RAW`; `eng/version.json`
+governs local builds and dry runs only. This prepare-only slice created no tag.
+
+## Release inventory: exactly four first-parent units
+
+The inventory is derived from the exact first-parent range. Git measured four
+commits, and every commit has one operator-observable outcome:
+
+- G788 — PR #1723 / issue #1722; merge commit `cfdacb4a657d9a60ab82fea3faa435ff732f389f`.
+  **Operator-observable outcome:** a delivered parent is cleared only when a
+  matching downstream delegation, child report, or queue transition carries
+  execution evidence; a true stall remains visible.
+- G789 — PR #1725 / issue #1724; merge commit `9d03309a155dc5f714be8a99bb3c2234724bf589`.
+  **Operator-observable outcome:** design-thread guides retain the additive
+  Orca operating block and resolve mixed-kind review seats without contradiction,
+  including topology fallback guidance.
+- G791 — PR #1728 / issue #1727; merge commit `aa5c49f51bffa634ca7a96a08f1245e53a372904`.
+  **Operator-observable outcome:** a nested pointer drift in another domain is
+  classified without writing that domain's submodule when every nested checkout
+  is clean.
+- G790 — PR #1729 / issue #1726; merge commit `79a245c655e17ac654ac440fda31709ee38e28b8`.
+  **Operator-observable outcome:** `session-layer inspect` reports recorded role
+  state and an optional bounded pane tail read without focus, prompts, key sends,
+  or process management.
+
+## First-parent accounting
+
+```text
+$ git rev-list --first-parent --reverse v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
+cfdacb4a657d9a60ab82fea3faa435ff732f389f
+9d03309a155dc5f714be8a99bb3c2234724bf589
+aa5c49f51bffa634ca7a96a08f1245e53a372904
+79a245c655e17ac654ac440fda31709ee38e28b8
+$ git rev-list --first-parent --count v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
+4
+```
+
+| first-parent commit | classification | release inventory |
+| --- | --- | --- |
+| `cfdacb4a657d9a60ab82fea3faa435ff732f389f` | G788 / PR #1723 / issue #1722 | included |
+| `9d03309a155dc5f714be8a99bb3c2234724bf589` | G789 / PR #1725 / issue #1724 | included |
+| `aa5c49f51bffa634ca7a96a08f1245e53a372904` | G791 / PR #1728 / issue #1727 | included |
+| `79a245c655e17ac654ac440fda31709ee38e28b8` | G790 / PR #1729 / issue #1726 | included |
+
+The first-parent range contains exactly these four merge commits and nothing
+else; the table is not a changelog of second-parent commits.
+
+## Consumer follow-up after publication
+
+The operator report issue remains open until a GitHub Release exists. This
+prepare-only slice posts no consumer comment; after publication, design posts
+the released version and closes it.
+
+| consumer issue | linked arc unit | post-publish follow-up |
+| --- | --- | --- |
+| (#1721) | G788 | cite v0.31.0 and close after the consumer report |
+
+## Truthfulness boundaries
+
+- G788's delivered-never-executed finding checks the downstream delegation,
+  child report carrying the same execution-unit token, and queue transition
+  evidence. It still fires on a true stall and lists what it checked rather
+  than asserting absence.
+- `session-layer inspect` is read-only, resolves a target only from recorded
+  topology or an explicit `--role`, has no focus default, exits 0 when the
+  session layer is unavailable (exit 0), and does not answer dialogs. `notify adjudicate`
+  remains the dialog path.
+- The G791 host guard proceeds on another domain's nested pointer drift only
+  when every nested checkout is clean; it refuses uncommitted nested content
+  and writes to no other domain's submodule.
+- G789's design-thread Orca block is non-normative; intent-cli neither launches
+  nor manages Orca.
+
+## Prepare-only verification
+
+`ReleaseNotesV0310DocsTests` compares the EN/JA unit/PR/issue/merge tuples and
+consumer row, and deliberately fails on a one-field mirror mutation. The PR
+pastes the actual parent absence/failure output for each new test, focused
+release-note validation (13 passed), full CLI Release validation (5655 passed,
+1 skipped, 0 failed), all-project Release validation (5985 passed, 1 skipped,
+0 failed), all three identity outputs, `git diff --check`, and exact-head CI.
+The diff is limited to release notes, version policy, placeholders,
+developer-reference readiness, and tests; it has no tag, GitHub Release,
+package publish, workflow/publish-config, consumer-comment, or product-source
+change.

--- a/docs/en/release-notes-v0.31.1.md
+++ b/docs/en/release-notes-v0.31.1.md
@@ -1,0 +1,8 @@
+# Release Notes — intent-cli v0.31.1
+
+> **DRAFT / UNRELEASED.** This replaceable planning scaffold is not a changelog.
+> The next release-prep packet will replace this placeholder after measuring the next release.
+
+This placeholder intentionally contains no release entries. No tag, GitHub
+Release, or package publish exists for v0.31.1. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.31.1`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3051,41 +3051,63 @@ result は literal bytes の削減、追加した reference bytes、record の n
 `shrink-audit.jsonl` に明記します。`.intent-cli/runs/*.provider.jsonl` は別の provider-run state なので
 scope 外です。`--dry-run` なら manifest、JSONL、audit を書き込まずに測定済み plan だけを確認できます。
 
-### 次リリース準備(v0.30.1)
+### 次リリース準備(v0.31.1)
 
 **RELEASE PREPARED / NOT PUBLISHED。**
 
-G787 は exact named product base
-`d9dc053dd81f53c3a8be420ee7c6798b808f4521` から v0.30.0 preparation を測定しました。
-rolled policy で normal clean Release build は `intent-cli 0.30.1-d9dc053-G772` を返し、
-これは新しい `nextVersion` placeholder identity であって v0.30.0 ではありません。同じ base を
-explicit `-p:Version=0.30.0` で build すると `intent-cli 0.30.0-d9dc053-G772` を返します。
-published v0.30.0 は `release.yml` の release tag `RAW` から `VERSION` を導出し、
+G792 は G788、G789、G791、G790 の四つの first-parent merge 後の exact named
+product base `79a245c655e17ac654ac440fda31709ee38e28b8` から v0.31.0 preparation を測定しました。
+normal clean Release build は `intent-cli 0.31.1-79a245c-G791` を返します。これは新しい
+`nextVersion` placeholder identity であり、**v0.31.0 ではありません**。同じ base を
+explicit `-p:Version=0.31.0` で build すると `intent-cli 0.31.0-79a245c-G791` を返します。
+published v0.31.0 は `release.yml` の release tag の `RAW` から `VERSION` を導出し、
 `eng/version.json` は local builds と dry runs だけを管理します。
 
-prepared files は `release-notes-v0.30.0.md` と
-`release-notes-v0.30.1.md` の DRAFT stub です。current policy は次のとおりです:
+prepared files は `release-notes-v0.31.0.md` と
+`release-notes-v0.31.1.md` の DRAFT stub です。current policy は次のとおりです:
 
 ```json
 {
-  "stableVersion": "0.30.0",
-  "nextVersion": "0.30.1"
+  "stableVersion": "0.31.0",
+  "nextVersion": "0.31.1"
 }
 ```
 
-`0.30.1` は replaceable development placeholder であり、次の real release number
+`0.31.1` は replaceable development placeholder であり、次の real release number
 ではありません。tag、GitHub Release、package publish、workflow change、product source
 change はこの prepare-only slice に含みません。
 
-active package-policy evidence は `stableVersion 0.30.0`、`nextVersion 0.30.1`、local
-candidate `JTechJapan.IntentSystem.Cli.0.30.1.nupkg` です。host-only release-prep claim boundary は
-`release-prep:<owner/repo>:0.30.1` で、この child release-prep は提供済みの権限を使い、
-host state を inspect/mutate しません。eight-unit inventory は G779–G786
-で、EN/JA tuple と consumer-follow-up parity、measured identity、truthfulness、placeholder
-check は `ReleaseNotesV0300DocsTests` が guard します。
-G780 は declared same-repository host の canonical claim location を
-`metadata_write_branch` に変更します。この arc の `--verify`、`--accept-evidence-gap`、
-`--shell-policy` は option-level surface であり、extra command route ではありません。
+active package-policy evidence は `stableVersion 0.31.0`、`nextVersion 0.31.1`、local
+candidate `JTechJapan.IntentSystem.Cli.0.31.1.nupkg` です。host-only release-prep claim boundary は
+`release-prep:<owner/repo>:0.31.0` で、この child release-prep は提供済みの権限を使い、
+host state を inspect/mutate しません。exact four-unit inventory は G788、G789、G791、G790
+で、EN/JA の unit/PR/issue/merge tuple と consumer-follow-up parity、measured identity、
+truthfulness、placeholder check は `ReleaseNotesV0310DocsTests` が guard し、
+`ReleasePackageMetadataTests` は release-policy shape と next-version note を引き続き guard します。
+G788 の evidence source、G789 の guide block、G791 の nested-pointer-drift classification は
+extra command route ではなく option/behavior addition です。
+
+minor の測定判断は v0.28.0 の rule に従います: **a command-route addition is a minor bump;
+option-level additions do not count as command routes.** tagged v0.30.0 tool には
+`session-layer inspect` がなく、named base がこの read-only command route を一つ追加しました。
+G788 evidence source/informational output、G789 guide text、G791 nested-pointer-drift
+classification は列挙しますが route としては数えません。
+current readiness record は `metadata_write_branch` topology evidence と
+`--verify`、`--accept-evidence-gap`、`--shell-policy` の option-level surface も保持します。
+まだ GitHub Release は存在しません。
+policy-derived next-version placeholder boundary は
+`release-prep:<owner/repo>:0.31.1` のままで、prepared release target は
+`release-prep:<owner/repo>:0.31.0` です。
+
+G792 の truthfulness boundary は次のとおりです。delivered-never-executed finding は downstream
+delegation、同じ execution-unit token を持つ child report、または queue transition を execution
+evidence として数え、true stall では引き続き発火し、absence を断定せず checked list を示します。
+`session-layer inspect` は read-only で、recorded topology または明示的 `--role` からだけ target
+を解決し、focus default を持たず、session layer unavailable のとき exit 0 となり、dialog に回答しません。
+その経路は `notify adjudicate` のままです。host guard は別 domain の nested pointer drift に対して、
+すべての nested checkout が clean の場合だけ進み、uncommitted nested content は拒否し、他 domain の
+submodule には書き込みません。G789 design-thread の Orca block は non-normative で、intent-cli は
+Orca を launch も manage もしません。
 
 ### previous v0.29.0 release-prep evidence (history のみ)
 

--- a/docs/ja/release-notes-v0.31.0.md
+++ b/docs/ja/release-notes-v0.31.0.md
@@ -1,0 +1,169 @@
+# リリースノート — intent-cli v0.31.0
+
+> **PREPARED / NOT PUBLISHED。** これは測定済み G788–G791 chain の prepare-only
+> notes です。tag / GitHub Release / package publish、workflow または publish
+> configuration、consumer comment、product source の変更は行いません。
+
+v0.31.0 の GitHub Release はまだ存在せず、この notes は preparation evidence だけです。
+matching install query は `JTechJapan.IntentSystem.Cli --version 0.31.0` です。
+この preparation 後の policy は次のとおりです:
+
+```json
+{
+  "stableVersion": "0.31.0",
+  "nextVersion": "0.31.1"
+}
+```
+
+`0.31.1` は replaceable development placeholder であり、次の real release number の決定では
+ありません。EN/JA の v0.31.1 file は planning scaffold であり、changelog ではありません。
+
+## 独自に測定した minor justification
+
+named product base は `79a245c655e17ac654ac440fda31709ee38e28b8` です。installed tagged
+v0.30.0 tool を explicit release version で測定しました:
+
+```text
+$ dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj --configuration Release --no-restore -p:Version=0.30.0 -p:IntentSystemLatestExecutionUnit=G772
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.30.0-f4b01c2-G772
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll session-layer --help
+intent-cli session-layer — group help
+Usage: intent-cli session-layer <subcommand> [--help]
+
+Subcommands (run with --help for details):
+- marker
+- model-resolution
+- set
+- show
+- team-mode
+- topology
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll session-layer inspect --help
+Command 'session-layer inspect' is not yet implemented.
+EXIT:1
+```
+
+この tagged surface には `inspect` route がありません。v0.28.0 の auditable rule は
+**a command-route addition is a minor bump; option-level additions do not count as command
+routes.** です。named base が read-only `session-layer inspect` command route を一つ追加した
+ため v0.31.0 と判断します。G788 evidence source/informational output、G789 guide block、
+G791 nested-pointer-drift classification は列挙しますが extra route とは数えません。
+
+## 測定した version identities
+
+policy roll 後の named base を clean Release build で確認しました:
+
+```text
+$ git rev-parse HEAD
+79a245c655e17ac654ac440fda31709ee38e28b8
+$ dotnet clean
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet build IntentSystem.sln --configuration Release
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.31.1-79a245c-G791
+```
+
+この normal identity は `nextVersion` placeholder であり、**v0.31.0 ではありません**。
+同じ base に explicit property を指定した測定:
+
+```text
+$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.31.0
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.31.0-79a245c-G791
+```
+
+published version は local policy file ではなく `release.yml` が導出する third identity です:
+
+```text
+$ RAW=v0.31.0; VERSION="${RAW#v}"; printf 'RAW=%s\nVERSION=%s\n' "$RAW" "$VERSION"
+RAW=v0.31.0
+VERSION=0.31.0
+```
+
+release workflow は `RAW` から `-p:Version=<tag>` を供給し、`eng/version.json` は local builds と dry runs だけを管理します。この prepare-only slice は tag を作成していません (no tag)。
+
+## Release inventory: 正確に四つの first-parent unit
+
+exact first-parent range から inventory を導出しました。Git は四つの commit を測定し、各
+commit に operator-observable outcome を一つ記録します:
+
+- G788 — PR #1723 / issue #1722; merge commit `cfdacb4a657d9a60ab82fea3faa435ff732f389f`。
+  **Operator-observable outcome:** matching downstream delegation、child report、または
+  queue transition が execution evidence を持つ場合だけ delivered parent を clear し、
+  true stall は見え続けます。
+- G789 — PR #1725 / issue #1724; merge commit `9d03309a155dc5f714be8a99bb3c2234724bf589`。
+  **Operator-observable outcome:** design-thread guide は additive Orca operating block を
+  保ち、mixed-kind review seat を矛盾なく解決し、topology fallback guidance も含みます。
+- G791 — PR #1728 / issue #1727; merge commit `aa5c49f51bffa634ca7a96a08f1245e53a372904`。
+  **Operator-observable outcome:** すべての nested checkout が clean のとき、別 domain の
+  nested pointer drift をその domain の submodule に書き込まず分類します。
+- G790 — PR #1729 / issue #1726; merge commit `79a245c655e17ac654ac440fda31709ee38e28b8`。
+  **Operator-observable outcome:** `session-layer inspect` は recorded role state と optional
+  bounded pane tail を focus、prompt、key send、process management なしで報告します。
+
+## First-parent accounting
+
+```text
+$ git rev-list --first-parent --reverse v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
+cfdacb4a657d9a60ab82fea3faa435ff732f389f
+9d03309a155dc5f714be8a99bb3c2234724bf589
+aa5c49f51bffa634ca7a96a08f1245e53a372904
+79a245c655e17ac654ac440fda31709ee38e28b8
+$ git rev-list --first-parent --count v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
+4
+```
+
+| first-parent commit | classification | release inventory |
+| --- | --- | --- |
+| `cfdacb4a657d9a60ab82fea3faa435ff732f389f` | G788 / PR #1723 / issue #1722 | included |
+| `9d03309a155dc5f714be8a99bb3c2234724bf589` | G789 / PR #1725 / issue #1724 | included |
+| `aa5c49f51bffa634ca7a96a08f1245e53a372904` | G791 / PR #1728 / issue #1727 | included |
+| `79a245c655e17ac654ac440fda31709ee38e28b8` | G790 / PR #1729 / issue #1726 | included |
+
+この range はこの四つの merge commit だけで、second-parent commit の changelog ではありません。
+
+## Publish 後の consumer follow-up
+
+GitHub Release が存在するまで operator report issue は open のままです。この prepare-only
+slice は consumer comment を投稿しません。publish 後に design が released version を投稿して
+close します。
+
+| consumer issue | linked arc unit | post-publish follow-up |
+| --- | --- | --- |
+| (#1721) | G788 | cite v0.31.0 and close after the consumer report |
+
+## Truthfulness boundaries
+
+- G788 の delivered-never-executed finding は downstream delegation、同じ execution-unit token
+  を持つ child report、queue transition を checked evidence として数えます。true stall では
+  発火し続け、absence を断定せず checked list を示します。
+- `session-layer inspect` は read-only で、recorded topology または明示的 `--role` からだけ
+  target を解決し、focus default を持たず、session layer unavailable でも exit 0 です (exit 0)。dialog
+  には回答せず、その path は `notify adjudicate` のままです。
+- G791 host guard は別 domain の nested pointer drift に対して、すべての nested checkout が
+  clean の場合だけ進みます。uncommitted nested content は拒否し、他 domain の submodule へ
+  書き込みません。
+- G789 design-thread guide の Orca block は non-normative であり、intent-cli は Orca を
+  launch も manage もしません。
+
+## Prepare-only verification
+
+`ReleaseNotesV0310DocsTests` は EN/JA の unit/PR/issue/merge tuple と consumer row を比較し、
+mirror の一フィールド mutation で意図的に fail します。PR には各 new test の parent
+absence/failure actual output、focused release-note validation (13 passed)、full CLI Release
+validation (5655 passed, 1 skipped, 0 failed)、all-project Release validation (5985 passed,
+1 skipped, 0 failed)、三つの identity、`git diff --check`、exact-head CI を貼っています。diff は
+release notes、version policy、placeholder、developer reference readiness、test に限定され、
+tag / GitHub Release / package publish / workflow または publish-config / consumer-comment /
+product-source change は含みません。

--- a/docs/ja/release-notes-v0.31.1.md
+++ b/docs/ja/release-notes-v0.31.1.md
@@ -1,0 +1,8 @@
+# リリースノート — intent-cli v0.31.1
+
+> **DRAFT / 未リリース。** これは replaceable planning scaffold であり、changelog ではありません。
+> 次の release-prep packet が次の release を測定した後にこの placeholder を置き換えます。
+
+この placeholder には release entry を記録しません。v0.31.1 の tag、GitHub
+Release、package publish はまだ存在しません。matching install query は
+`JTechJapan.IntentSystem.Cli --version 0.31.1` です。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.30.0",
-  "nextVersion": "0.30.1"
+  "stableVersion": "0.31.0",
+  "nextVersion": "0.31.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
@@ -169,8 +169,8 @@ public sealed class ReleaseNotesV0240DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.30.0", policy.StableVersion);
-        Assert.Equal("0.30.1", policy.NextVersion);
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -198,7 +198,7 @@ public sealed class ReleaseNotesV0240DocsTests
             Assert.DoesNotContain("release-notes-v0.27.0.md", reference, StringComparison.Ordinal);
             Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
             Assert.Contains(
-                language == "en" ? "Next release readiness (v0.30.1)" : "次リリース準備(v0.30.1)",
+                language == "en" ? "Next release readiness (v0.31.1)" : "次リリース準備(v0.31.1)",
                 reference,
                 StringComparison.Ordinal);
             Assert.Contains("intent-cli 0.29.0-65e02d8-G772", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
@@ -165,8 +165,8 @@ public sealed class ReleaseNotesV0250DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
 
-        Assert.Equal("0.30.0", policy.StableVersion);
-        Assert.Equal("0.30.1", policy.NextVersion);
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -193,7 +193,7 @@ public sealed class ReleaseNotesV0250DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.30.1)" : "次リリース準備(v0.30.1)",
+            language == "en" ? "Next release readiness (v0.31.1)" : "次リリース準備(v0.31.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(CurrentStableInstallDisplayIdentity, reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
@@ -214,12 +214,12 @@ public sealed class ReleaseNotesV0260DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policyPath = Path.Combine(root, "eng", "version.json");
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.30.0", policy.StableVersion);
-        Assert.Equal("0.30.1", policy.NextVersion);
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
@@ -155,12 +155,12 @@ public sealed class ReleaseNotesV0270DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.30.0", policy.StableVersion);
-        Assert.Equal("0.30.1", policy.NextVersion);
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
@@ -18,12 +18,12 @@ public sealed class ReleaseNotesV0271DocsTests
         var policyPath = Path.Combine(root, "eng", "version.json");
 
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.30.0", policy.StableVersion);
-        Assert.Equal("0.30.1", policy.NextVersion);
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
@@ -156,12 +156,12 @@ public sealed class ReleaseNotesV0280DocsTests
         var policyPath = Path.Combine(root, "eng", "version.json");
 
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.30.0", policy.StableVersion);
-        Assert.Equal("0.30.1", policy.NextVersion);
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
@@ -124,12 +124,12 @@ public sealed class ReleaseNotesV0290DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.30.0", policy.StableVersion);
-        Assert.Equal("0.30.1", policy.NextVersion);
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -151,7 +151,7 @@ public sealed class ReleaseNotesV0290DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "### Next release readiness (v0.30.1)" : "### 次リリース準備(v0.30.1)",
+            language == "en" ? "### Next release readiness (v0.31.1)" : "### 次リリース準備(v0.31.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(NormalBaseIdentity, reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
@@ -179,17 +179,17 @@ public sealed class ReleaseNotesV0300DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.30.0\",\n  \"nextVersion\": \"0.30.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.30.0", policy.StableVersion);
-        Assert.Equal("0.30.1", policy.NextVersion);
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.30.0.md")));
-            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.30.1.md"));
+            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.31.1.md"));
             Assert.Contains("DRAFT", stub, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(language == "en" ? "not a changelog" : "changelog ではありません", stub, StringComparison.OrdinalIgnoreCase);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
@@ -1,0 +1,233 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G792: v0.31.0 is a measured, prepare-only release line. These guards keep
+/// the exact first-parent inventory, three independently measured identities,
+/// EN/JA parity, truthfulness boundaries, and version-policy roll durable.
+/// </summary>
+public sealed class ReleaseNotesV0310DocsTests
+{
+    private const string Base = "79a245c655e17ac654ac440fda31709ee38e28b8";
+    private const string NormalPlaceholderIdentity = "intent-cli 0.31.1-79a245c-G791";
+    private const string ExplicitReleaseIdentity = "intent-cli 0.31.0-79a245c-G791";
+    private const string TaggedIdentity = "intent-cli 0.30.0-f4b01c2-G772";
+
+    private static readonly (string Unit, string Pr, string Issue, string Merge)[] Units =
+    [
+        ("G788", "#1723", "#1722", "cfdacb4a657d9a60ab82fea3faa435ff732f389f"),
+        ("G789", "#1725", "#1724", "9d03309a155dc5f714be8a99bb3c2234724bf589"),
+        ("G791", "#1728", "#1727", "aa5c49f51bffa634ca7a96a08f1245e53a372904"),
+        ("G790", "#1729", "#1726", "79a245c655e17ac654ac440fda31709ee38e28b8"),
+    ];
+
+    private static readonly (string Issue, string Unit, string FollowUp)[] ConsumerFollowUps =
+    [
+        ("#1721", "G788", "cite v0.31.0"),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyTheFourGitDerivedUnits(string language)
+    {
+        var notes = ReadNotes(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(4, listed.Length);
+
+        foreach (var unit in Units)
+        {
+            var entry = FindEntry(notes, unit.Unit);
+            Assert.NotEmpty(entry);
+            Assert.Contains($"PR {unit.Pr} / issue {unit.Issue};", entry, StringComparison.Ordinal);
+            Assert.Contains($"merge commit `{unit.Merge}`", entry, StringComparison.Ordinal);
+            Assert.Contains("Operator-observable outcome", entry, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUp()
+    {
+        var english = ReadNotes("en");
+        var japanese = ReadNotes("ja");
+
+        Assert.Equal(Units, ParseInventory(english));
+        Assert.Equal(Units, ParseInventory(japanese));
+        Assert.Equal(ParseInventory(english), ParseInventory(japanese));
+        Assert.Equal(ConsumerFollowUps, ParseConsumerFollowUps(english));
+        Assert.Equal(ConsumerFollowUps, ParseConsumerFollowUps(japanese));
+        Assert.Equal(ParseConsumerFollowUps(english), ParseConsumerFollowUps(japanese));
+    }
+
+    [Fact]
+    public void MirrorParityDetectsSingleFieldMutation()
+    {
+        var english = ReadNotes("en");
+        var japanese = ReadNotes("ja");
+
+        var changedIssue = japanese.Replace("issue #1722", "issue #9999", StringComparison.Ordinal);
+        var changedFollowUp = japanese.Replace(
+            "| (#1721) | G788 | cite v0.31.0 and close after the consumer report |",
+            "| (#1721) | G790 | cite v0.31.0 and close after the consumer report |",
+            StringComparison.Ordinal);
+
+        Assert.False(ParseInventory(english).SequenceEqual(ParseInventory(changedIssue)));
+        Assert.False(ParseConsumerFollowUps(english).SequenceEqual(ParseConsumerFollowUps(changedFollowUp)));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinThreeMeasuredVersionIdentitiesAndMinorDecision(string language)
+    {
+        var notes = ReadNotes(language);
+        var normalized = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Contains(Base, notes, StringComparison.Ordinal);
+        Assert.Contains(TaggedIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains(NormalPlaceholderIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains(ExplicitReleaseIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains("dotnet build IntentSystem.sln --configuration Release", notes, StringComparison.Ordinal);
+        Assert.Contains("-p:Version=0.31.0", notes, StringComparison.Ordinal);
+        Assert.Contains("release.yml", notes, StringComparison.Ordinal);
+        Assert.Contains("RAW=v0.31.0", notes, StringComparison.Ordinal);
+        Assert.Contains("VERSION=0.31.0", notes, StringComparison.Ordinal);
+        Assert.Contains("eng/version.json", notes, StringComparison.Ordinal);
+        Assert.Contains("local builds", notes, StringComparison.Ordinal);
+        Assert.Contains("dry runs", notes, StringComparison.Ordinal);
+        Assert.Contains("session-layer inspect", notes, StringComparison.Ordinal);
+        Assert.Contains("Command 'session-layer inspect' is not yet implemented.", notes, StringComparison.Ordinal);
+        Assert.Contains("EXIT:1", notes, StringComparison.Ordinal);
+        Assert.Contains("command-route", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("option-level", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "**not** v0.31.0" : "**v0.31.0 ではありません**", normalized, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinEveryFirstParentCommitAndPrepareOnlyBoundary(string language)
+    {
+        var notes = ReadNotes(language);
+        const string range = "v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8";
+
+        Assert.Contains($"git rev-list --first-parent --reverse {range}", notes, StringComparison.Ordinal);
+        Assert.Contains($"git rev-list --first-parent --count {range}", notes, StringComparison.Ordinal);
+        Assert.Contains("\n4\n", notes, StringComparison.Ordinal);
+        Assert.Contains("PREPARED / NOT PUBLISHED", notes, StringComparison.Ordinal);
+        Assert.Contains("no tag", notes, StringComparison.OrdinalIgnoreCase);
+
+        foreach (var unit in Units)
+        {
+            Assert.Contains(unit.Merge, notes, StringComparison.Ordinal);
+            Assert.Contains($"{unit.Unit} / PR {unit.Pr} / issue {unit.Issue}", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinFourTruthfulnessBoundaries(string language)
+    {
+        var notes = ReadNotes(language);
+        var normalized = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Contains("downstream delegation", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("child report", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("queue transition", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("true stall", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "lists what it checked" : "checked list", normalized, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Contains("read-only", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("recorded topology", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--role", normalized, StringComparison.Ordinal);
+        Assert.Contains("focus default", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("exit 0", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("notify adjudicate", normalized, StringComparison.Ordinal);
+
+        Assert.Contains(language == "en" ? "every nested checkout is clean" : "すべての nested checkout が clean", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("uncommitted nested content", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "no other domain's submodule" : "他 domain の submodule", normalized, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Contains("non-normative", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "neither launches" : "launch も manage もしません", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Orca", notes, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VersionPolicyRollAndNextVersionPlaceholdersAreExact()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        Assert.Equal(
+            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
+            File.ReadAllText(Path.Combine(root, "eng", "version.json")));
+
+        var policy = RepoVersionPolicySource.Read();
+        Assert.Equal("0.31.0", policy.StableVersion);
+        Assert.Equal("0.31.1", policy.NextVersion);
+
+        foreach (var language in new[] { "en", "ja" })
+        {
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.31.0.md")));
+            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.31.1.md"));
+            Assert.Contains("DRAFT", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(language == "en" ? "not a changelog" : "changelog ではありません", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("- G", stub, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReferenceReadinessMirrorsCurrentPreparedLine(string language)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+
+        Assert.Contains(
+            language == "en" ? "### Next release readiness (v0.31.1)" : "### 次リリース準備(v0.31.1)",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(NormalPlaceholderIdentity, reference, StringComparison.Ordinal);
+        Assert.Contains(ExplicitReleaseIdentity, reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.31.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.31.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0310DocsTests", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleasePackageMetadataTests", reference, StringComparison.Ordinal);
+    }
+
+    private static string FindEntry(string notes, string unit)
+    {
+        var match = Regex.Match(notes, $"(?ms)^- {Regex.Escape(unit)} —.*?(?=^- |^## |\\z)");
+        return match.Success ? match.Value : string.Empty;
+    }
+
+    private static IReadOnlyList<(string Unit, string Pr, string Issue, string Merge)> ParseInventory(string notes) =>
+        Regex.Matches(
+                notes,
+                @"(?ms)^- (G\d+) — PR (#\d+) / issue (#\d+); merge commit `([0-9a-f]{40})`.*?(?=^- |^## |\z)")
+            .Select(match => (
+                match.Groups[1].Value,
+                match.Groups[2].Value,
+                match.Groups[3].Value,
+                match.Groups[4].Value))
+            .ToArray();
+
+    private static IReadOnlyList<(string Issue, string Unit, string FollowUp)> ParseConsumerFollowUps(string notes) =>
+        Regex.Matches(notes, @"(?m)^\| \(#(\d+)\) \| (G\d+) \| (cite v0\.31\.0).*$")
+            .Select(match => (
+                $"#{match.Groups[1].Value}",
+                match.Groups[2].Value,
+                match.Groups[3].Value))
+            .ToArray();
+
+    private static string ReadNotes(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.31.0.md"));
+}


### PR DESCRIPTION
Closes #1730

# G792 — prepare v0.31.0 (prepare-only)

This PR implements the published G792 packet as one bounded release-prep slice.
It adds the EN/JA v0.31.0 notes, rolls `eng/version.json` to stable `0.31.0`
and next `0.31.1`, adds the demanded DRAFT placeholders, refreshes the mirrored
developer-reference readiness section, and adds durable release-note guards.
It does not tag, create a GitHub Release, publish packages, change a workflow or
publish configuration, post a consumer follow-up, or change product source.

## Criterion 1 — measured minor decision, exact four-unit inventory, follow-up

The tagged tool was built with the release version and the route check was run
from a temporary tagged checkout. The actual tagged command output is:

```text
$ dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj --configuration Release --no-restore -p:Version=0.30.0 -p:IntentSystemLatestExecutionUnit=G772
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.30.0-f4b01c2-G772
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll session-layer inspect --help
Command 'session-layer inspect' is not yet implemented.
EXIT:1
```

The v0.28.0 rule quoted in both notes is: “a command-route addition is a minor
bump; option-level additions do not count as command routes.” The named base
adds the single `session-layer inspect` route. G788 evidence sources and
informational output, G789 guide blocks, and G791 nested-pointer-drift
classification are listed but not counted as routes.

The exact first-parent measurement and inventory are:

```text
$ git rev-list --first-parent --reverse v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
cfdacb4a657d9a60ab82fea3faa435ff732f389f
9d03309a155dc5f714be8a99bb3c2234724bf589
aa5c49f51bffa634ca7a96a08f1245e53a372904
79a245c655e17ac654ac440fda31709ee38e28b8
$ git rev-list --first-parent --count v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
4
```

| unit | issue | PR | merge SHA | operator-observable outcome |
| --- | --- | --- | --- | --- |
| G788 | #1722 | #1723 | `cfdacb4a657d9a60ab82fea3faa435ff732f389f` | delivered-parent execution evidence is checked across delegation, child report, and queue transition while true stalls remain visible |
| G789 | #1724 | #1725 | `9d03309a155dc5f714be8a99bb3c2234724bf589` | additive Orca guidance and mixed-kind review-seat resolution remain non-contradictory |
| G791 | #1727 | #1728 | `aa5c49f51bffa634ca7a96a08f1245e53a372904` | clean nested-checkout pointer drift is classified without writing another domain's submodule |
| G790 | #1726 | #1729 | `79a245c655e17ac654ac440fda31709ee38e28b8` | read-only recorded-role/session inspection and optional bounded pane tail are available without focus or process management |

Consumer follow-up carried in both mirrors:

```text
| (#1721) | G788 | cite v0.31.0 and close after the consumer report |
```

## Criterion 2 — three measured version identities

The named base and clean Release build produced the following actual output:

```text
$ git rev-parse HEAD
79a245c655e17ac654ac440fda31709ee38e28b8
$ dotnet clean
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet build IntentSystem.sln --configuration Release
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.31.1-79a245c-G791
```

That normal identity is the `nextVersion` placeholder, not `0.31.0`. The
explicit release build produced:

```text
$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.31.0
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.31.0-79a245c-G791
```

The release tag derivation was measured directly:

```text
$ RAW=v0.31.0; VERSION="${RAW#v}"; printf 'RAW=%s\nVERSION=%s\n' "$RAW" "$VERSION"
RAW=v0.31.0
VERSION=0.31.0
```

The notes state that `release.yml` supplies the published tag version and that
`eng/version.json` is local-build/dry-run policy only. `ReleaseNotesV0310DocsTests`
guards all three identities and the policy roll.

## Criterion 3 — EN/JA tuple parity and one-field mutation proof

The focused parity test passes on the committed mirrors (13 tests). Before
restoring the mirror, I changed only JA `issue #1722` to `issue #9999` and ran
the same parity test. The actual failing output was:

```text
[xUnit.net 00:00:00.29] IntentSystem.Cli.Tests.ReleaseNotesV0310DocsTests.EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUp [FAIL]
Error Message:
 Assert.Equal() Failure: Collections differ
         ↓ (pos 0)
Expected: [Tuple ("G788", "#1723", "#1722", "cfdacb4a657d9a60ab82fea3faa435ff732f389f"), Tuple ("G789", "#1725", "#1724", "9d03309a155dc5f714be8a99bb3c2234724bf589"), Tuple ("G791", "#1728", "#1727", "aa5c49f51bffa634ca7a96a08f1245e53a372904"), Tuple ("G790", "#1729", "#1726", "79a245c655e17ac654ac440fda31709ee38e28b8")]
Actual:   [Tuple ("G788", "#1723", "#9999", "cfdacb4a657d9a60ab82fea3faa435ff732f389f"), Tuple ("G789", "#1725", "#1724", "9d03309a155dc5f714be8a99bb3c2234724bf589"), Tuple ("G791", "#1728", "#1727", "aa5c49f51bffa634ca7a96a08f1245e53a372904"), Tuple ("G790", "#1729", "#1726", "79a245c655e17ac654ac440fda31709ee38e28b8")]
Stack Trace:
 at IntentSystem.Cli.Tests.ReleaseNotesV0310DocsTests.EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUp() in tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs:line 61
Failed! - Failed: 1, Passed: 1, Skipped: 0, Total: 2
```

The mutation was reverted before commit. The passing focused command was:

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~ReleaseNotesV0310DocsTests
Passed! - Failed: 0, Passed: 13, Skipped: 0, Total: 13
```

## Criterion 4 — truthfulness boundaries

Both notes and the readiness mirror explicitly preserve these bounded statements:

1. G788 checks downstream delegation, same-token child reports, and queue
   transitions; it still reports a true stall and lists what was checked.
2. `session-layer inspect` is read-only, uses recorded topology or explicit
   `--role`, has no focus default, exits 0 when unavailable, and does not answer
   dialogs; `notify adjudicate` remains the dialog path.
3. G791 proceeds on another domain's pointer drift only when every nested
   checkout is clean; uncommitted nested content is refused and no other-domain
   submodule is written.
4. G789 Orca guidance is non-normative; intent-cli neither launches nor manages
   Orca.

## Criterion 5 — version-policy roll and release validation

The policy and placeholder guard output is:

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --no-build --filter 'FullyQualifiedName~ReleaseNotes|FullyQualifiedName~ReleasePackageMetadata|FullyQualifiedName~VersionSourcePolicy'
Passed! - Failed: 0, Passed: 303, Skipped: 0, Total: 303
```

The final all-project Release validation is:

```text
dotnet test IntentSystem.sln --configuration Release --no-restore --no-build
IntentSystem.Cli.Tests: Passed 5655, Skipped 1, Failed 0, Total 5656
all other Release test projects: Passed 330, Skipped 0, Failed 0
all-project total: Passed 5985, Skipped 1, Failed 0, Total 5986
```

## Criterion 6 — prepare-only scope and parent proof

The exact parent-to-head changed-path list is:

```text
docs/en/09-developer-reference.md
docs/en/release-notes-v0.31.0.md
docs/en/release-notes-v0.31.1.md
docs/ja/09-developer-reference.md
docs/ja/release-notes-v0.31.0.md
docs/ja/release-notes-v0.31.1.md
eng/version.json
tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
```

No tag, release, package, workflow/publish-config, consumer-comment, or product
source path is present. `git diff --check` was clean:

```text
git_diff_check_exit:0
```

Each new artifact/test was absent from the direct parent
`79a245c655e17ac654ac440fda31709ee38e28b8`; these are the actual `git show`
results (exit 128), not inferred absence:

```text
fatal: path 'tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
tests_parent_absence_exit:128
fatal: path 'docs/en/release-notes-v0.31.0.md' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
en_notes_parent_absence_exit:128
fatal: path 'docs/ja/release-notes-v0.31.0.md' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
ja_notes_parent_absence_exit:128
fatal: path 'docs/en/release-notes-v0.31.1.md' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
en_stub_parent_absence_exit:128
fatal: path 'docs/ja/release-notes-v0.31.1.md' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
ja_stub_parent_absence_exit:128
```

The working tree preserved the untracked `.artifacts/` directory and it is not
part of the commit.

## Criterion 7 — each new test parent absence proof

```text
fatal: path 'tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
tests_parent_absence_exit:128
fatal: path 'docs/en/release-notes-v0.31.0.md' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
en_notes_parent_absence_exit:128
fatal: path 'docs/ja/release-notes-v0.31.0.md' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
ja_notes_parent_absence_exit:128
fatal: path 'docs/en/release-notes-v0.31.1.md' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
en_stub_parent_absence_exit:128
fatal: path 'docs/ja/release-notes-v0.31.1.md' exists on disk, but not in '79a245c655e17ac654ac440fda31709ee38e28b8'
ja_stub_parent_absence_exit:128
```

These are the actual `git show` failures for every new test/note/placeholder
path; they are not inferred from the current tree.

## Criterion 8 — full Release suite actual counts

```text
dotnet test IntentSystem.sln --configuration Release --no-restore --no-build
IntentSystem.Cli.Tests: Passed 5655, Skipped 1, Failed 0, Total 5656
all other Release test projects: Passed 330, Skipped 0, Failed 0
all-project total: Passed 5985, Skipped 1, Failed 0, Total 5986
```

## Head and CI

Commit pushed by this PR: `1cfa6f530d03489a483e71a78e764b023afa60f9`.
Exact-head CI completed green:

```text
Build and test (source contract)  pass  2m54s  https://github.com/J-Tech-Japan/intent-system/actions/runs/33758690517/job/100659313649
npm package dry-run (no publish)  pass  1m25s  https://github.com/J-Tech-Japan/intent-system/actions/runs/33758690517/job/100660288496
```

The PR is non-draft and remains prepare-only; no merge is requested.
