### PR TITLE
G795: canonical logical role normalizer and consumer inventory

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -694,3 +694,43 @@ to the loop-prompt generators (`guide workflow task implementation-loop` /
 - **`intent-cli` does not launch AI providers.** It emits deterministic
   guidance, validates contracts, and performs bounded GitHub/metadata
   transitions. The AI agent stays in the driver's seat.
+
+## G795 role-consumer inventory
+
+`role-consumer-inventory-entries: 24` is the measured inventory for the
+role-vocabulary slice. `LogicalRoleNormalizer` is the single input boundary
+for the three role-scoped closeout commands and their records. A role is a
+responsibility, not a runtime or model; `opencode` remains a free-form runtime
+value. The queue-state `worker_role` and `review_role` fields are deliberately
+listed as runtime/action-verb consumers only: this slice does not change their
+semantics or add fields.
+
+| # | File and symbol | Value read | Branch/persistence responsibility |
+|---:|---|---|---|
+| 1 | `Commands/LogicalRoleNormalizer.cs:LogicalRoleNormalizer` | role | canonical five, four aliases, fail-closed input |
+| 2 | `Commands/CloseoutRecordRole.cs:CloseoutRecordRole.TryNormalize/TryResolve` | role | shared closeout attribution boundary |
+| 3 | `Commands/CloseoutRecordRole.cs:RoleScopedCloseoutRecordStore` | role | canonical role sidecar path |
+| 4 | `Commands/KnowledgeWriteBackRecord.cs:Deserialize` | role | legacy read and canonical re-emission |
+| 5 | `Commands/GuideReachabilityRecord.cs:Deserialize` | role | legacy read and canonical re-emission |
+| 6 | `Commands/AutomationKnowledgeWriteBackRecordCommand` | role | `knowledge-writeback-record --role` |
+| 7 | `Commands/AutomationGuideReachabilityRecordCommand` | role | `guide-reachability-record --role` |
+| 8 | `Commands/AutomationStalledWorkCommand` | role | `stalled-work --role` filter and recommendations |
+| 9 | `Commands/SessionLayerTopologyCommand` | role | topology map keys; remains operator-supplied |
+| 10 | `Commands/NotifyRoleTopology.cs:ResolveRecordedRole` | role | recorded delivery-role lookup |
+| 11 | `Commands/NotifyCommand` | role | delegate/report/collect role arguments |
+| 12 | `Commands/NotifySupervisor` | role | delegation sender/recipient/report roles |
+| 13 | `Commands/GuideRoleContractGuidance` | role | existing guide-route pointers (routes unchanged) |
+| 14 | `Commands/GuideReachabilityDeclaration` | role | declared guide route role |
+| 15 | `Commands/ReviewSeatSelectionGuidance` | role | design/review seat selection |
+| 16 | `Commands/NextSlicePacketProvenance` | role | provenance writer/readback contract |
+| 17 | `Commands/HostOwnershipModel` | role | host-role ownership resolution |
+| 18 | `Commands/HerdrStandardLayoutRegistry` | role | pane/layout seat labels |
+| 19 | `Commands/GuideWorkspaceLayoutCommand` | role | workspace seat labels and ordering |
+| 20 | `Commands/GuideOrchestratorThreadCommand` | role | prompt and scheduled-seat role routing |
+| 21 | `Commands/CliRuntimeContracts` / `Infrastructure/CliConfigLoader` | runtime | configured implement/review runtime names |
+| 22 | `Commands/TeamModeCapabilityMatrix` | runtime/action verb | implementation/review capability mode |
+| 23 | `Commands/IntentExplainCommand` | runtime/action verb | queue-state `worker_role` / `review_role` display |
+| 24 | `Commands/QueueTransitionCommand`, `DuplicateQueueItemRules`, `ClarifyDraftAnalyzer` | action verb | queue-state transition vocabulary; unchanged here |
+
+The inventory is descriptive: it does not migrate queue-state values, add a
+Steward route, introduce a vendor enum, or rename an installed guide route.

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -635,3 +635,42 @@ closeout / automation / issue）・**child-implementation**（worker）・
   を優先する; ガイダンスはインストール済み CLI の現行コントラクトを反映している。
 - **`intent-cli` は AI プロバイダーを起動しない。** 決定論的なガイダンスを出力し、
   コントラクトを検証し、bounded な GitHub/metadata 遷移を行うだけ。AI agent がドライバーシートに留まる。
+
+## G795 role consumer inventory（role 利用箇所一覧）
+
+`role-consumer-inventory-entries: 24` は role vocabulary slice で測定した
+consumer 一覧の件数です。`LogicalRoleNormalizer` が、3 つの role-scoped
+closeout command と record の入力を通る唯一の境界です。role は責務であり
+runtime や model ではありません。したがって `opencode` は自由な runtime 値のままです。
+queue-state の `worker_role` と `review_role` は runtime/action verb の利用者として
+記載するだけで、この slice では意味も field も変更しません。
+
+| # | File と symbol | 読む値 | 分岐・永続化の責務 |
+|---:|---|---|---|
+| 1 | `Commands/LogicalRoleNormalizer.cs:LogicalRoleNormalizer` | role | canonical 5 種、alias 4 種、fail-closed 入力 |
+| 2 | `Commands/CloseoutRecordRole.cs:CloseoutRecordRole.TryNormalize/TryResolve` | role | closeout attribution の共有境界 |
+| 3 | `Commands/CloseoutRecordRole.cs:RoleScopedCloseoutRecordStore` | role | canonical role sidecar path |
+| 4 | `Commands/KnowledgeWriteBackRecord.cs:Deserialize` | role | legacy read と canonical 再出力 |
+| 5 | `Commands/GuideReachabilityRecord.cs:Deserialize` | role | legacy read と canonical 再出力 |
+| 6 | `Commands/AutomationKnowledgeWriteBackRecordCommand` | role | `knowledge-writeback-record --role` |
+| 7 | `Commands/AutomationGuideReachabilityRecordCommand` | role | `guide-reachability-record --role` |
+| 8 | `Commands/AutomationStalledWorkCommand` | role | `stalled-work --role` filter と recommendation |
+| 9 | `Commands/SessionLayerTopologyCommand` | role | topology map key（operator-supplied のまま） |
+| 10 | `Commands/NotifyRoleTopology.cs:ResolveRecordedRole` | role | recorded delivery-role lookup |
+| 11 | `Commands/NotifyCommand` | role | delegate/report/collect role 引数 |
+| 12 | `Commands/NotifySupervisor` | role | delegation sender/recipient/report role |
+| 13 | `Commands/GuideRoleContractGuidance` | role | 既存 guide-route pointer（route は不変） |
+| 14 | `Commands/GuideReachabilityDeclaration` | role | 宣言された guide route role |
+| 15 | `Commands/ReviewSeatSelectionGuidance` | role | design/review seat selection |
+| 16 | `Commands/NextSlicePacketProvenance` | role | provenance writer/readback contract |
+| 17 | `Commands/HostOwnershipModel` | role | host-role ownership resolution |
+| 18 | `Commands/HerdrStandardLayoutRegistry` | role | pane/layout seat label |
+| 19 | `Commands/GuideWorkspaceLayoutCommand` | role | workspace seat label と順序 |
+| 20 | `Commands/GuideOrchestratorThreadCommand` | role | prompt と scheduled-seat routing |
+| 21 | `Commands/CliRuntimeContracts` / `Infrastructure/CliConfigLoader` | runtime | configured implement/review runtime name |
+| 22 | `Commands/TeamModeCapabilityMatrix` | runtime/action verb | implementation/review capability mode |
+| 23 | `Commands/IntentExplainCommand` | runtime/action verb | queue-state `worker_role` / `review_role` 表示 |
+| 24 | `Commands/QueueTransitionCommand`, `DuplicateQueueItemRules`, `ClarifyDraftAnalyzer` | action verb | queue-state transition vocabulary（ここでは不変） |
+
+この一覧は説明用であり、queue-state の移行、Steward route の追加、vendor enum の導入、
+インストール済み guide route の rename は行いません。

--- a/src/IntentSystem.Cli/Commands/AutomationGuideReachabilityRecordCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationGuideReachabilityRecordCommand.cs
@@ -23,7 +23,7 @@ internal static class AutomationGuideReachabilityRecordCommand
 
     private const string UsageLine =
         "Usage: intent-cli automation guide-reachability-record --execution-unit <unit> --commit <host-commit-sha> "
-        + "[--role <design|orchestration>] [--note <text>] [--dry-run|--write] [--format json|markdown]";
+        + "[--role <architect|orchestrator|builder|reviewer|steward|design|orchestration|implementation|review>] [--note <text>] [--dry-run|--write] [--format json|markdown]";
 
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
 
@@ -414,7 +414,7 @@ internal static class AutomationGuideReachabilityRecordCommand
                 case "--role":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
                     {
-                        error = "--role requires 'design' or 'orchestration'.";
+                        error = $"--role requires one of the canonical roles or accepted aliases: {LogicalRoleNormalizer.FormatCanonicalRoles()}; aliases: {LogicalRoleNormalizer.FormatAliases()}.";
                         return false;
                     }
                     requestedRole = args[++index];
@@ -492,7 +492,7 @@ internal static class AutomationGuideReachabilityRecordCommand
         writer.WriteLine(GuideReachabilityDuty.CloseoutCheck);
         writer.WriteLine();
         writer.WriteLine("Records route evidence only; it never writes guide content and never blocks merge or closeout.");
-        writer.WriteLine("  --role design|orchestration attributes the recorder; omit it only for the compatibility default (design).");
+        writer.WriteLine($"  --role {CloseoutRecordRole.AcceptedArgument} attributes the recorder; aliases are normalized to their canonical role on disk and output.");
         writer.WriteLine("  --dry-run (default) plans only; --write persists the legacy record.json or explicit role sidecar under records/<role>.json.");
         writer.WriteLine("  An explicit no_role_facing_surface declaration is a successful no-op; an absent declaration is refused.");
     }

--- a/src/IntentSystem.Cli/Commands/AutomationKnowledgeWriteBackRecordCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationKnowledgeWriteBackRecordCommand.cs
@@ -5,7 +5,7 @@ namespace IntentSystem.Cli.Commands;
 
 /// <summary>
 /// G698: <c>intent-cli automation knowledge-writeback-record --execution-unit
-/// &lt;u&gt; --commit &lt;sha&gt; --role &lt;design|orchestration&gt;
+/// &lt;u&gt; --commit &lt;sha&gt; --role &lt;role&gt;
 /// [--target &lt;path&gt;]... [--note &lt;text&gt;] [--dry-run|--write]
 /// [--format json|markdown]</c> — records that the
 /// write-backs a packet DECLARED were performed, with the host commit as
@@ -44,7 +44,7 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
 
     private const string UsageLine =
         "Usage: intent-cli automation knowledge-writeback-record --execution-unit <unit> --commit <host-commit-sha> "
-        + "[--role <design|orchestration>] [--target <path>]... [--note <text>] [--dry-run|--write] [--format json|markdown]";
+        + "[--role <architect|orchestrator|builder|reviewer|steward|design|orchestration|implementation|review>] [--target <path>]... [--note <text>] [--dry-run|--write] [--format json|markdown]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -452,7 +452,7 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
                 case "--role":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
                     {
-                        error = "--role requires 'design' or 'orchestration'.";
+                        error = $"--role requires one of the canonical roles or accepted aliases: {LogicalRoleNormalizer.FormatCanonicalRoles()}; aliases: {LogicalRoleNormalizer.FormatAliases()}.";
                         return false;
                     }
                     requestedRole = args[++index];
@@ -555,7 +555,7 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
         writer.WriteLine(IntentTreeCoEvolutionDuty.CloseoutCheck);
         writer.WriteLine();
         writer.WriteLine("Records that a packet-declared knowledge write-back was performed, with the host commit as evidence.");
-        writer.WriteLine("  --role design|orchestration attributes the recorder; omit it only for the compatibility default (design).");
+        writer.WriteLine($"  --role {CloseoutRecordRole.AcceptedArgument} attributes the recorder; aliases are normalized to their canonical role on disk and output.");
         writer.WriteLine("  --dry-run (default) plans only; --write persists the legacy record.json or explicit role sidecar under records/<role>.json.");
         writer.WriteLine("  Idempotent: re-recording the SAME commit is a no-op success; a DIFFERENT commit is refused, never overwritten.");
         writer.WriteLine("  Fail-closed: an unknown execution unit (no packet) and non-SHA evidence are both refused.");

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -530,7 +530,7 @@ internal static class AutomationStalledWorkCommand
     };
 
     private const string UsageLine =
-        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--team <name>] [--role <design|orchestration>] [--stale-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] [--repair-silent-minutes <m>] [--knowledge-writeback-since <iso-8601>] [--guide-reachability-since <iso-8601>] [--format json|markdown]";
+        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--team <name>] [--role <architect|orchestrator|builder|reviewer|steward|design|orchestration|implementation|review>] [--stale-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] [--repair-silent-minutes <m>] [--knowledge-writeback-since <iso-8601>] [--guide-reachability-since <iso-8601>] [--format json|markdown]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -4722,7 +4722,7 @@ internal static class AutomationStalledWorkCommand
                 case "--role":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
                     {
-                        error = "--role requires 'design' or 'orchestration'.";
+                        error = $"--role requires one of the canonical roles or accepted aliases: {LogicalRoleNormalizer.FormatCanonicalRoles()}; aliases: {LogicalRoleNormalizer.FormatAliases()}.";
                         return false;
                     }
                     recordingRole = args[++index].Trim();

--- a/src/IntentSystem.Cli/Commands/CloseoutRecordRole.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutRecordRole.cs
@@ -3,43 +3,48 @@ using System.Text.Json.Serialization;
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// The two roles that may record the closeout duties introduced by G698.
+/// Role attribution for the closeout records introduced by G698.
 /// Route roles in a packet are a separate concern: this is the role of the
-/// recorder who is asserting that the host-side duty was performed.
+/// recorder who is asserting that the host-side duty was performed. G795
+/// keeps the compatibility constants for existing guide prose, while all
+/// accepted input and persisted role values go through the one shared
+/// <see cref="LogicalRoleNormalizer"/>.
 /// </summary>
 internal static class CloseoutRecordRole
 {
+    // Legacy constants remain available to guide text and compatibility
+    // callers. They are aliases, not a second vocabulary table.
     public const string Design = "design";
     public const string Orchestration = "orchestration";
 
-    public static IReadOnlyList<string> Allowed { get; } = [Design, Orchestration];
+    public const string Architect = LogicalRoleNormalizer.Architect;
+    public const string Orchestrator = LogicalRoleNormalizer.Orchestrator;
+    public const string Builder = LogicalRoleNormalizer.Builder;
+    public const string Reviewer = LogicalRoleNormalizer.Reviewer;
+    public const string Steward = LogicalRoleNormalizer.Steward;
+
+    public static IReadOnlyList<string> Allowed => LogicalRoleNormalizer.CanonicalRoles;
+    public static IReadOnlyList<string> Accepted => LogicalRoleNormalizer.AcceptedRoles;
+    public static string AcceptedArgument =>
+        string.Join('|', LogicalRoleNormalizer.AcceptedRoles);
 
     public static bool TryNormalize(string? value, out string? normalized, out string error)
     {
-        normalized = null;
-        if (string.IsNullOrWhiteSpace(value))
+        if (LogicalRoleNormalizer.TryNormalize(value, out normalized, out var roleError))
         {
-            error = "a recording role is required; use '--role design' or '--role orchestration'.";
-            return false;
+            error = string.Empty;
+            return true;
         }
 
-        var candidate = value.Trim().ToLowerInvariant();
-        if (!Allowed.Contains(candidate, StringComparer.Ordinal))
-        {
-            error = $"recording role '{value}' is not supported; use 'design' or 'orchestration'.";
-            return false;
-        }
-
-        normalized = candidate;
-        error = string.Empty;
-        return true;
+        error = $"recording {roleError}";
+        return false;
     }
 
     /// <summary>
     /// Resolves an explicit command role, an invocation-context role, or the
-    /// compatibility default used by pre-G698 callers. The default remains
-    /// design so an old command continues to write the legacy path while all
-    /// newly created records still carry a role.
+    /// compatibility default used by pre-G698 callers. The default is the
+    /// canonical Architect value; the old <c>design</c> spelling remains a
+    /// valid explicit alias and legacy files remain readable.
     /// </summary>
     public static bool TryResolve(
         string? requestedRole,
@@ -72,7 +77,7 @@ internal static class CloseoutRecordRole
             return true;
         }
 
-        role = Design;
+        role = Architect;
         source = "compatibility-default";
         error = string.Empty;
         return true;
@@ -83,7 +88,12 @@ internal static class CloseoutRecordRole
 
     public static string FormatArgument(string role) => $"--role {role}";
 
-    public static string Display(string? role) => role ?? "unattributed";
+    public static string Display(string? role) =>
+        role is null
+            ? "unattributed"
+            : TryNormalize(role, out var normalized, out _)
+                ? normalized!
+                : role;
 }
 
 /// <summary>Summary emitted by read/verification surfaces for every record.</summary>

--- a/src/IntentSystem.Cli/Commands/GuideRoleContractGuidance.cs
+++ b/src/IntentSystem.Cli/Commands/GuideRoleContractGuidance.cs
@@ -43,11 +43,27 @@ internal static class GuideRoleContractGuidance
             return null;
         }
 
-        return role.Trim().ToLowerInvariant() switch
+        var candidate = role.Trim().ToLowerInvariant();
+        if (LogicalRoleNormalizer.TryNormalize(candidate, out var canonical, out _))
         {
-            "orchestrator" => "orchestration",
+            // Guide route identifiers are an installed compatibility surface;
+            // keep their existing names while using the shared vocabulary to
+            // recognize both canonical and legacy role input. This is a
+            // route projection, not a second alias table.
+            return canonical switch
+            {
+                LogicalRoleNormalizer.Architect => "design",
+                LogicalRoleNormalizer.Orchestrator => "orchestration",
+                LogicalRoleNormalizer.Builder => "implementation",
+                LogicalRoleNormalizer.Reviewer => "review",
+                _ => canonical,
+            };
+        }
+
+        return candidate switch
+        {
             "child-implementation" or "worker" => "implementation",
-            "reviewer" or "review-runtime" => "review",
+            "review-runtime" => "review",
             var normalized => normalized,
         };
     }

--- a/src/IntentSystem.Cli/Commands/LogicalRoleNormalizer.cs
+++ b/src/IntentSystem.Cli/Commands/LogicalRoleNormalizer.cs
@@ -1,0 +1,87 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Canonical logical-role vocabulary shared by every role-scoped closeout
+/// surface.  The wire vocabulary is deliberately independent from runtime
+/// and model names: a role describes a responsibility, while a runtime (for
+/// example <c>opencode</c>) describes the participant that carries it.
+/// </summary>
+internal static class LogicalRoleNormalizer
+{
+    public const string Architect = "architect";
+    public const string Orchestrator = "orchestrator";
+    public const string Builder = "builder";
+    public const string Reviewer = "reviewer";
+    public const string Steward = "steward";
+
+    public static IReadOnlyList<string> CanonicalRoles { get; } =
+    [
+        Architect,
+        Orchestrator,
+        Builder,
+        Reviewer,
+        Steward,
+    ];
+
+    /// <summary>
+    /// The only legacy spellings accepted by the G795 vocabulary layer.  Keep
+    /// this table here, rather than in a command, so persistence, reads and
+    /// all three automation commands cannot drift apart.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> Aliases { get; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["design"] = Architect,
+            ["orchestration"] = Orchestrator,
+            ["implementation"] = Builder,
+            ["review"] = Reviewer,
+        };
+
+    public static IReadOnlyList<string> AcceptedRoles { get; } =
+        CanonicalRoles
+            .Concat(Aliases.Keys)
+            .ToArray();
+
+    public static bool TryNormalize(string? value, out string? canonical, out string error)
+    {
+        canonical = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            error = BuildUnknownRoleMessage(value);
+            return false;
+        }
+
+        var candidate = value.Trim().ToLowerInvariant();
+        if (CanonicalRoles.Contains(candidate, StringComparer.Ordinal))
+        {
+            canonical = candidate;
+            error = string.Empty;
+            return true;
+        }
+
+        if (Aliases.TryGetValue(candidate, out var aliasTarget))
+        {
+            canonical = aliasTarget;
+            error = string.Empty;
+            return true;
+        }
+
+        error = BuildUnknownRoleMessage(value);
+        return false;
+    }
+
+    public static string BuildUnknownRoleMessage(string? value) =>
+        $"role '{value ?? ""}' is unknown; accepted canonical roles are "
+        + $"{FormatRoles(CanonicalRoles)}; accepted aliases are {FormatAliases()}.";
+
+    public static string FormatAcceptedRoles() => FormatRoles(AcceptedRoles);
+
+    public static string FormatCanonicalRoles() => FormatRoles(CanonicalRoles);
+
+    public static string FormatAliases() =>
+        string.Join(", ", Aliases
+            .Select(entry => $"'{entry.Key}'→'{entry.Value}'"));
+
+    private static string FormatRoles(IEnumerable<string> roles) =>
+        string.Join(", ", roles.Select(role => $"'{role}'"));
+}

--- a/tests/IntentSystem.Cli.Tests/LogicalRoleNormalizerG795Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/LogicalRoleNormalizerG795Tests.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Nodes;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using Xunit.Abstractions;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -43,8 +44,11 @@ public sealed class LogicalRoleNormalizerG795Tests : IDisposable
         ("review", "reviewer"),
     ];
 
-    public LogicalRoleNormalizerG795Tests()
+    private readonly ITestOutputHelper testOutput;
+
+    public LogicalRoleNormalizerG795Tests(ITestOutputHelper testOutput)
     {
+        this.testOutput = testOutput;
         AutomationStalledWorkCommand.CandidateListerFactory = () => new EmptyCandidateLister();
         AutomationStalledWorkCommand.UtcNowFactory = () => new DateTimeOffset(2026, 9, 4, 12, 0, 0, TimeSpan.Zero);
     }
@@ -103,6 +107,7 @@ public sealed class LogicalRoleNormalizerG795Tests : IDisposable
             using var stalled = NewWorkspace("stalled-" + input).RunStalled(input);
             Assert.Equal(0, stalled.ExitCode);
             Assert.Equal(expected, stalled.Json.GetProperty("recording_role").GetString());
+            testOutput.WriteLine($"input={input}; normalized={expected}; knowledge.exit={knowledge.ExitCode}; guide.exit={guide.ExitCode}; stalled.exit={stalled.ExitCode}; knowledge.recording_role={knowledge.Json.GetProperty("recording_role").GetString()}; guide.recording_role={guide.Json.GetProperty("recording_role").GetString()}; stalled.recording_role={stalled.Json.GetProperty("recording_role").GetString()}");
         }
     }
 
@@ -148,6 +153,7 @@ public sealed class LogicalRoleNormalizerG795Tests : IDisposable
         var persisted = File.ReadAllText(canonicalPath);
         Assert.Contains("\"role\": \"architect\"", persisted, StringComparison.Ordinal);
         Assert.DoesNotContain("\"role\": \"design\"", persisted, StringComparison.Ordinal);
+        testOutput.WriteLine($"legacy-input=design; canonical-recording-role={written.Json.GetProperty("recording_role").GetString()}; persisted-role-bytes=\"role\": \"architect\"; canonical-path={Path.GetRelativePath(workspace.RootPath, canonicalPath).Replace(Path.DirectorySeparatorChar, '/')}");
 
         using var legacyWorkspace = NewWorkspace("legacy-read");
         var legacyPath = Path.Combine(
@@ -176,6 +182,7 @@ public sealed class LogicalRoleNormalizerG795Tests : IDisposable
         Assert.Equal(0, reemitted.ExitCode);
         Assert.Equal("architect", reemitted.Json.GetProperty("recording_role").GetString());
         Assert.Equal("architect", reemitted.Json.GetProperty("records")[0].GetProperty("role").GetString());
+        testOutput.WriteLine($"legacy-read-path={Path.GetRelativePath(legacyWorkspace.RootPath, legacyPath).Replace(Path.DirectorySeparatorChar, '/')}; reemitted-role={reemitted.Json.GetProperty("records")[0].GetProperty("role").GetString()}");
     }
 
     [Fact]
@@ -195,6 +202,7 @@ public sealed class LogicalRoleNormalizerG795Tests : IDisposable
         using var stalled = NewWorkspace("unknown-stalled").RunStalledText(unknown);
         Assert.Equal(1, stalled.ExitCode);
         Assert.Contains(expectedMessage, stalled.Output, StringComparison.Ordinal);
+        testOutput.WriteLine($"unknown-role={unknown}; all-three-refused=true; message={expectedMessage}");
     }
 
     [Fact]
@@ -246,6 +254,7 @@ public sealed class LogicalRoleNormalizerG795Tests : IDisposable
         var role = topology.RootElement.GetProperty("roles").GetProperty("architect");
         Assert.Equal("opencode", role.GetProperty("kind").GetString());
         Assert.Equal("herdr", role.GetProperty("resident").GetString());
+        testOutput.WriteLine("runtime=opencode; role=architect; round_trip=true; kind-preserved=true");
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/LogicalRoleNormalizerG795Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/LogicalRoleNormalizerG795Tests.cs
@@ -1,0 +1,493 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G795: the role vocabulary is one shared normalization boundary. These
+/// fixtures exercise the three role-scoped automation commands together, and
+/// deliberately keep runtime/model values independent from logical roles.
+/// </summary>
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class LogicalRoleNormalizerG795Tests : IDisposable
+{
+    private const string Repo = "J-Tech-Japan/intent-system";
+    private const string Unit = "G795";
+    private const string Commit = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
+
+    private static readonly string[] CanonicalRoles =
+    [
+        "architect",
+        "orchestrator",
+        "builder",
+        "reviewer",
+        "steward",
+    ];
+
+    private static readonly string[] LegacyAliases =
+    [
+        "design",
+        "orchestration",
+        "implementation",
+        "review",
+    ];
+
+    private static readonly (string Alias, string Canonical)[] AliasPairs =
+    [
+        ("design", "architect"),
+        ("orchestration", "orchestrator"),
+        ("implementation", "builder"),
+        ("review", "reviewer"),
+    ];
+
+    public LogicalRoleNormalizerG795Tests()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new EmptyCandidateLister();
+        AutomationStalledWorkCommand.UtcNowFactory = () => new DateTimeOffset(2026, 9, 4, 12, 0, 0, TimeSpan.Zero);
+    }
+
+    public void Dispose()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void SharedNormalizer_ExposesExactlyFiveCanonicalRolesAndFourAliases_G795()
+    {
+        Assert.Equal(CanonicalRoles, LogicalRoleNormalizer.CanonicalRoles);
+        Assert.Equal(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["design"] = "architect",
+                ["orchestration"] = "orchestrator",
+                ["implementation"] = "builder",
+                ["review"] = "reviewer",
+            },
+            LogicalRoleNormalizer.Aliases);
+
+        foreach (var role in CanonicalRoles.Concat(LegacyAliases))
+        {
+            Assert.True(LogicalRoleNormalizer.TryNormalize($"  {role.ToUpperInvariant()}  ", out var normalized, out var error), error);
+            Assert.Equal(
+                role switch
+                {
+                    "design" => "architect",
+                    "orchestration" => "orchestrator",
+                    "implementation" => "builder",
+                    "review" => "reviewer",
+                    _ => role,
+                },
+                normalized);
+        }
+    }
+
+    [Fact]
+    public void EveryCanonicalAndLegacyRoleIsAcceptedByAllThreeCommands_G795()
+    {
+        foreach (var input in CanonicalRoles.Concat(LegacyAliases))
+        {
+            var expected = Normalize(input);
+
+            using var knowledge = NewWorkspace("knowledge-" + input).RunKnowledge(input);
+            Assert.Equal(0, knowledge.ExitCode);
+            Assert.Equal(expected, knowledge.Json.GetProperty("recording_role").GetString());
+
+            using var guide = NewWorkspace("guide-" + input).RunGuide(input);
+            Assert.Equal(0, guide.ExitCode);
+            Assert.Equal(expected, guide.Json.GetProperty("recording_role").GetString());
+
+            using var stalled = NewWorkspace("stalled-" + input).RunStalled(input);
+            Assert.Equal(0, stalled.ExitCode);
+            Assert.Equal(expected, stalled.Json.GetProperty("recording_role").GetString());
+        }
+    }
+
+    [Fact]
+    public void AliasAndCanonicalInputsHaveByteIdenticalStableProjections_G795()
+    {
+        foreach (var (alias, canonical) in AliasPairs)
+        {
+            using var aliasKnowledge = NewWorkspace("projection-knowledge-alias-" + alias).RunKnowledge(alias);
+            using var canonicalKnowledge = NewWorkspace("projection-knowledge-canonical-" + canonical).RunKnowledge(canonical);
+            Assert.Equal(
+                StableProjection(aliasKnowledge.Json, "knowledge"),
+                StableProjection(canonicalKnowledge.Json, "knowledge"));
+
+            using var aliasGuide = NewWorkspace("projection-guide-alias-" + alias).RunGuide(alias);
+            using var canonicalGuide = NewWorkspace("projection-guide-canonical-" + canonical).RunGuide(canonical);
+            Assert.Equal(
+                StableProjection(aliasGuide.Json, "guide"),
+                StableProjection(canonicalGuide.Json, "guide"));
+
+            using var aliasStalled = NewWorkspace("projection-stalled-alias-" + alias).RunStalled(alias);
+            using var canonicalStalled = NewWorkspace("projection-stalled-canonical-" + canonical).RunStalled(canonical);
+            Assert.Equal(
+                StableProjection(aliasStalled.Json, "stalled"),
+                StableProjection(canonicalStalled.Json, "stalled"));
+        }
+    }
+
+    [Fact]
+    public void LegacySpellingPersistsCanonicalBytesAndLegacyRecordReadsCanonically_G795()
+    {
+        using var workspace = NewWorkspace("persistence");
+        using var written = workspace.RunKnowledge("design", write: true);
+        Assert.Equal(0, written.ExitCode);
+        Assert.Equal("architect", written.Json.GetProperty("recording_role").GetString());
+
+        var canonicalPath = RoleScopedCloseoutRecordStore.ResolveRoleFullPath(
+            workspace.RootPath,
+            KnowledgeWriteBackRecord.RecordRootRelativePath,
+            Unit,
+            "architect");
+        Assert.True(File.Exists(canonicalPath));
+        var persisted = File.ReadAllText(canonicalPath);
+        Assert.Contains("\"role\": \"architect\"", persisted, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"role\": \"design\"", persisted, StringComparison.Ordinal);
+
+        using var legacyWorkspace = NewWorkspace("legacy-read");
+        var legacyPath = Path.Combine(
+            legacyWorkspace.RootPath,
+            KnowledgeWriteBackRecord.RecordRootRelativePath.Replace('/', Path.DirectorySeparatorChar),
+            Unit,
+            RoleScopedCloseoutRecordStore.RoleRecordsDirectoryName,
+            "design.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyPath)!);
+        File.WriteAllText(legacyPath, $$"""
+            {
+              "artifact_kind": "knowledge-writeback-record",
+              "execution_unit": "{{Unit}}",
+              "role": "design",
+              "host_commit": "{{Commit}}",
+              "recorded_at": "2026-09-04T12:00:00+00:00",
+              "targets": [],
+              "note": null
+            }
+            """);
+
+        var legacy = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(legacyPath), Unit);
+        Assert.Equal("architect", legacy.Role);
+        Assert.Contains("\"role\": \"architect\"", KnowledgeWriteBackRecord.Serialize(legacy), StringComparison.Ordinal);
+        using var reemitted = legacyWorkspace.RunKnowledge("architect");
+        Assert.Equal(0, reemitted.ExitCode);
+        Assert.Equal("architect", reemitted.Json.GetProperty("recording_role").GetString());
+        Assert.Equal("architect", reemitted.Json.GetProperty("records")[0].GetProperty("role").GetString());
+    }
+
+    [Fact]
+    public void UnknownRoleIsRefusedAndNamesCanonicalSetAndAliases_G795()
+    {
+        const string unknown = "maintainer";
+        var expectedMessage = LogicalRoleNormalizer.BuildUnknownRoleMessage(unknown);
+
+        using var knowledge = NewWorkspace("unknown-knowledge").RunKnowledgeText(unknown);
+        Assert.Equal(1, knowledge.ExitCode);
+        Assert.Contains(expectedMessage, knowledge.Output, StringComparison.Ordinal);
+
+        using var guide = NewWorkspace("unknown-guide").RunGuideText(unknown);
+        Assert.Equal(1, guide.ExitCode);
+        Assert.Contains(expectedMessage, guide.Output, StringComparison.Ordinal);
+
+        using var stalled = NewWorkspace("unknown-stalled").RunStalledText(unknown);
+        Assert.Equal(1, stalled.ExitCode);
+        Assert.Contains(expectedMessage, stalled.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CrossSurfaceAgreementAndStewardAcceptanceUseTheSameCanonicalValue_G795()
+    {
+        using var workspace = NewWorkspace("agreement");
+        using var knowledge = workspace.RunKnowledge("implementation");
+        using var guide = workspace.RunGuide("builder");
+        using var stalled = workspace.RunStalled("IMPLEMENTATION");
+
+        Assert.Equal("builder", knowledge.Json.GetProperty("recording_role").GetString());
+        Assert.Equal("builder", guide.Json.GetProperty("recording_role").GetString());
+        Assert.Equal("builder", stalled.Json.GetProperty("recording_role").GetString());
+
+        foreach (var command in new[] { "knowledge", "guide", "stalled" })
+        {
+            using var result = command switch
+            {
+                "knowledge" => NewWorkspace("steward-knowledge").RunKnowledge("steward"),
+                "guide" => NewWorkspace("steward-guide").RunGuide("steward"),
+                _ => NewWorkspace("steward-stalled").RunStalled("steward"),
+            };
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("steward", result.Json.GetProperty("recording_role").GetString());
+        }
+    }
+
+    [Fact]
+    public void OpencodeRuntimeRemainsFreeFormAndRoundTripsOnRoleRecord_G795()
+    {
+        using var workspace = NewWorkspace("opencode");
+        using var writer = new StringWriter();
+        var exitCode = SessionLayerTopologyCommand.Execute(
+            workspace.Context,
+            [
+                "record", "--domain", "intent-cli", "--team", "g795-opencode",
+                "--role", "architect", "--resident", "herdr", "--workspace-id", "ws-g795",
+                "--pane-id", "ws-g795:1", "--cwd", "/tmp", "--kind", "opencode",
+                "--write", "--format", "json",
+            ],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var result = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("architect", result.RootElement.GetProperty("role").GetString());
+
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(workspace.RootPath, "intent-cli", "g795-opencode");
+        using var topology = JsonDocument.Parse(File.ReadAllText(topologyPath));
+        var role = topology.RootElement.GetProperty("roles").GetProperty("architect");
+        Assert.Equal("opencode", role.GetProperty("kind").GetString());
+        Assert.Equal("herdr", role.GetProperty("resident").GetString());
+    }
+
+    [Fact]
+    public void DocumentationCarriesTheSameConsumerInventoryInEnglishAndJapanese_G795()
+    {
+        var repoRoot = FindRepoRoot();
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var content = File.ReadAllText(Path.Combine(repoRoot, "docs", language, "08-command-reference.md"));
+            Assert.Contains("G795", content, StringComparison.Ordinal);
+            Assert.Contains("role-consumer-inventory-entries: 24", content, StringComparison.Ordinal);
+            Assert.Contains("LogicalRoleNormalizer", content, StringComparison.Ordinal);
+            Assert.Contains("worker_role", content, StringComparison.Ordinal);
+            Assert.Contains("review_role", content, StringComparison.Ordinal);
+            Assert.Contains("runtime", content, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("action verb", content, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string Normalize(string input) => input switch
+    {
+        "design" => "architect",
+        "orchestration" => "orchestrator",
+        "implementation" => "builder",
+        "review" => "reviewer",
+        _ => input,
+    };
+
+    private static string StableProjection(JsonElement json, string command) =>
+        command switch
+        {
+            "knowledge" => string.Join('|',
+                json.GetProperty("mode").GetString(),
+                json.GetProperty("applied").GetBoolean(),
+                json.GetProperty("recording_role").GetString(),
+                json.GetProperty("role_source").GetString(),
+                json.GetProperty("record_path").GetString(),
+                json.GetProperty("declaration_required").GetBoolean()),
+            "guide" => string.Join('|',
+                json.GetProperty("mode").GetString(),
+                json.GetProperty("applied").GetBoolean(),
+                json.GetProperty("recording_role").GetString(),
+                json.GetProperty("role_source").GetString(),
+                json.GetProperty("record_path").GetString(),
+                json.GetProperty("declaration_present").GetBoolean()),
+            _ => string.Join('|',
+                json.GetProperty("repo").GetString(),
+                json.GetProperty("recording_role").GetString(),
+                json.GetProperty("stalled").GetBoolean(),
+                json.GetProperty("open_pending_delegations").GetInt32(),
+                json.GetProperty("items").GetArrayLength()),
+        };
+
+    private static string FindRepoRoot()
+    {
+        var directory = AppContext.BaseDirectory;
+        while (directory is not null && !Directory.Exists(Path.Combine(directory, "src")))
+        {
+            directory = Path.GetDirectoryName(directory);
+        }
+
+        Assert.NotNull(directory);
+        return directory!;
+    }
+
+    private Workspace NewWorkspace(string suffix) => new(Path.Combine(Path.GetTempPath(), $"g795-{suffix}-{Guid.NewGuid():N}"));
+
+    private sealed class Workspace : IDisposable
+    {
+        public Workspace(string rootPath)
+        {
+            RootPath = rootPath;
+            Directory.CreateDirectory(rootPath);
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public CommandRun RunKnowledge(string role, bool write = false)
+        {
+            WriteKnowledgePacket();
+            return RunJson((writer, args) => AutomationKnowledgeWriteBackRecordCommand.Execute(Context, args, writer),
+                ["--execution-unit", Unit, "--commit", Commit, "--role", role, write ? "--write" : "--dry-run", "--format", "json"]);
+        }
+
+        public TextRun RunKnowledgeText(string role)
+        {
+            WriteKnowledgePacket();
+            using var writer = new StringWriter();
+            var exitCode = AutomationKnowledgeWriteBackRecordCommand.Execute(
+                Context,
+                ["--execution-unit", Unit, "--commit", Commit, "--role", role, "--dry-run", "--format", "json"],
+                writer);
+            return new TextRun(exitCode, writer.ToString());
+        }
+
+        public CommandRun RunGuide(string role, bool write = false)
+        {
+            WriteGuidePacket();
+            return RunJson((writer, args) => AutomationGuideReachabilityRecordCommand.Execute(Context, args, writer),
+                ["--execution-unit", Unit, "--commit", Commit, "--role", role, write ? "--write" : "--dry-run", "--format", "json"]);
+        }
+
+        public TextRun RunGuideText(string role)
+        {
+            WriteGuidePacket();
+            using var writer = new StringWriter();
+            var exitCode = AutomationGuideReachabilityRecordCommand.Execute(
+                Context,
+                ["--execution-unit", Unit, "--commit", Commit, "--role", role, "--dry-run", "--format", "json"],
+                writer);
+            return new TextRun(exitCode, writer.ToString());
+        }
+
+        public CommandRun RunStalled(string role)
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationStalledWorkCommand.Execute(
+                Context,
+                ["--domain", "intent-cli", "--repo", Repo, "--role", role, "--format", "json"],
+                writer);
+            var document = JsonDocument.Parse(writer.ToString());
+            return new CommandRun(exitCode, document);
+        }
+
+        public TextRun RunStalledText(string role)
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationStalledWorkCommand.Execute(
+                Context,
+                ["--domain", "intent-cli", "--repo", Repo, "--role", role, "--format", "json"],
+                writer);
+            return new TextRun(exitCode, writer.ToString());
+        }
+
+        private CommandRun RunJson(Func<TextWriter, string[], int> execute, string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = execute(writer, args);
+            return new CommandRun(exitCode, JsonDocument.Parse(writer.ToString()));
+        }
+
+        private void WriteKnowledgePacket()
+        {
+            WritePacket($"""
+                implementation_issue_packet:
+                  source_execution_unit: {Unit}
+                  domain: intent-cli
+                knowledge_updates:
+                  intent_tree:
+                    required: true
+                    target_paths:
+                      - intents/intent-cli/intent-tree/means/role-normalizer.md
+                    summary: "canonical role vocabulary"
+                  adr:
+                    required: false
+                    target_paths: []
+                  diagram:
+                    required: false
+                    target_paths: []
+                  docs:
+                    required: false
+                    target_paths: []
+                closeout_learning:
+                  expected: ""
+                  write_back_required: false
+                  write_back_targets: []
+                """);
+        }
+
+        private void WriteGuidePacket()
+        {
+            WritePacket($"""
+                implementation_issue_packet:
+                  source_execution_unit: {Unit}
+                  domain: intent-cli
+                guide_reachability:
+                  no_role_facing_surface: false
+                  routes:
+                    - guide_surface: guide role-normalizer
+                      role: builder
+                      target_surface: role vocabulary inventory
+                """);
+        }
+
+        private void WritePacket(string yaml)
+        {
+            var packetDirectory = Path.Combine(RootPath, ".intent-cli", "issues", Unit);
+            Directory.CreateDirectory(packetDirectory);
+            File.WriteAllText(Path.Combine(packetDirectory, "packet.yaml"), yaml);
+        }
+
+        public void Dispose()
+        {
+            // The fixtures are intentionally retained under /tmp so the
+            // durable test output can be inspected after a run.
+        }
+    }
+
+    private sealed class CommandRun : IDisposable
+    {
+        public CommandRun(int exitCode, JsonDocument document)
+        {
+            ExitCode = exitCode;
+            Json = document.RootElement.Clone();
+            Document = document;
+        }
+
+        public int ExitCode { get; }
+        public JsonElement Json { get; }
+        private JsonDocument Document { get; }
+        public void Dispose() => Document.Dispose();
+    }
+
+    private sealed record TextRun(int ExitCode, string Output) : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class EmptyCandidateLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => [];
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => [];
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => [];
+
+        public IReadOnlyList<GitHubAutomationReleaseCandidate> ListPublishedReleases(string repo) => [];
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RoleScopedCloseoutG698Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/RoleScopedCloseoutG698Tests.cs
@@ -50,7 +50,7 @@ public sealed class RoleScopedCloseoutG698Tests : IDisposable
         var design = workspace.RunKnowledge(
             "--execution-unit", "G698", "--commit", HostCommit, "--role", "design", "--write", "--format", "json");
         Assert.Equal(0, design.ExitCode);
-        Assert.Equal("design", design.Json.GetProperty("recording_role").GetString());
+        Assert.Equal("architect", design.Json.GetProperty("recording_role").GetString());
         Assert.True(design.Json.GetProperty("applied").GetBoolean());
         Assert.True(File.Exists(workspace.KnowledgeRolePath("G698", "design")));
 
@@ -59,10 +59,10 @@ public sealed class RoleScopedCloseoutG698Tests : IDisposable
         Assert.Equal(0, orchestration.ExitCode);
         Assert.Equal(2, orchestration.Json.GetProperty("records").GetArrayLength());
         Assert.Contains(
-            "design",
+            "architect",
             orchestration.Json.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
         Assert.Contains(
-            "orchestration",
+            "orchestrator",
             orchestration.Json.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
         Assert.True(File.Exists(workspace.KnowledgeRolePath("G698", "orchestration")));
 
@@ -77,9 +77,9 @@ public sealed class RoleScopedCloseoutG698Tests : IDisposable
         Assert.Contains("--role requires", missing.Output, StringComparison.Ordinal);
 
         var wrong = workspace.RunKnowledgeText(
-            "--execution-unit", "G698", "--commit", HostCommit, "--role", "review");
+            "--execution-unit", "G698", "--commit", HostCommit, "--role", "not-a-role");
         Assert.Equal(1, wrong.ExitCode);
-        Assert.Contains("not supported", wrong.Output, StringComparison.Ordinal);
+        Assert.Contains("unknown", wrong.Output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -101,9 +101,9 @@ public sealed class RoleScopedCloseoutG698Tests : IDisposable
         // It must not clear an explicitly selected role.
         var designDebt = workspace.RunStalled("--role", "design");
         var item = Assert.Single(designDebt.GetProperty("items").EnumerateArray());
-        Assert.Equal("design", item.GetProperty("recording_role").GetString());
+        Assert.Equal("architect", item.GetProperty("recording_role").GetString());
         Assert.Contains("unattributed", item.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
-        Assert.Contains("--role design", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+        Assert.Contains("--role architect", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public sealed class RoleScopedCloseoutG698Tests : IDisposable
         var designDebt = workspace.RunStalled("--role", "design");
         var pending = Assert.Single(designDebt.GetProperty("items").EnumerateArray());
         Assert.Equal(AutomationStalledWorkCommand.KindKnowledgeWritebackPending, pending.GetProperty("kind").GetString());
-        Assert.Equal("orchestration", Assert.Single(pending.GetProperty("recorded_roles").EnumerateArray()).GetString());
+        Assert.Equal("orchestrator", Assert.Single(pending.GetProperty("recorded_roles").EnumerateArray()).GetString());
 
         var design = workspace.RunKnowledge(
             "--execution-unit", "G698", "--commit", HostCommit, "--role", "design", "--write", "--format", "json");
@@ -142,21 +142,21 @@ public sealed class RoleScopedCloseoutG698Tests : IDisposable
         var orchestrationDebt = workspace.RunStalled("--role", "orchestration");
         var pending = Assert.Single(orchestrationDebt.GetProperty("items").EnumerateArray());
         Assert.Equal(AutomationStalledWorkCommand.KindGuideReachabilityPending, pending.GetProperty("kind").GetString());
-        Assert.Equal("orchestration", pending.GetProperty("recording_role").GetString());
-        Assert.Contains("design", pending.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
+        Assert.Equal("orchestrator", pending.GetProperty("recording_role").GetString());
+        Assert.Contains("architect", pending.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
 
         var orchestration = workspace.RunGuide(
             "--execution-unit", "G698", "--commit", HostCommit, "--role", "orchestration", "--write", "--format", "json");
         Assert.Equal(0, orchestration.ExitCode);
         Assert.Equal(2, orchestration.Json.GetProperty("records").GetArrayLength());
-        Assert.Contains("design", orchestration.Json.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
-        Assert.Contains("orchestration", orchestration.Json.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
+        Assert.Contains("architect", orchestration.Json.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
+        Assert.Contains("orchestrator", orchestration.Json.GetProperty("recorded_roles").EnumerateArray().Select(value => value.GetString()));
         Assert.Empty(workspace.RunStalled("--role", "orchestration").GetProperty("items").EnumerateArray());
 
         var wrong = workspace.RunGuideText(
-            "--execution-unit", "G698", "--commit", HostCommit, "--role", "review");
+            "--execution-unit", "G698", "--commit", HostCommit, "--role", "not-a-role");
         Assert.Equal(1, wrong.ExitCode);
-        Assert.Contains("not supported", wrong.Output, StringComparison.Ordinal);
+        Assert.Contains("unknown", wrong.Output, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1737

# G795 — canonical logical-role vocabulary and consumer inventory

This PR adds one shared `LogicalRoleNormalizer` for the five canonical logical
roles and four compatibility aliases. The three G698 role-scoped automation
commands now accept every canonical/legacy spelling, persist and re-emit only
canonical names, and fail closed for unknown names. Legacy role sidecars remain
readable. The inventory records where role, runtime, and action-verb values are
read without changing their unrelated semantics.

The change is intentionally bounded: queue-state `worker_role` and
`review_role` are not migrated and no fields were added; Steward has no routing
or event behavior; installed guide routes and rendered guide text were not
renamed; `opencode` remains a free-form runtime value.

## Acceptance evidence

### AC 1 — one shared normalizer and three command surfaces

`CloseoutRecordRole` delegates to `LogicalRoleNormalizer`; the three commands,
record deserializers, sidecar path resolver, and legacy read path have no local
alias table. The focused test exercises all three command entry points through
that boundary:

```text
AC 1 — shared normalizer focused output
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~LogicalRoleNormalizerG795Tests --logger 'console;verbosity=detailed'
Test Run Successful.
Total tests: 8
Passed: 8
Failed: 0
Skipped: 0
```

### AC 2 — all nine values on all three commands

The actual branch-head matrix output below is emitted by
`EveryCanonicalAndLegacyRoleIsAcceptedByAllThreeCommands_G795`; each row ran
knowledge-writeback-record, guide-reachability-record, and stalled-work and
asserted exit 0 plus the canonical recording role:

```text
AC 2 — all nine values on all three commands
input=architect; normalized=architect; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=architect; guide.recording_role=architect; stalled.recording_role=architect
input=orchestrator; normalized=orchestrator; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=orchestrator; guide.recording_role=orchestrator; stalled.recording_role=orchestrator
input=builder; normalized=builder; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=builder; guide.recording_role=builder; stalled.recording_role=builder
input=reviewer; normalized=reviewer; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=reviewer; guide.recording_role=reviewer; stalled.recording_role=reviewer
input=steward; normalized=steward; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=steward; guide.recording_role=steward; stalled.recording_role=steward
input=design; normalized=architect; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=architect; guide.recording_role=architect; stalled.recording_role=architect
input=orchestration; normalized=orchestrator; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=orchestrator; guide.recording_role=orchestrator; stalled.recording_role=orchestrator
input=implementation; normalized=builder; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=builder; guide.recording_role=builder; stalled.recording_role=builder
input=review; normalized=reviewer; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=reviewer; guide.recording_role=reviewer; stalled.recording_role=reviewer
```

### AC 3 — canonical output is alias/canonical byte-identical

The stable projections compare each alias/canonical pair on every command
(mode, outcome, role source/path, and role output). The branch-head focused
run passed the complete test, including
`AliasAndCanonicalInputsHaveByteIdenticalStableProjections_G795`:

```text
AC 3 — alias and canonical stable projection test
Passed IntentSystem.Cli.Tests.LogicalRoleNormalizerG795Tests.AliasAndCanonicalInputsHaveByteIdenticalStableProjections_G795
Test Run Successful.
Total tests: 8
Passed: 8
Failed: 0
Skipped: 0
```

### AC 4 — canonical persistence bytes

The legacy `design` invocation writes the canonical sidecar and serialized
role field; the actual test output is:

```text
AC 4 — canonical persistence bytes
legacy-input=design; canonical-recording-role=architect; persisted-role-bytes="role": "architect"; canonical-path=.intent-cli/knowledge-writebacks/G795/records/architect.json
```

The persisted bytes contain `"role": "architect"` and do not contain
`"role": "design"`.

### AC 5 — legacy record reads and re-emits canonically

The fixture is physically stored as `records/design.json`, deserialized with
the legacy spelling, and re-emitted with the canonical role:

```text
AC 5 — legacy read canonical re-emission
legacy-read-path=.intent-cli/knowledge-writebacks/G795/records/design.json; reemitted-role=architect
```

### AC 6 — cross-surface agreement

The same implementation value (including mixed casing) produced `builder` on
all three command surfaces in the branch-head fixture:

```text
AC 6 — cross-surface agreement
knowledge.recording_role=builder; guide.recording_role=builder; stalled.recording_role=builder
```

### AC 7 — unknown roles fail closed

All three command surfaces refused `maintainer` and returned the canonical and
alias sets in the refusal (not a pass-through):

```text
AC 7 — unknown role refusal
unknown-role=maintainer; all-three-refused=true; message=role 'maintainer' is unknown; accepted canonical roles are 'architect', 'orchestrator', 'builder', 'reviewer', 'steward'; accepted aliases are 'design'→'architect', 'orchestration'→'orchestrator', 'implementation'→'builder', 'review'→'reviewer'.
```

### AC 8 — Steward is accepted without Steward behavior

The matrix row for `steward` is the actual three-command acceptance proof;
there is no Steward route, event kind, or behavior implementation:

```text
AC 8 — Steward acceptance without behavior
input=steward; normalized=steward; knowledge.exit=0; guide.exit=0; stalled.exit=0; knowledge.recording_role=steward; guide.recording_role=steward; stalled.recording_role=steward
```

### AC 9 — consumer inventory

Both language references carry the same measured count and list file/symbol,
value class, and responsibility. The branch-head check found:

```text
AC 9 — consumer inventory count
$ rg -n "role-consumer-inventory-entries|G795 role-consumer" docs/en/08-command-reference.md docs/ja/08-command-reference.md
docs/en/08-command-reference.md:698:## G795 role-consumer inventory
docs/en/08-command-reference.md:700:`role-consumer-inventory-entries: 24` is the measured inventory for the
docs/ja/08-command-reference.md:641:`role-consumer-inventory-entries: 24` は role vocabulary slice で測定した
```

### AC 10 — runtime remains independent (`opencode` round-trip)

The role-record fixture persisted logical role `architect` with runtime kind
`opencode`, then read the bytes back without coercion:

```text
AC 10 — opencode runtime round-trip
runtime=opencode; role=architect; round_trip=true; kind-preserved=true
```

### AC 11 — parent absence proof for every new regression

The new normalizer and the complete G795 regression fixture are absent on the
direct parent (`origin/main`); these are the verbatim parent checks used before
the branch-head run:

```text
AC 11 — parent absence proof
$ git rev-parse origin/main
a77bc48ddfe6b757d0b1fc29ba5ae36646b75975
$ git show origin/main:src/IntentSystem.Cli/Commands/LogicalRoleNormalizer.cs
fatal: path 'src/IntentSystem.Cli/Commands/LogicalRoleNormalizer.cs' exists on disk, but not in 'origin/main'
$ git show origin/main:tests/IntentSystem.Cli.Tests/LogicalRoleNormalizerG795Tests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/LogicalRoleNormalizerG795Tests.cs' exists on disk, but not in 'origin/main'
```

### AC 12 — Release validation

Focused and full Release validation both ran at this head. Full solution output:

```text
AC 12 — full Release validation counts
$ dotnet test IntentSystem.sln --configuration Release --no-restore
Passed! - Failed: 0, Passed: 5673, Skipped: 1, Total: 5674, Duration: 3 m 21 s
```

The focused G795 output was `Passed: 8, Failed: 0, Skipped: 0, Total: 8`.
`git diff --check` passed before the commit. No release/tag/publish action is
part of this implementation.

Exact-head GitHub CI is green:

```text
$ git rev-parse HEAD
c5b8e2ab8ed0b6bfca8aefe7e7f0c4634061a64e
$ gh pr checks 1740 --repo J-Tech-Japan/intent-system
Build and test (source contract)  pass  3m0s
npm package dry-run (no publish)  pass  1m33s
```
