### PR TITLE
G798: canonical config and queue roles

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs
@@ -479,8 +479,8 @@ internal static class AutomationHostQueueItemRecoveryCommand
                 },
                 LinkedIssue = newLinkedIssue,
                 LinkedPr = proposed.LinkedPrUrl,
-                WorkerRole = "coder",
-                ReviewRole = "reviewer",
+                WorkerRole = LogicalRoleNormalizer.Builder,
+                ReviewRole = LogicalRoleNormalizer.Reviewer,
                 Priority = "normal",
             });
         }

--- a/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
@@ -435,8 +435,8 @@ internal static class AutomationIssueRetireCommand
                     },
                     LinkedIssue = new LinkedIssue { Repo = repo!, Number = issue, Url = snapshot.Url },
                     LinkedPr = null,
-                    WorkerRole = CliRuntimeContracts.DefaultImplementRole,
-                    ReviewRole = CliRuntimeContracts.DefaultReviewRole,
+                    WorkerRole = LogicalRoleNormalizer.Builder,
+                    ReviewRole = LogicalRoleNormalizer.Reviewer,
                     Priority = "high",
                     RetirementReason = retirementReason,
                 });

--- a/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
@@ -300,20 +300,15 @@ internal static class AutomationQueueSeedFromPacketCommand
         // `QueueEnqueueCommand` contract so seeded queue items look
         // the same as packets enqueued through the standard path.
         // - WorkerRole / ReviewRole default to the host's configured
-        //   roles (`context.Config.Roles.Implement` / `Review`,
-        //   which default to logical implementation / review roles per
-        //   `CliRuntimeContracts.DefaultImplementRole` /
-        //   `DefaultReviewRole`).
+        //   logical roles (`context.Config.Roles.WorkerRoleForQueue` /
+        //   `ReviewRoleForQueue`), which canonicalize aliases and keep
+        //   historical vendor values out of newly seeded records.
         // - Priority defaults to "high" to match
         //   `QueueEnqueueCommand.DefaultPriority`.
         // Packets that explicitly declare any of these still win via
         // `LookupScalar` precedence inside BuildSeedItem.
-        var defaultWorkerRole = !string.IsNullOrWhiteSpace(context.Config.Roles?.Implement)
-            ? context.Config.Roles!.Implement
-            : CliRuntimeContracts.DefaultImplementRole;
-        var defaultReviewRole = !string.IsNullOrWhiteSpace(context.Config.Roles?.Review)
-            ? context.Config.Roles!.Review
-            : CliRuntimeContracts.DefaultReviewRole;
+        var defaultWorkerRole = context.Config.Roles.WorkerRoleForQueue;
+        var defaultReviewRole = context.Config.Roles.ReviewRoleForQueue;
         const string defaultPriority = "high";
 
         var seed = BuildSeedItem(
@@ -491,14 +486,16 @@ internal static class AutomationQueueSeedFromPacketCommand
         // different from packets enqueued via the standard path.
         // Packets that DO declare any field still win via
         // LookupScalar.
-        var workerRole = LookupScalar(packetFields,
+        var workerRole = LogicalRoleNormalizer.NormalizeOrPreserveLegacy(
+            LookupScalar(packetFields,
             "worker_role",
-            "implementation_issue_packet.worker_role")
-            ?? defaultWorkerRole;
-        var reviewRole = LookupScalar(packetFields,
+            "implementation_issue_packet.worker_role"),
+            defaultWorkerRole);
+        var reviewRole = LogicalRoleNormalizer.NormalizeOrPreserveLegacy(
+            LookupScalar(packetFields,
             "review_role",
-            "implementation_issue_packet.review_role")
-            ?? defaultReviewRole;
+            "implementation_issue_packet.review_role"),
+            defaultReviewRole);
         var priority = LookupScalar(packetFields,
             "priority",
             "implementation_issue_packet.priority")

--- a/src/IntentSystem.Cli/Commands/AutomationSummaryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationSummaryAnalyzer.cs
@@ -97,6 +97,7 @@ internal static class AutomationSummaryAnalyzer
             RunsLogPath = bindings.RunsLogPath,
             PacketRoot = bindings.PacketRoot,
             ExecutionUnitRegex = bindings.ExecutionUnitRegex,
+            LegacyRoleMappings = context.Config.Roles.LegacyValues,
             EffectiveBaseBranchPolicy = effectivePolicy,
             ImplementationBaseBranch = implementationBaseBranch,
             SameRepoTopology = sameRepoTopology,

--- a/src/IntentSystem.Cli/Commands/AutomationSummaryRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationSummaryRenderer.cs
@@ -46,6 +46,20 @@ internal static class AutomationSummaryRenderer
         writer.WriteLine($"- execution_unit_regex: {FormatNullable(result.ExecutionUnitRegex)}");
         writer.WriteLine();
 
+        writer.WriteLine("## Role mappings");
+        if (result.LegacyRoleMappings.Count == 0)
+        {
+            writer.WriteLine("- legacy_role_mappings: (none)");
+        }
+        else
+        {
+            foreach (var mapping in result.LegacyRoleMappings.OrderBy(entry => entry.Key, StringComparer.Ordinal))
+            {
+                writer.WriteLine($"- legacy_role_mappings.{mapping.Key}: {mapping.Value}");
+            }
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Issue workflow labels");
         WriteBulletList(writer, result.IssueWorkflowLabels);
         writer.WriteLine();

--- a/src/IntentSystem.Cli/Commands/AutomationSummaryResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationSummaryResult.cs
@@ -32,6 +32,16 @@ internal sealed record AutomationSummaryResult
     public string? ExecutionUnitRegex { get; init; }
 
     /// <summary>
+    /// G798: explicit <c>[roles]</c> entries whose values are not logical
+    /// roles (for example vendor/runtime names). They remain readable for
+    /// compatibility, but are surfaced as legacy so queue writers do not
+    /// mistake them for staffing decisions.
+    /// </summary>
+    [JsonPropertyName("legacy_role_mappings")]
+    public IReadOnlyDictionary<string, string> LegacyRoleMappings { get; init; }
+        = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
     /// G346: the effective base branch policy for this domain/host, sourced from
     /// <c>.intent-cli/config.toml</c> <c>base_branch_policy</c> (defaults to
     /// <c>direct-main</c> when the key is absent). AI threads should derive the

--- a/src/IntentSystem.Cli/Commands/LogicalRoleNormalizer.cs
+++ b/src/IntentSystem.Cli/Commands/LogicalRoleNormalizer.cs
@@ -70,6 +70,56 @@ internal static class LogicalRoleNormalizer
         return false;
     }
 
+    /// <summary>
+    /// Resolve a value for a newly-written role-bearing field. Known canonical
+    /// names and aliases are projected to the canonical vocabulary. Unknown
+    /// values are intentionally not treated as roles; callers receive the
+    /// trimmed legacy value so compatibility surfaces can preserve it and
+    /// report it as legacy. A missing value receives the supplied canonical
+    /// fallback (for example <c>builder</c> or <c>reviewer</c>). Existing
+    /// queue-state values are read as-is so legacy records remain displayable
+    /// and round-trippable.
+    /// </summary>
+    public static string NormalizeForWrite(string? value, string fallback)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fallback);
+
+        if (TryNormalize(fallback, out var canonicalFallback, out var fallbackError)
+            && canonicalFallback is not null)
+        {
+            if (TryNormalize(value, out var canonical, out _)
+                && canonical is not null)
+            {
+                return canonical;
+            }
+
+            return string.IsNullOrWhiteSpace(value) ? canonicalFallback : value.Trim();
+        }
+
+        throw new ArgumentException(fallbackError, nameof(fallback));
+    }
+
+    /// <summary>
+    /// Resolve a configuration value while retaining an unknown legacy value
+    /// for diagnostics. This is the compatibility path for vendor/action
+    /// values in the historical <c>[roles]</c> section; it never invents a
+    /// second role vocabulary.
+    /// </summary>
+    public static string NormalizeOrPreserveLegacy(string? value, string fallback)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fallback);
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        return TryNormalize(value, out var canonical, out _)
+            && canonical is not null
+            ? canonical
+            : value.Trim();
+    }
+
     public static string BuildUnknownRoleMessage(string? value) =>
         $"role '{value ?? ""}' is unknown; accepted canonical roles are "
         + $"{FormatRoles(CanonicalRoles)}; accepted aliases are {FormatAliases()}.";

--- a/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
@@ -153,8 +153,12 @@ internal static class QueueEnqueueCommand
             ClarificationReturnPath = packet.ClarificationReturnPath,
             PacketPaths = packetPaths,
             LinkedIssue = null,
-            WorkerRole = context.Config.Roles.Implement,
-            ReviewRole = context.Config.Roles.Review,
+            // Queue-state role fields carry logical roles only. Config values
+            // that are known aliases are canonicalized; historical runtime
+            // names are not silently persisted as roles and fall back to the
+            // worker/reviewer responsibilities.
+            WorkerRole = context.Config.Roles.WorkerRoleForQueue,
+            ReviewRole = context.Config.Roles.ReviewRoleForQueue,
             Priority = DefaultPriority
         };
     }

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -447,16 +447,32 @@ internal static class CliConfigLoader
             return new RoleMappings();
         }
 
+        var legacyValues = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        string ReadRole(string key, string fallback)
+        {
+            var raw = TryGetOptionalString(rolesTable, key);
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return fallback;
+            }
+
+            var value = LogicalRoleNormalizer.NormalizeOrPreserveLegacy(raw, fallback);
+            if (!LogicalRoleNormalizer.TryNormalize(raw, out _, out _))
+            {
+                legacyValues[key] = raw.Trim();
+            }
+
+            return value;
+        }
+
         return new RoleMappings
         {
-            Implement = TryGetOptionalString(rolesTable, CliRuntimeContracts.ImplementRoleKey)
-                ?? CliRuntimeContracts.DefaultImplementRole,
-            Review = TryGetOptionalString(rolesTable, CliRuntimeContracts.ReviewRoleKey)
-                ?? CliRuntimeContracts.DefaultReviewRole,
-            Interview = TryGetOptionalString(rolesTable, CliRuntimeContracts.InterviewRoleKey)
-                ?? CliRuntimeContracts.DefaultInterviewRole,
-            Clarify = TryGetOptionalString(rolesTable, CliRuntimeContracts.ClarifyRoleKey)
-                ?? CliRuntimeContracts.DefaultClarifyRole
+            Implement = ReadRole(CliRuntimeContracts.ImplementRoleKey, CliRuntimeContracts.DefaultImplementRole),
+            Review = ReadRole(CliRuntimeContracts.ReviewRoleKey, CliRuntimeContracts.DefaultReviewRole),
+            Interview = ReadRole(CliRuntimeContracts.InterviewRoleKey, CliRuntimeContracts.DefaultInterviewRole),
+            Clarify = ReadRole(CliRuntimeContracts.ClarifyRoleKey, CliRuntimeContracts.DefaultClarifyRole),
+            LegacyValues = legacyValues
         };
     }
 

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -85,6 +85,44 @@ internal sealed record RoleMappings
     public string Interview { get; init; } = CliRuntimeContracts.DefaultInterviewRole;
 
     public string Clarify { get; init; } = CliRuntimeContracts.DefaultClarifyRole;
+
+    /// <summary>
+    /// Explicit <c>[roles]</c> values that are not logical roles. Historical
+    /// configs use this map for runtime names such as <c>Claude</c> and
+    /// <c>Codex</c>; retaining the values lets existing configs load without a
+    /// rewrite while making the legacy meaning observable to diagnostics.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> LegacyValues { get; init; }
+        = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    public bool HasLegacyValues => LegacyValues.Count > 0;
+
+    /// <summary>
+    /// Returns the value safe for a queue writer. Explicit vendor/runtime
+    /// values loaded from the historical config are not persisted into the
+    /// logical queue vocabulary; they fall back to the corresponding
+    /// responsibility. Values supplied directly by compatibility callers are
+    /// still preserved unless they are a known alias/canonical role.
+    /// </summary>
+    public string WorkerRoleForQueue => ResolveForQueue(
+        CliRuntimeContracts.ImplementRoleKey,
+        Implement,
+        LogicalRoleNormalizer.Builder);
+
+    public string ReviewRoleForQueue => ResolveForQueue(
+        CliRuntimeContracts.ReviewRoleKey,
+        Review,
+        LogicalRoleNormalizer.Reviewer);
+
+    private string ResolveForQueue(string key, string value, string fallback)
+    {
+        if (LegacyValues.ContainsKey(key))
+        {
+            return LogicalRoleNormalizer.NormalizeForWrite(null, fallback);
+        }
+
+        return LogicalRoleNormalizer.NormalizeForWrite(value, fallback);
+    }
 }
 
 internal sealed record SupervisionConfig

--- a/tests/IntentSystem.Cli.Tests/AutomationHostQueueItemRecoveryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostQueueItemRecoveryCommandTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -93,6 +94,10 @@ public sealed class AutomationHostQueueItemRecoveryCommandTests : IDisposable
         Assert.Contains(Unit, queueJson, StringComparison.Ordinal);
         Assert.Contains(PrNumber.ToString(), queueJson, StringComparison.Ordinal);
         Assert.Contains(IssueNumber.ToString(), queueJson, StringComparison.Ordinal);
+        var recovered = Assert.Single(QueueStateSerializer.Deserialize(queueJson).Items);
+        Assert.Equal(LogicalRoleNormalizer.Builder, recovered.WorkerRole);
+        Assert.Equal(LogicalRoleNormalizer.Reviewer, recovered.ReviewRole);
+        Assert.DoesNotContain("\"coder\"", queueJson, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -96,6 +96,8 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         Assert.Equal(QueueItemState.Retired, item.State);
         Assert.Contains("decomposed", item.RetirementReason, StringComparison.Ordinal);
         Assert.Equal(1744, item.LinkedIssue!.Number);
+        Assert.Equal(LogicalRoleNormalizer.Builder, item.WorkerRole);
+        Assert.Equal(LogicalRoleNormalizer.Reviewer, item.ReviewRole);
 
         var runsPath = workspace.Context.GetRunLogPath();
         Assert.True(File.Exists(runsPath));

--- a/tests/IntentSystem.Cli.Tests/AutomationQueueSeedFromPacketCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationQueueSeedFromPacketCommandTests.cs
@@ -223,12 +223,12 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
         Assert.Equal("Demo", seeded.Title); // From packet.yaml issue_title.
         // PR #830 review repair #3: role / priority fallbacks now
         // align with the established `QueueEnqueueCommand` contract
-        // — host config Roles (defaulting to "Claude" / "Codex" per
-        // CliRuntimeContracts) and priority "high". The earlier
+        // — host config roles canonicalize to builder/reviewer and
+        // priority remains "high". The earlier
         // hardcoded "coder" / "reviewer" / "normal" values were
         // out of contract with the standard queue-enqueue path.
-        Assert.Equal(CliRuntimeContracts.DefaultImplementRole, seeded.WorkerRole);
-        Assert.Equal(CliRuntimeContracts.DefaultReviewRole, seeded.ReviewRole);
+        Assert.Equal(LogicalRoleNormalizer.Builder, seeded.WorkerRole);
+        Assert.Equal(LogicalRoleNormalizer.Reviewer, seeded.ReviewRole);
         Assert.Equal("high", seeded.Priority);
 
         // runs.jsonl appended with the seed event.
@@ -656,8 +656,8 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
         // so packets seeded via this lane look identical to packets
         // enqueued via the standard path.
         using var customWorkspace = new TestWorkspace();
-        // Override the default RoleMappings (`Claude` / `Codex`) on
-        // the seeded test context with explicitly configured values
+        // Override the default RoleMappings on the seeded test context
+        // with explicitly configured values
         // so the assertion proves the seed reads from config, not
         // from a hardcoded fallback.
         var newContext = new CliContext

--- a/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
@@ -43,8 +43,8 @@ public sealed class QueueEnqueueCommandTests
             Assert.Equal(["G4"], selectedItem.BlockedBy);
             Assert.Equal("intents/intent-cli/clarifications/open.md", selectedItem.ClarificationReturnPath);
             Assert.Equal(".intent-cli/issues/G38/packet.yaml", selectedItem.PacketPaths.Yaml);
-            Assert.Equal(CliRuntimeContracts.DefaultImplementRole, selectedItem.WorkerRole);
-            Assert.Equal(CliRuntimeContracts.DefaultReviewRole, selectedItem.ReviewRole);
+            Assert.Equal(LogicalRoleNormalizer.Builder, selectedItem.WorkerRole);
+            Assert.Equal(LogicalRoleNormalizer.Reviewer, selectedItem.ReviewRole);
             Assert.Equal("high", selectedItem.Priority);
 
             var runEvents = RunLogSerializer.DeserializeAll(

--- a/tests/IntentSystem.Cli.Tests/RoleVocabularyG798Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/RoleVocabularyG798Tests.cs
@@ -1,0 +1,297 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Infrastructure;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G798 contract coverage: config values, queue writer vocabulary, legacy
+/// display/duplicate compatibility, and the deliberate absence of a runtime
+/// field in queue-state.
+/// </summary>
+public sealed class RoleVocabularyG798Tests
+{
+    [Fact]
+    public void Load_ExactFourLineVendorConfig_IsUnchangedAndReportsEveryLegacyKey()
+    {
+        using var fixture = new Fixture();
+        var configText = """
+            default_domain = "intent-cli"
+            artifact_root = ".intent-cli"
+            [roles]
+            implement = "Claude"
+            review = "Codex"
+            interview = "Claude"
+            clarify = "Codex"
+            """;
+        var configPath = fixture.WriteFile(".intent-cli/config.toml", configText);
+        var before = File.ReadAllBytes(configPath);
+
+        var config = CliConfigLoader.LoadFromFile(configPath);
+        Assert.Equal("Claude", config.Roles.Implement);
+        Assert.Equal("Codex", config.Roles.Review);
+        Assert.Equal("Claude", config.Roles.Interview);
+        Assert.Equal("Codex", config.Roles.Clarify);
+        Assert.Equal(
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["implement"] = "Claude",
+                ["review"] = "Codex",
+                ["interview"] = "Claude",
+                ["clarify"] = "Codex",
+            },
+            config.Roles.LegacyValues);
+
+        var context = fixture.CreateContext(config);
+        using var writer = new StringWriter();
+        var exitCode = AutomationSummaryCommand.Execute(context, ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var report = document.RootElement.GetProperty("legacy_role_mappings");
+        Assert.Equal("Claude", report.GetProperty("implement").GetString());
+        Assert.Equal("Codex", report.GetProperty("review").GetString());
+        Assert.Equal("Claude", report.GetProperty("interview").GetString());
+        Assert.Equal("Codex", report.GetProperty("clarify").GetString());
+        Assert.Equal(before, File.ReadAllBytes(configPath));
+    }
+
+    [Fact]
+    public void Load_CanonicalAndAliasValues_UsesLogicalRoleNormalizer()
+    {
+        var config = CliConfigLoader.Load("""
+            default_domain = "intent-cli"
+            artifact_root = ".intent-cli"
+            [roles]
+            implement = "IMPLEMENTATION"
+            review = "review"
+            interview = "architect"
+            clarify = "steward"
+            """);
+
+        Assert.Equal(LogicalRoleNormalizer.Builder, config.Roles.Implement);
+        Assert.Equal(LogicalRoleNormalizer.Reviewer, config.Roles.Review);
+        Assert.Equal(LogicalRoleNormalizer.Architect, config.Roles.Interview);
+        Assert.Equal(LogicalRoleNormalizer.Steward, config.Roles.Clarify);
+        Assert.Empty(config.Roles.LegacyValues);
+        Assert.Equal(LogicalRoleNormalizer.Builder, config.Roles.WorkerRoleForQueue);
+        Assert.Equal(LogicalRoleNormalizer.Reviewer, config.Roles.ReviewRoleForQueue);
+    }
+
+    [Fact]
+    public void SeedAndQueueEnqueue_NormalizeKnownValuesAndVendorFallbacks()
+    {
+        Assert.True(
+            PacketYamlDocument.TryParse(
+                "implementation_issue_packet:\n  issue_title: G798\n  worker_role: implementation\n  review_role: review\n",
+                out var packet,
+                out var parseError),
+            parseError);
+        Assert.NotNull(packet);
+
+        var seeded = AutomationQueueSeedFromPacketCommand.BuildSeedItem(
+            "G798",
+            packet!,
+            "intents/intent-cli/clarifications/open.md",
+            LogicalRoleNormalizer.Builder,
+            LogicalRoleNormalizer.Reviewer,
+            "high");
+        Assert.Equal(LogicalRoleNormalizer.Builder, seeded.WorkerRole);
+        Assert.Equal(LogicalRoleNormalizer.Reviewer, seeded.ReviewRole);
+
+        var context = new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+                Roles = new RoleMappings
+                {
+                    Implement = "Claude",
+                    Review = "Codex",
+                    LegacyValues = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["implement"] = "Claude",
+                        ["review"] = "Codex",
+                    },
+                },
+            },
+        };
+        var queueItem = QueueEnqueueCommand.CreateQueueItem(
+            context,
+            new QueueEnqueueCommand.ResolvedQueuePacket
+            {
+                ExecutionUnit = "G798",
+                IssueTitle = "G798",
+                Dependencies = [],
+                ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            },
+            new PacketPaths
+            {
+                Implementation = ".intent-cli/issues/G798/implementation.md",
+                ReviewContext = ".intent-cli/issues/G798/review-context.md",
+                Yaml = ".intent-cli/issues/G798/packet.yaml",
+            });
+        Assert.Equal(LogicalRoleNormalizer.Builder, queueItem.WorkerRole);
+        Assert.Equal(LogicalRoleNormalizer.Reviewer, queueItem.ReviewRole);
+    }
+
+    [Fact]
+    public void IntentExplain_RendersEveryLegacyValue()
+    {
+        using var fixture = new Fixture();
+        var items = new[]
+        {
+            CreateItem("G798-claude-codex", "Claude", "Codex"),
+            CreateItem("G798-implement-intake", "implement", "intake"),
+            CreateItem("G798-clarify-interview", "clarify", "interview"),
+            CreateItem("G798-fix-queue", "fix", "queue"),
+            CreateItem("G798-review-coder", "review", "coder"),
+        };
+        fixture.WriteQueueState(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-09-04T00:00:00Z"),
+            Items = items,
+        });
+
+        var output = new StringBuilder();
+        var context = fixture.CreateContext();
+        foreach (var item in items)
+        {
+            using var writer = new StringWriter();
+            Assert.Equal(0, IntentExplainCommand.Execute(context, [item.ExecutionUnit], writer));
+            output.Append(writer);
+        }
+
+        foreach (var value in new[]
+        {
+            "Claude", "Codex", "implement", "intake", "clarify",
+            "interview", "fix", "queue", "review", "coder",
+        })
+        {
+            Assert.True(
+                output.ToString().Contains($"worker role: {value}", StringComparison.Ordinal)
+                    || output.ToString().Contains($"review role: {value}", StringComparison.Ordinal),
+                $"legacy value '{value}' was not rendered by intent explain");
+        }
+    }
+
+    [Fact]
+    public void DuplicateDetection_RemainsDuplicateAcrossCanonicalAndLegacyVocabulary()
+    {
+        var legacy = CreateItem("G798", "implement", "review") with { State = QueueItemState.Queued };
+        var canonical = CreateItem("G798", LogicalRoleNormalizer.Builder, LogicalRoleNormalizer.Reviewer) with
+        {
+            State = QueueItemState.Queued,
+        };
+
+        var groups = DuplicateQueueItemRules.Analyze(
+        [
+            DuplicateQueueItemRules.FromQueueItem(legacy, 0),
+            DuplicateQueueItemRules.FromQueueItem(canonical, 1),
+        ]);
+
+        var group = Assert.Single(groups);
+        Assert.Equal("G798", group.ExecutionUnit);
+        Assert.Equal(2, group.Entries.Count);
+        Assert.Null(group.Winner);
+    }
+
+    [Fact]
+    public void QueueStateSchema_HasNoRuntimeField_AndOpenCodeRoundTrips()
+    {
+        var config = CliConfigLoader.Load("""
+            default_domain = "intent-cli"
+            artifact_root = ".intent-cli"
+            [roles]
+            implement = "opencode"
+            review = "opencode"
+            """);
+        Assert.Equal("opencode", config.Roles.Implement);
+        Assert.Equal("opencode", config.Roles.Review);
+        Assert.Equal("opencode", config.Roles.LegacyValues["implement"]);
+        Assert.Equal("opencode", config.Roles.LegacyValues["review"]);
+        Assert.Equal(LogicalRoleNormalizer.Builder, config.Roles.WorkerRoleForQueue);
+        Assert.Equal(LogicalRoleNormalizer.Reviewer, config.Roles.ReviewRoleForQueue);
+
+        var state = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-09-04T00:00:00Z"),
+            Items = [CreateItem("G798-opencode", "opencode", "opencode")],
+        };
+        var serialized = QueueStateSerializer.Serialize(state);
+        using var document = JsonDocument.Parse(serialized);
+        var item = document.RootElement.GetProperty("items")[0];
+        Assert.False(item.TryGetProperty("runtime", out _));
+        Assert.Equal("opencode", item.GetProperty("worker_role").GetString());
+        Assert.Equal("opencode", item.GetProperty("review_role").GetString());
+        var roundTrip = QueueStateSerializer.Deserialize(serialized).Items.Single();
+        Assert.Equal("opencode", roundTrip.WorkerRole);
+        Assert.Equal("opencode", roundTrip.ReviewRole);
+    }
+
+    private static QueueItem CreateItem(string executionUnit, string workerRole, string reviewRole)
+        => new()
+        {
+            ExecutionUnit = executionUnit,
+            Title = executionUnit,
+            State = QueueItemState.Completed,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+            },
+            WorkerRole = workerRole,
+            ReviewRole = reviewRole,
+            Priority = "normal",
+        };
+
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string root = Directory.CreateTempSubdirectory("intent-g798-").FullName;
+
+        public string WriteFile(string relativePath, string content)
+        {
+            var path = Path.Combine(root, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            return path;
+        }
+
+        public void WriteQueueState(QueueState state)
+        {
+            WriteFile(".intent-cli/queue-state.json", QueueStateSerializer.Serialize(state));
+        }
+
+        public CliContext CreateContext(CliConfig? config = null)
+        {
+            return new CliContext
+            {
+                RepoRoot = root,
+                Config = config ?? new CliConfig
+                {
+                    Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+                },
+            };
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RoleVocabularyG798Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/RoleVocabularyG798Tests.cs
@@ -6,6 +6,7 @@ using IntentSystem.Cli.Infrastructure;
 using IntentSystem.Cli.Models;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
+using Xunit.Abstractions;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -16,6 +17,13 @@ namespace IntentSystem.Cli.Tests;
 /// </summary>
 public sealed class RoleVocabularyG798Tests
 {
+    private readonly ITestOutputHelper output;
+
+    public RoleVocabularyG798Tests(ITestOutputHelper output)
+    {
+        this.output = output;
+    }
+
     [Fact]
     public void Load_ExactFourLineVendorConfig_IsUnchangedAndReportsEveryLegacyKey()
     {
@@ -59,6 +67,9 @@ public sealed class RoleVocabularyG798Tests
         Assert.Equal("Claude", report.GetProperty("interview").GetString());
         Assert.Equal("Codex", report.GetProperty("clarify").GetString());
         Assert.Equal(before, File.ReadAllBytes(configPath));
+        output.WriteLine("AC1/AC2 legacy_role_mappings JSON:");
+        output.WriteLine(writer.ToString());
+        output.WriteLine($"AC2 exit_code={exitCode}; config_bytes_unchanged={before.SequenceEqual(File.ReadAllBytes(configPath))}");
     }
 
     [Fact]
@@ -139,6 +150,7 @@ public sealed class RoleVocabularyG798Tests
             });
         Assert.Equal(LogicalRoleNormalizer.Builder, queueItem.WorkerRole);
         Assert.Equal(LogicalRoleNormalizer.Reviewer, queueItem.ReviewRole);
+        output.WriteLine($"AC3 seed worker_role={seeded.WorkerRole}; review_role={seeded.ReviewRole}; queue-enqueue worker_role={queueItem.WorkerRole}; review_role={queueItem.ReviewRole}; coder_written=false");
     }
 
     [Fact]
@@ -160,13 +172,13 @@ public sealed class RoleVocabularyG798Tests
             Items = items,
         });
 
-        var output = new StringBuilder();
+        var rendered = new StringBuilder();
         var context = fixture.CreateContext();
         foreach (var item in items)
         {
             using var writer = new StringWriter();
             Assert.Equal(0, IntentExplainCommand.Execute(context, [item.ExecutionUnit], writer));
-            output.Append(writer);
+            rendered.Append(writer);
         }
 
         foreach (var value in new[]
@@ -176,10 +188,12 @@ public sealed class RoleVocabularyG798Tests
         })
         {
             Assert.True(
-                output.ToString().Contains($"worker role: {value}", StringComparison.Ordinal)
-                    || output.ToString().Contains($"review role: {value}", StringComparison.Ordinal),
+                rendered.ToString().Contains($"worker role: {value}", StringComparison.Ordinal)
+                    || rendered.ToString().Contains($"review role: {value}", StringComparison.Ordinal),
                 $"legacy value '{value}' was not rendered by intent explain");
         }
+        output.WriteLine("AC4 intent explain output:");
+        output.WriteLine(rendered.ToString());
     }
 
     [Fact]
@@ -201,6 +215,7 @@ public sealed class RoleVocabularyG798Tests
         Assert.Equal("G798", group.ExecutionUnit);
         Assert.Equal(2, group.Entries.Count);
         Assert.Null(group.Winner);
+        output.WriteLine($"AC5 duplicate_groups={groups.Count}; execution_unit={group.ExecutionUnit}; entries={group.Entries.Count}; winner={(group.Winner is null ? "unresolved" : "selected")}");
     }
 
     [Fact]
@@ -235,6 +250,9 @@ public sealed class RoleVocabularyG798Tests
         var roundTrip = QueueStateSerializer.Deserialize(serialized).Items.Single();
         Assert.Equal("opencode", roundTrip.WorkerRole);
         Assert.Equal("opencode", roundTrip.ReviewRole);
+        output.WriteLine("AC6/AC7 queue-state JSON:");
+        output.WriteLine(serialized);
+        output.WriteLine($"AC7 config_worker_role={config.Roles.Implement}; config_review_role={config.Roles.Review}; queue_roundtrip_worker_role={roundTrip.WorkerRole}; queue_roundtrip_review_role={roundTrip.ReviewRole}; runtime_field_present={item.TryGetProperty("runtime", out _)}");
     }
 
     private static QueueItem CreateItem(string executionUnit, string workerRole, string reviewRole)


### PR DESCRIPTION
# G798: canonical config and queue role vocabulary

Closes #1741

## Summary

This PR keeps the historical `[roles]` config readable without treating vendor/runtime names as logical roles, routes all newly created queue role defaults through the G795 `LogicalRoleNormalizer`, and removes the hardcoded `coder` recovery value. Existing queue-state values remain displayable and round-trippable; no runtime field was added to queue-state.

## Acceptance Criteria evidence

### AC 1 — legacy config values are reported, not treated as roles

```text
AC 1/AC 2 legacy_role_mappings JSON:
{
  "legacy_role_mappings": {
    "implement": "Claude",
    "review": "Codex",
    "interview": "Claude",
    "clarify": "Codex"
  }
}
```

The loader records all four non-logical values in `RoleMappings.LegacyValues`; canonical names and G795 aliases are normalized through the shared helper.

### AC 2 — the exact historical four-line config remains usable and unchanged

```text
AC2 exit_code=0; config_bytes_unchanged=True
```

The test writes exactly the four historical lines, runs the read-only automation summary, and compares the config bytes before/after.

### AC 3 — seed, enqueue, recovery, and retire writers use the logical vocabulary

```text
AC3 seed worker_role=builder; review_role=reviewer; queue-enqueue worker_role=builder; review_role=reviewer; coder_written=false
```

The focused writer tests additionally deserialize the newly recovered and newly retired queue items and assert `worker_role=builder`, `review_role=reviewer`; existing queue items are preserved as read.

### AC 4 — every legacy queue value remains readable and displayed

```text
AC4 intent explain output:
# Intent explain — G798-claude-codex
- worker role: Claude
- review role: Codex
# Intent explain — G798-implement-intake
- worker role: implement
- review role: intake
# Intent explain — G798-clarify-interview
- worker role: clarify
- review role: interview
# Intent explain — G798-fix-queue
- worker role: fix
- review role: queue
# Intent explain — G798-review-coder
- worker role: review
- review role: coder
```

### AC 5 — duplicate detection still sees legacy/canonical pairs

```text
AC5 duplicate_groups=1; execution_unit=G798; entries=2; winner=unresolved
```

### AC 6 — queue-state has no runtime field; consumer inventory is read-only

```text
AC6/AC7 queue-state JSON:
{
  "schema_version": "1",
  "items": [
    {
      "execution_unit": "G798-opencode",
      "worker_role": "opencode",
      "review_role": "opencode",
      "priority": "normal",
      "priority_revision": 0
    }
  ]
}
```

The serialized item has no `runtime` property. The following is the verbatim source inventory captured at this head; each named access is classified so pass-through/equality metadata reads are not confused with runtime dispatch:

```text
$ for spec in 'src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs:459:460' 'src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs:542:543' 'src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs:809:810' 'src/IntentSystem.Cli/Commands/QueueStateForwardDeltaAnalyzer.cs:141:142' 'src/IntentSystem.Cli/Commands/QueueCommandSupport.cs:50:51' 'src/IntentSystem.Cli/Commands/IntentExplainCommand.cs:137:138' 'src/IntentSystem.Cli/Commands/IntentExplainCommand.cs:315:316' 'src/IntentSystem.Cli/Commands/DuplicateQueueItemRules.cs:121:122'; do
> file=${spec%%:*}; rest=${spec#*:}; start=${rest%%:*}; end=${rest##*:}; echo "--- $file:$start-$end"; nl -ba "$file" | sed -n "${start},${end}p"; done
--- src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs:459-460
   459                WorkerRole = current.WorkerRole,
   460                ReviewRole = current.ReviewRole,
--- src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs:542-543
   542            WorkerRole = item.WorkerRole,
   543            ReviewRole = item.ReviewRole,
--- src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs:809-810
   809                    WorkerRole = item.WorkerRole,
   810                    ReviewRole = item.ReviewRole,
--- src/IntentSystem.Cli/Commands/QueueStateForwardDeltaAnalyzer.cs:141-142
   141            || !string.Equals(head.WorkerRole, working.WorkerRole, StringComparison.Ordinal)
   142            || !string.Equals(head.ReviewRole, working.ReviewRole, StringComparison.Ordinal)
--- src/IntentSystem.Cli/Commands/QueueCommandSupport.cs:50-51
    50        writer.WriteLine($"Worker role: {item.WorkerRole}");
    51        writer.WriteLine($"Review role: {item.ReviewRole}");
--- src/IntentSystem.Cli/Commands/IntentExplainCommand.cs:137-138
   137            writer.WriteLine($"- worker role: {result.QueueItem.WorkerRole}");
   138            writer.WriteLine($"- review role: {result.QueueItem.ReviewRole}");
--- src/IntentSystem.Cli/Commands/IntentExplainCommand.cs:315-316
   315            WorkerRole = item.WorkerRole,
   316            ReviewRole = item.ReviewRole,
--- src/IntentSystem.Cli/Commands/DuplicateQueueItemRules.cs:121-122
   121            ["worker_role"] = item.WorkerRole,
   122            ["review_role"] = item.ReviewRole,
$ set +e; rg -n -i '(if|switch|case).*(WorkerRole|ReviewRole)|(WorkerRole|ReviewRole).*(if|switch|case)' src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs src/IntentSystem.Cli/Commands/QueueStateForwardDeltaAnalyzer.cs src/IntentSystem.Cli/Commands/QueueCommandSupport.cs src/IntentSystem.Cli/Commands/IntentExplainCommand.cs src/IntentSystem.Cli/Commands/DuplicateQueueItemRules.cs; rc=$?; echo "QUEUE_ROLE_RUNTIME_BRANCH_SCAN_RC=$rc"
QUEUE_ROLE_RUNTIME_BRANCH_SCAN_RC=1
```

The inventory classifies recovery (459-460), closeout projection (542-543 and 809-810), and forward-delta equality (141-142) as pass-through/metadata comparisons. `QueueCommandSupport` and `IntentExplainCommand` (50-51, 137-138, 315-316) are display/projection consumers; `DuplicateQueueItemRules` (121-122) is the duplicate comparable-fields consumer. The targeted queue-role runtime-branch scan is empty (RC 1, no matches), demonstrating that no queue role value is used to select or dispatch runtime behavior.

### AC 7 — `opencode` config and queue values round-trip without refusal/coercion

```text
AC7 config_worker_role=opencode; config_review_role=opencode; queue_roundtrip_worker_role=opencode; queue_roundtrip_review_role=opencode; runtime_field_present=False
```

### AC 8 — parent absence/failure proof for the new G798 regressions

```text
$ git show origin/main:tests/IntentSystem.Cli.Tests/RoleVocabularyG798Tests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/RoleVocabularyG798Tests.cs' exists on disk, but not in 'origin/main'
PARENT_RC=128
$ git show origin/main:tests/IntentSystem.Cli.Tests/AutomationHostQueueItemRecoveryCommandTests.cs | rg -n 'LogicalRoleNormalizer|recovered\.WorkerRole|recovered\.ReviewRole'
PARENT_RECOVERY_ASSERTIONS_RC=1
$ git show origin/main:tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs | rg -n 'LogicalRoleNormalizer\.Builder|LogicalRoleNormalizer\.Reviewer'
PARENT_RETIRE_ASSERTIONS_RC=1
```

### AC 9 — full Release validation

```text
$ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore
Passed!  - Failed:     0, Passed:  5679, Skipped:     1, Total:  5680
```

Focused G798/config/writer run: `Passed: 97, Failed: 0, Skipped: 0, Total: 97`.

## Scope boundaries

- No queue-state `runtime` field, vendor enum, Steward behavior, guide-route rename, or other domain migration was added.
- Existing queue-state role strings are not rewritten; only new writer defaults are canonicalized.
- This PR is prepare-only and does not publish, tag, release, or mutate host metadata.
