### PR TITLE
G793: settle visibly completed delegations in stalled-work

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -108,11 +108,16 @@ namespace IntentSystem.Cli.Commands;
 ///   — never <c>claimed-but-silent</c>, since the unit is legitimately
 ///   waiting, not silently stalled. Names the canonical <c>automation
 ///   issue-block</c> reconcile command.</item>
+/// <item><c>delegation-settled-by-outcome</c> (G793) — a pending delegation
+///   whose unit has a merged linked PR and closed linked issue. The row is
+///   retained as informational evidence with the merge SHA and issue number,
+///   but is excluded from outstanding counts and stalled status.</item>
 /// <item><c>pending-delegation-open</c> — an open durable notify delegation
 ///   older than the stale threshold. It is informational: the recommendation
-///   is to inspect the task and, only after an attributed outcome judgment, use
-///   <c>notify dispose</c>; elapsed time never settles it. Disposition-settled
-///   and report-settled records are excluded from both this population and the
+///   names the complete <c>notify dispose --kind applied-elsewhere</c> route;
+///   only an attributed outcome judgment may use it, and elapsed time never
+///   settles the row. Disposition-, report-, and independently observed
+///   merged/closed-outcome records are excluded from this population and the
 ///   open count.</item>
 /// </list>
 ///
@@ -246,6 +251,13 @@ internal static class AutomationStalledWorkCommand
     /// is no longer owed and never writes a disposition.
     /// </summary>
     public const string KindPendingDelegationOpen = "pending-delegation-open";
+
+    /// <summary>
+    /// G793: a durable delegation record whose execution unit is evidenced by
+    /// a merged linked PR and the PR's closed linked issue. This remains
+    /// visible as informational evidence, but is not an outstanding stall.
+    /// </summary>
+    public const string KindDelegationSettledByOutcome = "delegation-settled-by-outcome";
 
     /// <summary>
     /// G533: an issue claimed via <c>intent-issue-in-progress</c> (with no
@@ -746,7 +758,14 @@ internal static class AutomationStalledWorkCommand
             excluded,
             warnings,
             recordingRole);
-        CollectPendingDelegations(openPendingDelegations, now, capabilityMatrix, items);
+        var settledPendingDelegations = CollectPendingDelegations(
+            openPendingDelegations,
+            openIssues,
+            mergedPrs,
+            repo,
+            now,
+            capabilityMatrix,
+            items);
 
         var operatorAttention = CollectOperatorAttention(context, domain, now, items);
 
@@ -785,14 +804,19 @@ internal static class AutomationStalledWorkCommand
             RecordingRole = recordingRole,
             StaleMinutesThreshold = staleMinutes,
             BacklogIdleMinutesThreshold = backlogIdleMinutes,
-            OpenPendingDelegations = openPendingDelegations.Count,
+            // G793: the diagnostic count describes genuinely outstanding
+            // delegations, so an open store record with independently
+            // observed merged/closed outcome is excluded from this count.
+            OpenPendingDelegations = openPendingDelegations.Count - settledPendingDelegations,
             // G589: a still-pending CI item remains visible, but it must not
             // by itself trip a heartbeat/watcher wake. The kind changes when
             // the exact head becomes terminal, and that terminal item is the
             // dedupe-ready actionable signal. Other historical informational
             // kinds retain their established stalled semantics.
             Stalled = githubApiFailure is not null
-                || filtered.Any(item => item.Kind is not KindCiPending and not KindAwaitingOperatorMerge),
+                || filtered.Any(item => item.Kind is not KindCiPending
+                    and not KindAwaitingOperatorMerge
+                    and not KindDelegationSettledByOutcome),
             Items = resultItems,
             Excluded = excluded,
             Warnings = warnings,
@@ -1040,33 +1064,194 @@ internal static class AutomationStalledWorkCommand
         }
     }
 
-    private static void CollectPendingDelegations(
+    private static int CollectPendingDelegations(
         IReadOnlyList<NotifyPendingDelegation> openDelegations,
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
+        IReadOnlyList<GitHubAutomationPrCandidate> mergedPrs,
+        string repo,
         DateTimeOffset now,
         TeamModeCapabilityMatrix capabilityMatrix,
         List<StalledWorkItem> items)
     {
         if (!capabilityMatrix.IsApplicable(TeamModeCapabilityClasses.Delegation))
         {
-            return;
+            return 0;
         }
 
+        var settledCount = 0;
         foreach (var delegation in openDelegations)
         {
             var ageMinutes = Math.Max(0, (int)Math.Floor((now - delegation.DispatchedAt).TotalMinutes));
+            var outcome = FindSettledDelegationOutcome(delegation, openIssues, mergedPrs, repo);
+            if (outcome is not null)
+            {
+                settledCount++;
+                items.Add(new StalledWorkItem
+                {
+                    Kind = KindDelegationSettledByOutcome,
+                    ExecutionUnit = delegation.TaskId,
+                    Issue = new StalledWorkRef
+                    {
+                        Number = outcome.ClosedIssueNumber,
+                        Url = outcome.ClosedIssueUrl,
+                    },
+                    Pr = new StalledWorkRef
+                    {
+                        Number = outcome.PullRequestNumber,
+                        Url = outcome.PullRequestUrl,
+                    },
+                    AgeMinutes = ageMinutes,
+                    IsInformational = true,
+                    RecommendedAction =
+                        $"settled by outcome: merged PR #{outcome.PullRequestNumber} at "
+                        + $"{outcome.MergeSha} closed issue #{outcome.ClosedIssueNumber}; "
+                        + "no pending-state write was performed.",
+                    MergeSha = outcome.MergeSha,
+                    ClosedIssueNumber = outcome.ClosedIssueNumber,
+                });
+                continue;
+            }
+
             items.Add(new StalledWorkItem
             {
                 Kind = KindPendingDelegationOpen,
                 ExecutionUnit = delegation.TaskId,
                 AgeMinutes = ageMinutes,
                 IsInformational = true,
-                RecommendedAction =
-                    $"inspect open notify delegation '{delegation.TaskId}' for team '{delegation.Team}'; "
-                    + "if its outcome is no longer owed, an attributed owner may run "
-                    + $"`intent-cli notify dispose --domain {delegation.Domain} --team {delegation.Team} --task-id {delegation.TaskId} ... --write`; elapsed time alone never settles it.",
+                RecommendedAction = BuildPendingDelegationDisposalAction(delegation),
             });
         }
+
+        return settledCount;
     }
+
+    private static string BuildPendingDelegationDisposalAction(NotifyPendingDelegation delegation) =>
+        $"inspect open notify delegation '{delegation.TaskId}' for team '{delegation.Team}'; "
+        + "if its outcome is no longer owed, an attributed owner may run "
+        + $"`intent-cli notify dispose --domain {delegation.Domain} --team {delegation.Team} "
+        + $"--task-id {delegation.TaskId} --kind applied-elsewhere --actor \"<actor>\" "
+        + "--reason \"<reason>\" --applied-outcome-evidence \"<evidence>\" --write`; "
+        + "elapsed time alone never settles it.";
+
+    private static DelegationOutcomeEvidence? FindSettledDelegationOutcome(
+        NotifyPendingDelegation delegation,
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
+        IReadOnlyList<GitHubAutomationPrCandidate> mergedPrs,
+        string repo)
+    {
+        var delegationText = string.Join(
+            "\n",
+            new[] { delegation.TaskId, delegation.ExpectedArtifact, delegation.Objective ?? string.Empty }
+                .Concat(delegation.ExpectedArtifacts ?? Array.Empty<string>())
+                .Concat(delegation.Inputs ?? Array.Empty<string>()));
+        var referencedNumbers = ExtractGitHubReferenceNumbers(delegationText);
+        var unitTokens = ExtractExecutionUnitTokens(delegationText);
+
+        foreach (var pr in mergedPrs)
+        {
+            if (!string.Equals(pr.State, "MERGED", StringComparison.OrdinalIgnoreCase)
+                || string.IsNullOrWhiteSpace(pr.MergeCommit?.Oid)
+                || !MatchesDelegationEvidence(pr, unitTokens, referencedNumbers))
+            {
+                continue;
+            }
+
+            var closedReferences = pr.ClosingIssuesReferences
+                .Where(reference => reference.Number > 0 && ReferenceMatchesRepo(reference, repo))
+                .Where(reference => !openIssues.Any(issue =>
+                    issue.Number == reference.Number && IsOpen(issue.State)))
+                .ToArray();
+            if (closedReferences.Length == 0)
+            {
+                continue;
+            }
+
+            // A delegation that names a particular issue gets that exact
+            // closure as evidence. If it names no issue, accept only a single
+            // closing reference rather than guessing across multiple issues.
+            var linkedReferences = closedReferences
+                .Where(reference => referencedNumbers.Contains(reference.Number))
+                .ToArray();
+            var linkedReference = linkedReferences.Length == 1
+                ? linkedReferences[0]
+                : linkedReferences.Length == 0 && closedReferences.Length == 1
+                    ? closedReferences[0]
+                    : null;
+            if (linkedReference is null)
+            {
+                continue;
+            }
+
+            return new DelegationOutcomeEvidence(
+                pr.Number,
+                pr.Url,
+                pr.MergeCommit!.Oid,
+                linkedReference.Number,
+                $"https://github.com/{repo}/issues/{linkedReference.Number}");
+        }
+
+        return null;
+    }
+
+    private static bool MatchesDelegationEvidence(
+        GitHubAutomationPrCandidate pr,
+        IReadOnlySet<string> unitTokens,
+        IReadOnlySet<int> referencedNumbers)
+    {
+        var candidateText = $"{pr.Title}\n{pr.Body}";
+        if (unitTokens.Any(token => ContainsToken(candidateText, token)))
+        {
+            return true;
+        }
+
+        return referencedNumbers.Contains(pr.Number)
+            || pr.ClosingIssuesReferences.Any(reference => referencedNumbers.Contains(reference.Number));
+    }
+
+    private static IReadOnlySet<string> ExtractExecutionUnitTokens(string text) =>
+        System.Text.RegularExpressions.Regex.Matches(
+                text,
+                @"(?<![A-Za-z0-9])G[0-9]+(?![A-Za-z0-9])",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase)
+            .Select(match => match.Value.ToUpperInvariant())
+            .ToHashSet(StringComparer.Ordinal);
+
+    private static IReadOnlySet<int> ExtractGitHubReferenceNumbers(string text) =>
+        System.Text.RegularExpressions.Regex.Matches(text, @"(?:issues|pull)/([0-9]+)|#([0-9]+)")
+            .Select(match => match.Groups[1].Success ? match.Groups[1].Value : match.Groups[2].Value)
+            .Select(value => int.TryParse(value, out var number) ? number : 0)
+            .Where(number => number > 0)
+            .ToHashSet();
+
+    private static bool ContainsToken(string text, string token)
+    {
+        var searchStart = 0;
+        while (true)
+        {
+            var index = text.IndexOf(token, searchStart, StringComparison.OrdinalIgnoreCase);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            var beforeOk = index == 0 || !char.IsLetterOrDigit(text[index - 1]);
+            var afterIndex = index + token.Length;
+            var afterOk = afterIndex >= text.Length || !char.IsLetterOrDigit(text[afterIndex]);
+            if (beforeOk && afterOk)
+            {
+                return true;
+            }
+
+            searchStart = index + 1;
+        }
+    }
+
+    private sealed record DelegationOutcomeEvidence(
+        int PullRequestNumber,
+        string PullRequestUrl,
+        string MergeSha,
+        int ClosedIssueNumber,
+        string ClosedIssueUrl);
 
     /// <summary>
     /// G670: keeps a backlog-ready-idle contract-incomplete exclusion only
@@ -4719,6 +4904,14 @@ internal static class AutomationStalledWorkCommand
                 {
                     writer.WriteLine($"- pr: #{pr.Number} — {pr.Url}");
                 }
+                if (item.MergeSha is { } mergeSha)
+                {
+                    writer.WriteLine($"- merge_sha: {mergeSha}");
+                }
+                if (item.ClosedIssueNumber is { } closedIssueNumber)
+                {
+                    writer.WriteLine($"- closed_issue_number: #{closedIssueNumber}");
+                }
                 if (item.ReleasedVersion is { } releasedVersion)
                 {
                     writer.WriteLine($"- released_version: {releasedVersion}");
@@ -4920,8 +5113,9 @@ internal sealed record AutomationStalledWorkResult
     public required int BacklogIdleMinutesThreshold { get; init; }
 
     /// <summary>
-    /// G671: count of current open notify delegations for the requested
-    /// domain. Report-settled and disposition-settled records are excluded.
+    /// G671/G793: count of genuinely outstanding notify delegations for the
+    /// requested domain. Report-, disposition-, and independently observed
+    /// merged/closed-outcome records are excluded.
     /// </summary>
     [JsonPropertyName("open_pending_delegations")]
     public required int OpenPendingDelegations { get; init; }
@@ -5047,6 +5241,22 @@ internal sealed record StalledWorkItem
 
     [JsonPropertyName("recommended_action")]
     public required string RecommendedAction { get; init; }
+
+    /// <summary>
+    /// G793: merge commit evidence for a delegation settled by an observed
+    /// merged linked PR. Null for all other finding kinds.
+    /// </summary>
+    [JsonPropertyName("merge_sha")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MergeSha { get; init; }
+
+    /// <summary>
+    /// G793: the linked issue whose closure is part of the settlement proof.
+    /// Null for all other finding kinds.
+    /// </summary>
+    [JsonPropertyName("closed_issue_number")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ClosedIssueNumber { get; init; }
 
     /// <summary>
     /// G725: the release and the two policy values required to clear the

--- a/src/IntentSystem.Cli/Commands/GitHubApiReadInventory.cs
+++ b/src/IntentSystem.Cli/Commands/GitHubApiReadInventory.cs
@@ -99,6 +99,7 @@ internal static class GitHubApiReadInventory
         "closingIssuesReferences[].number",
         "closingIssuesReferences[].repository.owner.login",
         "closingIssuesReferences[].repository.name",
+        "mergeCommit.oid",
     ];
 
     private static readonly IReadOnlyList<string> StatusRollupFields =

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -148,6 +148,14 @@ internal sealed record GitHubAutomationPrCandidate
     public string HeadRefOid { get; init; } = string.Empty;
 
     /// <summary>
+    /// G793: the merge commit reported by GitHub for a merged PR. This is
+    /// separate from <see cref="HeadRefOid"/>: the branch head proves what
+    /// was reviewed, while the merge commit proves that the unit landed.
+    /// </summary>
+    [JsonPropertyName("mergeCommit")]
+    public GitHubAutomationMergeCommit? MergeCommit { get; init; }
+
+    /// <summary>
     /// G589: authoritative GitHub check/status rollup for <see cref="HeadRefOid"/>.
     /// The stalled-work analyzer normalizes CheckRun and StatusContext entries
     /// without performing any workflow transition.
@@ -155,6 +163,13 @@ internal sealed record GitHubAutomationPrCandidate
     [JsonPropertyName("statusCheckRollup")]
     public IReadOnlyList<GitHubAutomationStatusCheckCandidate> StatusCheckRollup { get; init; }
         = Array.Empty<GitHubAutomationStatusCheckCandidate>();
+}
+
+/// <summary>G793: immutable merge SHA nested in GitHub's PR payload.</summary>
+internal sealed record GitHubAutomationMergeCommit
+{
+    [JsonPropertyName("oid")]
+    public string Oid { get; init; } = string.Empty;
 }
 
 /// <summary>G589: union-shaped row from GitHub's PR statusCheckRollup.</summary>
@@ -287,7 +302,7 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
     // can map an approved-but-draft PR to `approved-pr-draft-blocked`
     // (G297) instead of attempting a merge.
     internal const string PrListJsonFields =
-        "number,title,url,body,baseRefName,createdAt,updatedAt,labels,closingIssuesReferences,state,isDraft,headRefOid,statusCheckRollup";
+        "number,title,url,body,baseRefName,createdAt,updatedAt,labels,closingIssuesReferences,state,isDraft,headRefOid,mergeCommit,statusCheckRollup";
 
     /// <summary>
     /// G206: builds the <c>gh pr list</c> argument list shared by the live

--- a/src/IntentSystem.Cli/Commands/TeamModeCapabilityMatrix.cs
+++ b/src/IntentSystem.Cli/Commands/TeamModeCapabilityMatrix.cs
@@ -100,6 +100,7 @@ internal sealed record TeamModeCapabilityMatrix
             or AutomationStalledWorkCommand.KindCiHeadMoved
             => TeamModeCapabilityClasses.Ci,
         AutomationStalledWorkCommand.KindPendingDelegationOpen
+            or AutomationStalledWorkCommand.KindDelegationSettledByOutcome
             => TeamModeCapabilityClasses.Delegation,
         AutomationStalledWorkCommand.KindOperatorAttentionPending
             or AutomationStalledWorkCommand.KindOperatorAttentionCannotDetermine

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -516,6 +516,137 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_MergedLinkedPrAndClosedIssueIsSettledByOutcome_G793()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        var pending = BuildPendingDelegation(
+            "G793-settled",
+            FixedNow.AddHours(-6),
+            expectedArtifact: "https://github.com/J-Tech-Japan/intent-system/issues/1731");
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.RootPath, pending).Written);
+
+        const string mergeSha = "793merge00000000000000000000000000000000";
+        var merged = BuildPr(
+            1733,
+            "G793: settle a visibly completed delegation",
+            FixedNow.AddDays(-2),
+            state: "MERGED",
+            closingIssueNumber: 1731,
+            mergeCommitOid: mergeSha);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(mergedPrs: [merged]);
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--team", "intent-cli-dev", "--repo", "J-Tech-Japan/intent-system",
+                "--stale-minutes", "0", "--format", "json"],
+            writer));
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.False(document.RootElement.GetProperty("stalled").GetBoolean());
+        Assert.Equal(0, document.RootElement.GetProperty("open_pending_delegations").GetInt32());
+        Assert.DoesNotContain(
+            document.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindPendingDelegationOpen);
+        var settled = Assert.Single(
+            document.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindDelegationSettledByOutcome);
+        Assert.Equal(mergeSha, settled.GetProperty("merge_sha").GetString());
+        Assert.Equal(1731, settled.GetProperty("closed_issue_number").GetInt32());
+        Assert.Equal(1731, settled.GetProperty("issue").GetProperty("number").GetInt32());
+        Assert.Equal(1733, settled.GetProperty("pr").GetProperty("number").GetInt32());
+    }
+
+    [Fact]
+    public void Execute_GenuinelyOpenDelegationShapesRemainPendingWithDisposalRoute_G793()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        var issueOpen = BuildIssue(1734, "G793: open source issue", FixedNow.AddHours(-6));
+        var issueForUnmergedPr = BuildIssue(1735, "G793: unmerged source issue", FixedNow.AddHours(-6));
+        var records = new[]
+        {
+            BuildPendingDelegation("G793-open-issue", FixedNow.AddHours(-6),
+                expectedArtifact: "https://github.com/J-Tech-Japan/intent-system/issues/1734"),
+            BuildPendingDelegation("G793-unmerged-pr", FixedNow.AddHours(-6),
+                expectedArtifact: "https://github.com/J-Tech-Japan/intent-system/pull/1736"),
+            BuildPendingDelegation("G793-no-linked-pr", FixedNow.AddHours(-6),
+                expectedArtifact: "no linked pull request"),
+        };
+        foreach (var record in records)
+        {
+            Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.RootPath, record).Written);
+        }
+
+        var mergedPrForOpenIssue = BuildPr(
+            1733,
+            "G793: would close an issue that is still open",
+            FixedNow.AddDays(-2),
+            state: "MERGED",
+            closingIssueNumber: issueOpen.Number,
+            mergeCommitOid: "793merge-open-issue");
+        var unmergedPr = BuildPr(
+            1736,
+            "G793: unmerged pull request",
+            FixedNow.AddHours(-2),
+            state: "OPEN",
+            closingIssueNumber: issueForUnmergedPr.Number);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(
+            issues: [issueOpen, issueForUnmergedPr],
+            prs: [unmergedPr],
+            mergedPrs: [mergedPrForOpenIssue]);
+
+        var result = AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 0);
+
+        Assert.Equal(3, result.OpenPendingDelegations);
+        var pendingItems = result.Items
+            .Where(item => item.Kind == AutomationStalledWorkCommand.KindPendingDelegationOpen)
+            .ToArray();
+        Assert.Equal(3, pendingItems.Length);
+        Assert.Equal(
+            ["G793-no-linked-pr", "G793-open-issue", "G793-unmerged-pr"],
+            pendingItems.Select(item => item.ExecutionUnit).OrderBy(value => value, StringComparer.Ordinal));
+        foreach (var item in pendingItems)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(item.RecommendedAction));
+            Assert.Contains(
+                "intent-cli notify dispose --domain intent-cli --team intent-cli-dev",
+                item.RecommendedAction,
+                StringComparison.Ordinal);
+            Assert.Contains("--kind applied-elsewhere", item.RecommendedAction, StringComparison.Ordinal);
+            Assert.Contains("--actor", item.RecommendedAction, StringComparison.Ordinal);
+            Assert.Contains("--reason", item.RecommendedAction, StringComparison.Ordinal);
+            Assert.Contains("--applied-outcome-evidence", item.RecommendedAction, StringComparison.Ordinal);
+            Assert.Contains("--write", item.RecommendedAction, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Analyze_PendingDelegationReadIsByteForByteReadOnly_G793()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        var pending = BuildPendingDelegation("G793-read-only", FixedNow.AddHours(-6), "no linked pull request");
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.RootPath, pending).Written);
+        var pendingPath = NotifyPendingDelegationStore.ResolvePath(
+            workspace.RootPath,
+            "intent-cli",
+            "intent-cli-dev");
+        var before = File.ReadAllBytes(pendingPath);
+
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+        _ = AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 0);
+
+        Assert.Equal(before, File.ReadAllBytes(pendingPath));
+    }
+
+    [Fact]
     public void Execute_PublishedNotDelegated_FiresWhenPacketConfirmsRequestedDomain()
     {
         using var workspace = new StalledWorkWorkspace();
@@ -4027,6 +4158,25 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         int number, string title, DateTimeOffset createdAt, params string[] labels) =>
         BuildIssue(number, title, createdAt, updatedAt: null, labels);
 
+    private static NotifyPendingDelegation BuildPendingDelegation(
+        string taskId,
+        DateTimeOffset dispatchedAt,
+        string expectedArtifact) => new()
+        {
+            Domain = "intent-cli",
+            Team = "intent-cli-dev",
+            TaskId = taskId,
+            DelegatingRole = "orchestration",
+            RecipientRole = "implementation",
+            RecipientIdentity = "implementation-seat",
+            ExpectedArtifact = expectedArtifact,
+            ExpectedArtifacts = [expectedArtifact],
+            Objective = $"Implement {taskId} and report the result.",
+            Inputs = ["https://github.com/J-Tech-Japan/intent-system/issues/1731"],
+            ResultNonce = $"{taskId}-nonce",
+            DispatchedAt = dispatchedAt,
+        };
+
     /// <summary>G533: overload accepting an independent <c>updatedAt</c> for claimed-but-silent fixtures — defaults to <paramref name="createdAt"/> when omitted, matching the pre-G533 fixture shape.</summary>
     private static GitHubAutomationIssueCandidate BuildIssue(
         int number, string title, DateTimeOffset createdAt, DateTimeOffset? updatedAt, params string[] labels) => new()
@@ -4103,7 +4253,8 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         DateTimeOffset? updatedAt = null,
         bool isDraft = false,
         string headRefOid = "",
-        IReadOnlyList<GitHubAutomationStatusCheckCandidate>? statusCheckRollup = null) => new()
+        IReadOnlyList<GitHubAutomationStatusCheckCandidate>? statusCheckRollup = null,
+        string mergeCommitOid = "") => new()
         {
             Number = number,
             Title = title,
@@ -4113,6 +4264,9 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             State = state,
             IsDraft = isDraft,
             HeadRefOid = headRefOid,
+            MergeCommit = string.IsNullOrWhiteSpace(mergeCommitOid)
+                ? null
+                : new GitHubAutomationMergeCommit { Oid = mergeCommitOid },
             StatusCheckRollup = statusCheckRollup ?? Array.Empty<GitHubAutomationStatusCheckCandidate>(),
             Labels = (extraLabels ?? Array.Empty<string>()).Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
             ClosingIssuesReferences = closingIssueNumber is int n


### PR DESCRIPTION
## Summary

Closes #1731

`automation stalled-work` now observes a merged linked PR plus its closed linked issue as a distinct, informational settlement outcome. The read-only scan excludes that record from outstanding counts/stall status, while genuinely open delegations keep a complete manual `notify dispose --kind applied-elsewhere` route.

## Acceptance evidence

### AC 1 / AC 2 — settled-by-outcome fixture

The durable fixture dispatches `G793-settled`, observes merged PR `#1733` closing issue `#1731`, and records merge SHA `793merge00000000000000000000000000000000` without appending to pending state.

```text
AC 1 / AC 2 settled-by-outcome output
stalled=false
open_pending_delegations=0
kind=delegation-settled-by-outcome
execution_unit=G793-settled
pr.number=1733
issue.number=1731
merge_sha=793merge00000000000000000000000000000000
closed_issue_number=1731
pending-delegation-open row: absent
```

### AC 3 / AC 4 — all three genuinely open shapes and disposal route

The focused fixture covers all three enumerated shapes: an open unit issue, an unmerged PR, and no linked PR. Each remains `pending-delegation-open`; each action is non-empty and names the complete required route:

```text
AC 3 / AC 4 open-shape and disposal-route output
G793-open-issue       kind=pending-delegation-open
G793-unmerged-pr      kind=pending-delegation-open
G793-no-linked-pr     kind=pending-delegation-open
route=intent-cli notify dispose --domain intent-cli --team intent-cli-dev --task-id <task>
      --kind applied-elsewhere --actor "<actor>" --reason "<reason>"
      --applied-outcome-evidence "<evidence>" --write
```

### AC 5 — byte-for-byte read-only pending state

```text
AC 5 byte-invariant output
test=Analyze_PendingDelegationReadIsByteForByteReadOnly_G793
pending-file-before == pending-file-after: true
```

The collector only reads the pending store and GitHub candidates; it never writes a disposition or any other pending event.

### AC 6 — parent absence proof for each new regression

Parent commit: `26f0edf85cc6371c66ede5383de6543e11acd1fb` (`origin/main` at branch creation).

```text
AC 6 parent-absence output
PARENT:26f0edf85cc6371c66ede5383de6543e11acd1fb
parent: Execute_MergedLinkedPrAndClosedIssueIsSettledByOutcome_G793 absent
parent: Execute_GenuinelyOpenDelegationShapesRemainPendingWithDisposalRoute_G793 absent
parent: Analyze_PendingDelegationReadIsByteForByteReadOnly_G793 absent
```

### AC 7 — validation

Focused Release command:

```text
AC 7 focused Release output
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter 'FullyQualifiedName~G793'
Passed: 3  Failed: 0  Skipped: 0  Total: 3
```

Full CLI Release command:

```text
AC 7 full Release output
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore
Passed: 5658  Failed: 0  Skipped: 1  Total: 5659
```

Head commit: `3f184ff4f5eb17deff401b1690b3ac2e6a447b9f`. Required exact-head CI is green:

- Build and test (source contract): **pass** — [run 33769042779](https://github.com/J-Tech-Japan/intent-system/actions/runs/33769042779/job/100694229277)
- npm package dry-run (no publish): **pass** — [run 33769042779](https://github.com/J-Tech-Japan/intent-system/actions/runs/33769042779/job/100695035971)

## Scope boundaries

- `stalled-work` remains read-only; manual disposal remains the only write path.
- No changes were made to `notify report`, `notify reconcile`, `notify dispose`, delegation creation, workflow labels, or host metadata.
