### PR TITLE
G794: remeasure v0.31.0 notes through G793

### DIFF
--- a/docs/en/release-notes-v0.31.0.md
+++ b/docs/en/release-notes-v0.31.0.md
@@ -1,7 +1,7 @@
 # Release Notes — intent-cli v0.31.0
 
 > **PREPARED / NOT PUBLISHED.** This prepare-only note set records the measured
-> G788–G791 chain. It does not create a tag or GitHub Release, publish a package,
+> G788–G793 chain. It does not create a tag or GitHub Release, publish a package,
 > change a workflow or publish configuration, post a consumer comment, or change
 > product source.
 
@@ -22,7 +22,7 @@ changelogs.
 
 ## Independently measured minor justification
 
-The named product base is `79a245c655e17ac654ac440fda31709ee38e28b8`. The
+The named product base is `fed2bbc74449b389565b8241732fe376b7a1c421`. The
 installed tagged v0.30.0 tool was measured with an explicit release version:
 
 ```text
@@ -52,9 +52,9 @@ The tagged surface has no `inspect` route. The v0.28.0 release rule is the
 auditable distinction: **a command-route addition is a minor bump; option-level
 additions do not count as command routes.** The named base adds exactly one
 command route, the read-only `session-layer inspect`; that decides v0.31.0.
-G788 evidence sources and informational output, G789 guide blocks, and G791's
-nested-pointer-drift classification are listed but explicitly not counted as
-additional routes.
+G788 evidence sources and informational output, G789 guide blocks, G791's
+nested-pointer-drift classification, and G793's settled-outcome/disposal
+classification are listed but explicitly not counted as additional routes.
 
 ## Measured version identities
 
@@ -62,7 +62,7 @@ The named base was checked with a clean Release build after the policy roll:
 
 ```text
 $ git rev-parse HEAD
-79a245c655e17ac654ac440fda31709ee38e28b8
+fed2bbc74449b389565b8241732fe376b7a1c421
 $ dotnet clean
 Build succeeded.
     0 Warning(s)
@@ -72,7 +72,7 @@ Build succeeded.
     0 Warning(s)
     0 Error(s)
 $ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-intent-cli 0.31.1-79a245c-G791
+intent-cli 0.31.1-fed2bbc-G793
 ```
 
 That normal identity is the `nextVersion` placeholder and is **not** v0.31.0.
@@ -84,8 +84,12 @@ Build succeeded.
     0 Warning(s)
     0 Error(s)
 $ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-intent-cli 0.31.0-79a245c-G791
+intent-cli 0.31.0-fed2bbc-G793
 ```
+
+The historical G790 merge SHA `79a245c655e17ac654ac440fda31709ee38e28b8`
+remains only in the inventory; no measured identity banner contains that stale
+base fragment.
 
 Published versioning is a third identity and is derived by `release.yml`, not
 by the local policy file:
@@ -99,9 +103,9 @@ VERSION=0.31.0
 The release workflow supplies `-p:Version=<tag>` from `RAW`; `eng/version.json`
 governs local builds and dry runs only. This prepare-only slice created no tag.
 
-## Release inventory: exactly four first-parent units
+## Release inventory: exactly six first-parent units
 
-The inventory is derived from the exact first-parent range. Git measured four
+The inventory is derived from the exact first-parent range. Git measured six
 commits, and every commit has one operator-observable outcome:
 
 - G788 — PR #1723 / issue #1722; merge commit `cfdacb4a657d9a60ab82fea3faa435ff732f389f`.
@@ -120,17 +124,27 @@ commits, and every commit has one operator-observable outcome:
   **Operator-observable outcome:** `session-layer inspect` reports recorded role
   state and an optional bounded pane tail read without focus, prompts, key sends,
   or process management.
+- G792 — PR #1732 / issue #1730; merge commit `26f0edf85cc6371c66ede5383de6543e11acd1fb`.
+  **Operator-observable outcome:** this release's own preparation unit records
+  the measured v0.31.0 notes, identity banners, and version-policy roll.
+- G793 — PR #1733 / issue #1731; merge commit `fed2bbc74449b389565b8241732fe376b7a1c421`.
+  **Operator-observable outcome:** `automation stalled-work` stops reporting a
+  delegation as outstanding only after its own unit has a merged PR and closed
+  issue, records the settled classification with merge SHA and issue evidence,
+  and names `notify dispose --kind applied-elsewhere` on every still-open row.
 
 ## First-parent accounting
 
 ```text
-$ git rev-list --first-parent --reverse v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
+$ git rev-list --first-parent --reverse v0.30.0..fed2bbc74449b389565b8241732fe376b7a1c421
 cfdacb4a657d9a60ab82fea3faa435ff732f389f
 9d03309a155dc5f714be8a99bb3c2234724bf589
 aa5c49f51bffa634ca7a96a08f1245e53a372904
 79a245c655e17ac654ac440fda31709ee38e28b8
-$ git rev-list --first-parent --count v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
-4
+26f0edf85cc6371c66ede5383de6543e11acd1fb
+fed2bbc74449b389565b8241732fe376b7a1c421
+$ git rev-list --first-parent --count v0.30.0..fed2bbc74449b389565b8241732fe376b7a1c421
+6
 ```
 
 | first-parent commit | classification | release inventory |
@@ -139,8 +153,10 @@ $ git rev-list --first-parent --count v0.30.0..79a245c655e17ac654ac440fda31709ee
 | `9d03309a155dc5f714be8a99bb3c2234724bf589` | G789 / PR #1725 / issue #1724 | included |
 | `aa5c49f51bffa634ca7a96a08f1245e53a372904` | G791 / PR #1728 / issue #1727 | included |
 | `79a245c655e17ac654ac440fda31709ee38e28b8` | G790 / PR #1729 / issue #1726 | included |
+| `26f0edf85cc6371c66ede5383de6543e11acd1fb` | G792 / PR #1732 / issue #1730 | included — this release's own preparation unit |
+| `fed2bbc74449b389565b8241732fe376b7a1c421` | G793 / PR #1733 / issue #1731 | included |
 
-The first-parent range contains exactly these four merge commits and nothing
+The first-parent range contains exactly these six merge commits and nothing
 else; the table is not a changelog of second-parent commits.
 
 ## Consumer follow-up after publication
@@ -168,16 +184,19 @@ the released version and closes it.
   and writes to no other domain's submodule.
 - G789's design-thread Orca block is non-normative; intent-cli neither launches
   nor manages Orca.
+- G793's settled outcome requires both a merged linked PR and closed linked issue;
+  still-open rows remain pending and carry the non-empty
+  `notify dispose --kind applied-elsewhere` recommendation.
 
 ## Prepare-only verification
 
-`ReleaseNotesV0310DocsTests` compares the EN/JA unit/PR/issue/merge tuples and
-consumer row, and deliberately fails on a one-field mirror mutation. The PR
-pastes the actual parent absence/failure output for each new test, focused
-release-note validation (13 passed), full CLI Release validation (5655 passed,
-1 skipped, 0 failed), all-project Release validation (5985 passed, 1 skipped,
+`ReleaseNotesV0310DocsTests` and the G794 amendment guards compare the EN/JA
+unit/PR/issue/merge tuples and consumer row, assert the six measured commits,
+and deliberately fail on a one-field mirror mutation. The PR pastes the actual
+parent absence/failure output for each new test, focused release-note validation
+(20 passed, 0 skipped, 0 failed), full CLI Release validation (5665 passed,
+1 skipped, 0 failed), all-project Release validation (5995 passed, 1 skipped,
 0 failed), all three identity outputs, `git diff --check`, and exact-head CI.
-The diff is limited to release notes, version policy, placeholders,
-developer-reference readiness, and tests; it has no tag, GitHub Release,
-package publish, workflow/publish-config, consumer-comment, or product-source
-change.
+The diff is limited to the two release notes and tests; it has
+no tag, GitHub Release, package publish, workflow/publish-config,
+consumer-comment, version-policy, or product-source change.

--- a/docs/ja/release-notes-v0.31.0.md
+++ b/docs/ja/release-notes-v0.31.0.md
@@ -1,6 +1,6 @@
 # リリースノート — intent-cli v0.31.0
 
-> **PREPARED / NOT PUBLISHED。** これは測定済み G788–G791 chain の prepare-only
+> **PREPARED / NOT PUBLISHED。** これは測定済み G788–G793 chain の prepare-only
 > notes です。tag / GitHub Release / package publish、workflow または publish
 > configuration、consumer comment、product source の変更は行いません。
 
@@ -20,7 +20,7 @@ matching install query は `JTechJapan.IntentSystem.Cli --version 0.31.0` です
 
 ## 独自に測定した minor justification
 
-named product base は `79a245c655e17ac654ac440fda31709ee38e28b8` です。installed tagged
+named product base は `fed2bbc74449b389565b8241732fe376b7a1c421` です。installed tagged
 v0.30.0 tool を explicit release version で測定しました:
 
 ```text
@@ -50,7 +50,8 @@ EXIT:1
 **a command-route addition is a minor bump; option-level additions do not count as command
 routes.** です。named base が read-only `session-layer inspect` command route を一つ追加した
 ため v0.31.0 と判断します。G788 evidence source/informational output、G789 guide block、
-G791 nested-pointer-drift classification は列挙しますが extra route とは数えません。
+G791 nested-pointer-drift classification と G793 settled-outcome/disposal
+classification は列挙しますが extra route とは数えません。
 
 ## 測定した version identities
 
@@ -58,7 +59,7 @@ policy roll 後の named base を clean Release build で確認しました:
 
 ```text
 $ git rev-parse HEAD
-79a245c655e17ac654ac440fda31709ee38e28b8
+fed2bbc74449b389565b8241732fe376b7a1c421
 $ dotnet clean
 Build succeeded.
     0 Warning(s)
@@ -68,7 +69,7 @@ Build succeeded.
     0 Warning(s)
     0 Error(s)
 $ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-intent-cli 0.31.1-79a245c-G791
+intent-cli 0.31.1-fed2bbc-G793
 ```
 
 この normal identity は `nextVersion` placeholder であり、**v0.31.0 ではありません**。
@@ -80,8 +81,11 @@ Build succeeded.
     0 Warning(s)
     0 Error(s)
 $ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-intent-cli 0.31.0-79a245c-G791
+intent-cli 0.31.0-fed2bbc-G793
 ```
+
+歴史的な G790 merge SHA `79a245c655e17ac654ac440fda31709ee38e28b8` は inventory にだけ
+残り、測定した identity banner にこの stale base fragment は含まれません。
 
 published version は local policy file ではなく `release.yml` が導出する third identity です:
 
@@ -93,9 +97,9 @@ VERSION=0.31.0
 
 release workflow は `RAW` から `-p:Version=<tag>` を供給し、`eng/version.json` は local builds と dry runs だけを管理します。この prepare-only slice は tag を作成していません (no tag)。
 
-## Release inventory: 正確に四つの first-parent unit
+## Release inventory: 正確に六つの first-parent unit
 
-exact first-parent range から inventory を導出しました。Git は四つの commit を測定し、各
+exact first-parent range から inventory を導出しました。Git は六つの commit を測定し、各
 commit に operator-observable outcome を一つ記録します:
 
 - G788 — PR #1723 / issue #1722; merge commit `cfdacb4a657d9a60ab82fea3faa435ff732f389f`。
@@ -111,17 +115,27 @@ commit に operator-observable outcome を一つ記録します:
 - G790 — PR #1729 / issue #1726; merge commit `79a245c655e17ac654ac440fda31709ee38e28b8`。
   **Operator-observable outcome:** `session-layer inspect` は recorded role state と optional
   bounded pane tail を focus、prompt、key send、process management なしで報告します。
+- G792 — PR #1732 / issue #1730; merge commit `26f0edf85cc6371c66ede5383de6543e11acd1fb`。
+  **Operator-observable outcome:** この release 自身の preparation unit として、測定済み
+  v0.31.0 notes、identity banner、version-policy roll を記録します。
+- G793 — PR #1733 / issue #1731; merge commit `fed2bbc74449b389565b8241732fe376b7a1c421`。
+  **Operator-observable outcome:** `automation stalled-work` は自身の unit に merged PR と
+  closed issue の両方がある場合だけ delegation を outstanding から外し、merge SHA と
+  issue evidence 付きの settled classification を記録し、still-open row ごとに
+  `notify dispose --kind applied-elsewhere` を案内します。
 
 ## First-parent accounting
 
 ```text
-$ git rev-list --first-parent --reverse v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
+$ git rev-list --first-parent --reverse v0.30.0..fed2bbc74449b389565b8241732fe376b7a1c421
 cfdacb4a657d9a60ab82fea3faa435ff732f389f
 9d03309a155dc5f714be8a99bb3c2234724bf589
 aa5c49f51bffa634ca7a96a08f1245e53a372904
 79a245c655e17ac654ac440fda31709ee38e28b8
-$ git rev-list --first-parent --count v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8
-4
+26f0edf85cc6371c66ede5383de6543e11acd1fb
+fed2bbc74449b389565b8241732fe376b7a1c421
+$ git rev-list --first-parent --count v0.30.0..fed2bbc74449b389565b8241732fe376b7a1c421
+6
 ```
 
 | first-parent commit | classification | release inventory |
@@ -130,8 +144,10 @@ $ git rev-list --first-parent --count v0.30.0..79a245c655e17ac654ac440fda31709ee
 | `9d03309a155dc5f714be8a99bb3c2234724bf589` | G789 / PR #1725 / issue #1724 | included |
 | `aa5c49f51bffa634ca7a96a08f1245e53a372904` | G791 / PR #1728 / issue #1727 | included |
 | `79a245c655e17ac654ac440fda31709ee38e28b8` | G790 / PR #1729 / issue #1726 | included |
+| `26f0edf85cc6371c66ede5383de6543e11acd1fb` | G792 / PR #1732 / issue #1730 | included — this release's own preparation unit |
+| `fed2bbc74449b389565b8241732fe376b7a1c421` | G793 / PR #1733 / issue #1731 | included |
 
-この range はこの四つの merge commit だけで、second-parent commit の changelog ではありません。
+この range はこの六つの merge commit だけで、second-parent commit の changelog ではありません。
 
 ## Publish 後の consumer follow-up
 
@@ -156,14 +172,18 @@ close します。
   書き込みません。
 - G789 design-thread guide の Orca block は non-normative であり、intent-cli は Orca を
   launch も manage もしません。
+- G793 の settled outcome は自身の unit に対する merged linked PR と closed linked issue の
+  両方を要求します。still-open row は pending のままで、空でない
+  `notify dispose --kind applied-elsewhere` recommendation を持ちます。
 
 ## Prepare-only verification
 
-`ReleaseNotesV0310DocsTests` は EN/JA の unit/PR/issue/merge tuple と consumer row を比較し、
-mirror の一フィールド mutation で意図的に fail します。PR には各 new test の parent
-absence/failure actual output、focused release-note validation (13 passed)、full CLI Release
-validation (5655 passed, 1 skipped, 0 failed)、all-project Release validation (5985 passed,
-1 skipped, 0 failed)、三つの identity、`git diff --check`、exact-head CI を貼っています。diff は
-release notes、version policy、placeholder、developer reference readiness、test に限定され、
-tag / GitHub Release / package publish / workflow または publish-config / consumer-comment /
-product-source change は含みません。
+`ReleaseNotesV0310DocsTests` と G794 amendment guard は EN/JA の unit/PR/issue/merge tuple と
+consumer row を比較し、六つの測定済み commit を検査し、mirror の一フィールド mutation で
+意図的に fail します。PR には各 new test の parent absence/failure actual output、focused
+release-note validation (20 passed, 0 skipped, 0 failed)、full CLI Release validation (5665
+passed, 1 skipped, 0 failed)、all-project Release validation (5995 passed, 1 skipped, 0 failed)、
+三つの identity、`git diff --check`、exact-head CI を貼ります。
+diff は二つの release notes と test だけに限定され、tag / GitHub Release / package publish /
+workflow または publish-config / consumer-comment / version-policy / product-source change は
+含みません。

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
@@ -4,15 +4,18 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G792: v0.31.0 is a measured, prepare-only release line. These guards keep
+/// G794: v0.31.0 is a measured, prepare-only release line. These guards keep
 /// the exact first-parent inventory, three independently measured identities,
-/// EN/JA parity, truthfulness boundaries, and version-policy roll durable.
+/// EN/JA parity, truthfulness boundaries, and version-policy roll durable while
+/// the release base widens through G793.
 /// </summary>
 public sealed class ReleaseNotesV0310DocsTests
 {
-    private const string Base = "79a245c655e17ac654ac440fda31709ee38e28b8";
-    private const string NormalPlaceholderIdentity = "intent-cli 0.31.1-79a245c-G791";
-    private const string ExplicitReleaseIdentity = "intent-cli 0.31.0-79a245c-G791";
+    private const string Base = "fed2bbc74449b389565b8241732fe376b7a1c421";
+    private const string NormalPlaceholderIdentity = "intent-cli 0.31.1-fed2bbc-G793";
+    private const string ExplicitReleaseIdentity = "intent-cli 0.31.0-fed2bbc-G793";
+    private const string DeveloperReferenceNormalIdentity = "intent-cli 0.31.1-79a245c-G791";
+    private const string DeveloperReferenceExplicitIdentity = "intent-cli 0.31.0-79a245c-G791";
     private const string TaggedIdentity = "intent-cli 0.30.0-f4b01c2-G772";
 
     private static readonly (string Unit, string Pr, string Issue, string Merge)[] Units =
@@ -21,6 +24,8 @@ public sealed class ReleaseNotesV0310DocsTests
         ("G789", "#1725", "#1724", "9d03309a155dc5f714be8a99bb3c2234724bf589"),
         ("G791", "#1728", "#1727", "aa5c49f51bffa634ca7a96a08f1245e53a372904"),
         ("G790", "#1729", "#1726", "79a245c655e17ac654ac440fda31709ee38e28b8"),
+        ("G792", "#1732", "#1730", "26f0edf85cc6371c66ede5383de6543e11acd1fb"),
+        ("G793", "#1733", "#1731", "fed2bbc74449b389565b8241732fe376b7a1c421"),
     ];
 
     private static readonly (string Issue, string Unit, string FollowUp)[] ConsumerFollowUps =
@@ -31,7 +36,7 @@ public sealed class ReleaseNotesV0310DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void NotesCoverExactlyTheFourGitDerivedUnits(string language)
+    public void NotesCoverExactlyTheSixGitDerivedUnits(string language)
     {
         var notes = ReadNotes(language);
         var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
@@ -39,7 +44,7 @@ public sealed class ReleaseNotesV0310DocsTests
             .ToArray();
 
         Assert.Equal(Units.Select(unit => unit.Unit), listed);
-        Assert.Equal(4, listed.Length);
+        Assert.Equal(6, listed.Length);
 
         foreach (var unit in Units)
         {
@@ -107,6 +112,11 @@ public sealed class ReleaseNotesV0310DocsTests
         Assert.Contains("command-route", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("option-level", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(language == "en" ? "**not** v0.31.0" : "**v0.31.0 ではありません**", normalized, StringComparison.Ordinal);
+
+        foreach (Match identity in Regex.Matches(notes, @"(?m)^intent-cli [^\r\n]+"))
+        {
+            Assert.DoesNotContain("79a245c", identity.Value, StringComparison.Ordinal);
+        }
     }
 
     [Theory]
@@ -115,11 +125,11 @@ public sealed class ReleaseNotesV0310DocsTests
     public void NotesPinEveryFirstParentCommitAndPrepareOnlyBoundary(string language)
     {
         var notes = ReadNotes(language);
-        const string range = "v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8";
+        var range = $"v0.30.0..{Base}";
 
         Assert.Contains($"git rev-list --first-parent --reverse {range}", notes, StringComparison.Ordinal);
         Assert.Contains($"git rev-list --first-parent --count {range}", notes, StringComparison.Ordinal);
-        Assert.Contains("\n4\n", notes, StringComparison.Ordinal);
+        Assert.Contains("\n6\n", notes, StringComparison.Ordinal);
         Assert.Contains("PREPARED / NOT PUBLISHED", notes, StringComparison.Ordinal);
         Assert.Contains("no tag", notes, StringComparison.OrdinalIgnoreCase);
 
@@ -128,6 +138,13 @@ public sealed class ReleaseNotesV0310DocsTests
             Assert.Contains(unit.Merge, notes, StringComparison.Ordinal);
             Assert.Contains($"{unit.Unit} / PR {unit.Pr} / issue {unit.Issue}", notes, StringComparison.Ordinal);
         }
+
+        Assert.Contains("G792", notes, StringComparison.Ordinal);
+        Assert.Contains("G793", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "this release's own preparation unit" : "この release 自身の preparation unit",
+            notes,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]
@@ -158,6 +175,10 @@ public sealed class ReleaseNotesV0310DocsTests
         Assert.Contains("non-normative", normalized, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(language == "en" ? "neither launches" : "launch も manage もしません", normalized, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Orca", notes, StringComparison.Ordinal);
+        Assert.Contains("settled outcome", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("merged linked PR", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("closed linked issue", normalized, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("applied-elsewhere", normalized, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -195,8 +216,8 @@ public sealed class ReleaseNotesV0310DocsTests
             language == "en" ? "### Next release readiness (v0.31.1)" : "### 次リリース準備(v0.31.1)",
             reference,
             StringComparison.Ordinal);
-        Assert.Contains(NormalPlaceholderIdentity, reference, StringComparison.Ordinal);
-        Assert.Contains(ExplicitReleaseIdentity, reference, StringComparison.Ordinal);
+        Assert.Contains(DeveloperReferenceNormalIdentity, reference, StringComparison.Ordinal);
+        Assert.Contains(DeveloperReferenceExplicitIdentity, reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.31.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.31.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0310DocsTests", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0310G794AmendmentTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0310G794AmendmentTests.cs
@@ -1,0 +1,112 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G794: the v0.31.0 preparation is re-measured at the G793 merge base.
+/// These focused guards make the six-commit range, current identities, minor
+/// accounting, and mirror mutation oracle durable without changing product
+/// source or release policy.
+/// </summary>
+public sealed class ReleaseNotesV0310G794AmendmentTests
+{
+    private const string Base = "fed2bbc74449b389565b8241732fe376b7a1c421";
+    private const string Range = "v0.30.0..fed2bbc74449b389565b8241732fe376b7a1c421";
+    private static readonly string[] FirstParentCommits =
+    [
+        "cfdacb4a657d9a60ab82fea3faa435ff732f389f",
+        "9d03309a155dc5f714be8a99bb3c2234724bf589",
+        "aa5c49f51bffa634ca7a96a08f1245e53a372904",
+        "79a245c655e17ac654ac440fda31709ee38e28b8",
+        "26f0edf85cc6371c66ede5383de6543e11acd1fb",
+        Base,
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReMeasuredFirstParentRangePastesAllSixCommitsAndPrepClassification(string language)
+    {
+        var notes = ReadNotes(language);
+
+        Assert.Contains($"$ git rev-list --first-parent --reverse {Range}", notes, StringComparison.Ordinal);
+        Assert.Contains($"$ git rev-list --first-parent --count {Range}\n6", notes, StringComparison.Ordinal);
+        foreach (var commit in FirstParentCommits)
+        {
+            Assert.Contains(commit, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("G792 / PR #1732 / issue #1730", notes, StringComparison.Ordinal);
+        Assert.Contains("26f0edf85cc6371c66ede5383de6543e11acd1fb", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "this release's own preparation unit" : "この release 自身の preparation unit",
+            notes,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("G793 / PR #1733 / issue #1731", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ThreeVersionIdentityBannersUseCurrentBaseWithoutTheStaleBaseFragment(string language)
+    {
+        var notes = ReadNotes(language);
+
+        Assert.Contains(Base, notes, StringComparison.Ordinal);
+        Assert.Contains("intent-cli 0.31.1-fed2bbc-G793", notes, StringComparison.Ordinal);
+        Assert.Contains("intent-cli 0.31.0-fed2bbc-G793", notes, StringComparison.Ordinal);
+        Assert.Contains("RAW=v0.31.0", notes, StringComparison.Ordinal);
+        Assert.Contains("VERSION=0.31.0", notes, StringComparison.Ordinal);
+
+        foreach (Match identity in Regex.Matches(notes, @"(?m)^intent-cli [^\r\n]+"))
+        {
+            Assert.DoesNotContain("79a245c", identity.Value, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void MinorRationaleListsG793AsMeasuredButNotAnotherRoute(string language)
+    {
+        var notes = ReadNotes(language);
+        var identityHeading = language == "en"
+            ? "## Measured version identities"
+            : "## 測定した version identities";
+        var rationale = notes[..notes.IndexOf(identityHeading, StringComparison.Ordinal)];
+
+        Assert.Contains("session-layer inspect", rationale, StringComparison.Ordinal);
+        Assert.Contains("command-route", rationale, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("option-level", rationale, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("G793", rationale, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "not counted as additional routes" : "extra route とは数えません",
+            rationale,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MirrorMutationRemainsARealParityFailure_G794()
+    {
+        var english = ParseInventory(ReadNotes("en"));
+        var japanese = ReadNotes("ja");
+        var changedJapanese = japanese.Replace("issue #1731", "issue #9999", StringComparison.Ordinal);
+
+        Assert.NotEqual(english, ParseInventory(changedJapanese));
+        Console.WriteLine("G794 parity mutation: JA issue #1731 -> #9999; tuple oracle changed and the test would fail.");
+    }
+
+    private static string ReadNotes(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.31.0.md"));
+
+    private static IReadOnlyList<(string Unit, string Pr, string Issue, string Merge)> ParseInventory(string notes) =>
+        Regex.Matches(
+                notes,
+                @"(?ms)^- (G\d+) — PR (#\d+) / issue (#\d+); merge commit `([0-9a-f]{40})`.*?(?=^- |^## |\z)")
+            .Select(match => (
+                match.Groups[1].Value,
+                match.Groups[2].Value,
+                match.Groups[3].Value,
+                match.Groups[4].Value))
+            .ToArray();
+}


### PR DESCRIPTION
Closes #1735

# G794 — re-measure v0.31.0 through G793

Prepare-only release-note amendment. No tag, GitHub Release, package publish, workflow or publish-config change, consumer follow-up, version-policy change, or product-source change is included.

## AC 1 — new base and G793 inventory in both mirrors
AC 1 actual note facts:
```text
$ git rev-parse fed2bbc74449b389565b8241732fe376b7a1c421
fed2bbc74449b389565b8241732fe376b7a1c421
$ rg -n "G792 — PR #1732|G793 — PR #1733|exactly six|正確に六つ" docs/en/release-notes-v0.31.0.md docs/ja/release-notes-v0.31.0.md
106:## Release inventory: exactly six first-parent units
127:- G792 — PR #1732 / issue #1730; merge commit `26f0edf85cc6371c66ede5383de6543e11acd1fb`.
130:- G793 — PR #1733 / issue #1731; merge commit `fed2bbc74449b389565b8241732fe376b7a1c421`.
100:## Release inventory: 正確に六つの first-parent unit
118:- G792 — PR #1732 / issue #1730; merge commit `26f0edf85cc6371c66ede5383de6543e11acd1fb`。
121:- G793 — PR #1733 / issue #1731; merge commit `fed2bbc74449b389565b8241732fe376b7a1c421`。
```

Both mirrors carry the same six unit/PR/issue/merge tuples and the G793 settled-work outcome sentence.

## AC 2 — complete first-parent classification
AC 2 actual table output:
```text
G788 / PR #1723 / issue #1722 / cfdacb4a657d9a60ab82fea3faa435ff732f389f
G789 / PR #1725 / issue #1724 / 9d03309a155dc5f714be8a99bb3c2234724bf589
G791 / PR #1728 / issue #1727 / aa5c49f51bffa634ca7a96a08f1245e53a372904
G790 / PR #1729 / issue #1726 / 79a245c655e17ac654ac440fda31709ee38e28b8
G792 / PR #1732 / issue #1730 / 26f0edf85cc6371c66ede5383de6543e11acd1fb (this release preparation unit)
G793 / PR #1733 / issue #1731 / fed2bbc74449b389565b8241732fe376b7a1c421
```

## AC 3 — actual range and count at fed2bbc
AC 3 actual command output:
```text
$ git rev-list --first-parent --reverse v0.30.0..fed2bbc74449b389565b8241732fe376b7a1c421
cfdacb4a657d9a60ab82fea3faa435ff732f389f
9d03309a155dc5f714be8a99bb3c2234724bf589
aa5c49f51bffa634ca7a96a08f1245e53a372904
79a245c655e17ac654ac440fda31709ee38e28b8
26f0edf85cc6371c66ede5383de6543e11acd1fb
fed2bbc74449b389565b8241732fe376b7a1c421
$ git rev-list --first-parent --count v0.30.0..fed2bbc74449b389565b8241732fe376b7a1c421
6
```

## AC 4 — three measured identities and no stale identity banner
AC 4 actual identity output:
```text
$ git rev-parse HEAD
fed2bbc74449b389565b8241732fe376b7a1c421
$ dotnet build IntentSystem.sln --configuration Release
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.31.1-fed2bbc-G793
$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.31.0
Build succeeded.
    0 Warning(s)
    0 Error(s)
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.31.0-fed2bbc-G793
$ RAW=v0.31.0; VERSION="${RAW#v}"; printf "RAW=%s\nVERSION=%s\n" "$RAW" "$VERSION"
RAW=v0.31.0
VERSION=0.31.0
```

The tagged baseline is intent-cli 0.30.0-f4b01c2-G772. The historical 79a245c SHA remains only as G790 inventory; no measured identity banner uses it.

## AC 5 — route-addition minor rationale and G793 not counted
AC 5 actual note output:
```text
The named base adds exactly one command route, the read-only session-layer inspect; that decides v0.31.0.
G788 evidence sources and informational output, G789 guide blocks, G791 nested-pointer-drift classification, and G793 settled-outcome/disposal classification are listed but explicitly not counted as additional routes.
```

The EN/JA mirrors retain the v0.28.0 command-route versus option rule.

## AC 6 — parity, identity, and truthfulness guards
AC 6 focused validation:
```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~ReleaseNotesV0310
Passed!  - Failed:     0, Passed:    20, Skipped:     0, Total:    20
```
AC 6 actual parity mutation failure:
```text
[xUnit.net 00:00:00.37] IntentSystem.Cli.Tests.ReleaseNotesV0310DocsTests.EnglishAndJapaneseMirrorsHaveIdenticalUnitTuplesAndConsumerFollowUp [FAIL]
Error Message:
 Assert.Equal() Failure: Collections differ
Expected: [···, Tuple ("G793", "#1733", "#1731", "fed2bbc74449b389565b8241732fe376b7a1c421")]
Actual:   [···, Tuple ("G793", "#1733", "#9999", "fed2bbc74449b389565b8241732fe376b7a1c421")]
Failed! - Failed: 1, Passed: 1, Skipped: 0, Total: 2
mutation_test_exit:1
```

Only JA issue #1731 was mutated and reverted; the committed guards remain unweakened.

## AC 7 — prepare-only changed paths
AC 7 actual changed-path output:
```text
$ git diff-tree --no-commit-id --name-only -r 6cb8ca6c376bc5e9b973e22fcdae2bab5cf3bf5b
docs/en/release-notes-v0.31.0.md
docs/ja/release-notes-v0.31.0.md
tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0310G794AmendmentTests.cs
$ git diff --check
```

No tag, release, package, workflow/publish-config, consumer-comment, version-policy, or product-source path is present.

## AC 8 — parent failure or absence proof
AC 8 fresh verbatim direct-parent command output:
```text
$ git show fed2bbc74449b389565b8241732fe376b7a1c421:tests/IntentSystem.Cli.Tests/ReleaseNotesV0310G794AmendmentTests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/ReleaseNotesV0310G794AmendmentTests.cs' exists on disk, but not in 'fed2bbc74449b389565b8241732fe376b7a1c421'
parent_new_test_show_exit:128
$ git show fed2bbc74449b389565b8241732fe376b7a1c421:tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs | rg -n 'Base =|Assert.Equal\(4, listed.Length\)|v0\.30\.0\.\.79a245c655e17ac654ac440fda31709ee38e28b8'
13:    private const string Base = "79a245c655e17ac654ac440fda31709ee38e28b8";
42:        Assert.Equal(4, listed.Length);
118:        const string range = "v0.30.0..79a245c655e17ac654ac440fda31709ee38e28b8";
parent_changed_test_oracle_exit:0
```

The new G794 test is absent on the direct parent, and the parent copy of the changed guard still has the old four-unit/79a245c measurement.

## AC 9 — full Release validation
AC 9 full Release command output:
```text
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --no-build
Passed!  - Failed:     0, Passed:  5665, Skipped:     1, Total:  5666

$ dotnet test IntentSystem.sln --configuration Release --no-restore --no-build
IntentSystem.Cli.Tests: Passed 5665, Skipped 1, Failed 0, Total 5666
all other Release test projects: Passed 330, Skipped 0, Failed 0
all-project total: Passed 5995, Skipped 1, Failed 0, Total 5996
```

The full CLI and solution Release runs passed with the counts shown above.

## Head and CI\n\nPushed head: 6cb8ca6c376bc5e9b973e22fcdae2bab5cf3bf5b.\nCI will be checked at this exact head; no merge, tag, release, or publish is requested.

