### PR TITLE
G796: route notifications by event kind and enforce Steward boundary

### DIFF
--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -301,6 +301,7 @@ internal static class NotifyCommand
         // the operator has recorded a Steward seat. A topology that is absent
         // or unreadable leaves the historical caller-supplied destination in
         // place; the existing preflight still reports that structural issue.
+        NotifyRuling? upstreamRuling = null;
         if (operation is OperationDelegate or OperationReport or OperationEscalate)
         {
             var eventKind = NotifyEventKindRouting.ResolveForOperation(
@@ -334,11 +335,70 @@ internal static class NotifyCommand
                     fallbackTarget),
             };
 
+            var isStewardJudgement = LogicalRoleNormalizer.TryNormalize(
+                    options.FromRole,
+                    out var canonicalFromRole,
+                    out _)
+                && string.Equals(canonicalFromRole, LogicalRoleNormalizer.Steward, StringComparison.Ordinal)
+                && NotifyEventKindRouting.IsJudgement(eventKind);
+            var downstreamEvidenceResolved = true;
+            if (isStewardJudgement)
+            {
+                var upstreamLookup = NotifyPendingDelegationStore.Find(
+                    routingRoot,
+                    options.Domain,
+                    options.Team,
+                    options.TaskId!);
+                if (!upstreamLookup.Resolved
+                    || upstreamLookup.Record is not { } upstreamRecord)
+                {
+                    Emit(writer, options.Format, FailureResult(
+                        operation,
+                        options,
+                        SessionLayerMode.Default,
+                        "steward-boundary-refused",
+                        $"Steward judgement refused for task '{options.TaskId}': no recorded upstream Architect ruling/delegation was found."));
+                    return 1;
+                }
+
+                if (!NotifyRulingRelay.TryResolveUpstreamArchitectRuling(
+                        upstreamRecord,
+                        out upstreamRuling,
+                        out var upstreamError))
+                {
+                    Emit(writer, options.Format, FailureResult(
+                        operation,
+                        options,
+                        SessionLayerMode.Default,
+                        "steward-boundary-refused",
+                        upstreamError));
+                    return 1;
+                }
+
+                downstreamEvidenceResolved = NotifyDelegationExecutionEvidence.TryResolveDownstreamReference(
+                    routingRoot,
+                    upstreamRecord,
+                    options.DownstreamDelegationReference,
+                    out _,
+                    out var downstreamEvidenceError);
+                if (!downstreamEvidenceResolved)
+                {
+                    Emit(writer, options.Format, FailureResult(
+                        operation,
+                        options,
+                        SessionLayerMode.Default,
+                        "steward-boundary-refused",
+                        downstreamEvidenceError));
+                    return 1;
+                }
+            }
+
             if (!NotifyRulingRelay.TryValidateStewardAnswer(
                     options.FromRole,
                     eventKind,
                     options.ToRole,
                     options.DownstreamDelegationReference,
+                    downstreamEvidenceResolved,
                     out var stewardshipError))
             {
                 Emit(writer, options.Format, FailureResult(
@@ -350,7 +410,7 @@ internal static class NotifyCommand
                 return 1;
             }
 
-            if (!TryPrepareRuling(options, out var ruling, out var rulingError))
+            if (!TryPrepareRuling(options, upstreamRuling, out var ruling, out var rulingError))
             {
                 Emit(writer, options.Format, FailureResult(
                     operation,
@@ -2387,6 +2447,7 @@ internal static class NotifyCommand
             Cwd = cwd,
             Kind = kind,
             LaunchArguments = launchArguments,
+            Ruling = options.PreparedRuling,
         };
     }
 
@@ -2697,6 +2758,7 @@ internal static class NotifyCommand
 
     private static bool TryPrepareRuling(
         NotifyOptions options,
+        NotifyRuling? upstreamRuling,
         out NotifyRuling? ruling,
         out string error)
     {
@@ -2706,6 +2768,55 @@ internal static class NotifyCommand
             || options.RulingOrigin is not null
             || options.RulingDigest is not null
             || options.RulingEnvelopeFields.Count > 0;
+
+        if (upstreamRuling is not null)
+        {
+            // A Steward report/escalation inherits the durable Architect
+            // ruling. Envelope fields are additive; supplying a ruling
+            // payload/origin/digest asks us to prove it is the same ruling.
+            var hasRulingIdentity = options.RulingPayload is not null
+                || options.RulingOrigin is not null
+                || options.RulingDigest is not null;
+            if (!hasRulingIdentity)
+            {
+                if (!NotifyRulingEnvelope.TryCreate(
+                        upstreamRuling,
+                        options.RulingEnvelopeFields,
+                        out _,
+                        out error))
+                {
+                    return false;
+                }
+
+                ruling = upstreamRuling;
+                return true;
+            }
+
+            if (!NotifyRuling.TryCreate(
+                    options.RulingPayload,
+                    options.RulingOrigin,
+                    options.RulingDigest,
+                    out var relayedRuling,
+                    out error)
+                || relayedRuling is null)
+            {
+                return false;
+            }
+
+            if (!NotifyRulingRelay.TryRelay(
+                    upstreamRuling,
+                    relayedRuling,
+                    options.RulingEnvelopeFields,
+                    out var relay))
+            {
+                error = relay.Summary ?? "Steward ruling relay was refused.";
+                return false;
+            }
+
+            ruling = upstreamRuling;
+            return true;
+        }
+
         if (!hasRulingMetadata)
         {
             return true;

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -16,10 +16,10 @@ internal static class NotifyCommand
     private const string OperationDispose = "dispose";
     internal const string OperationStatus = "status";
     internal const string OperationSupervise = "supervise";
-    private const string CompletionEventKind = "completion";
-    private const string BlockedEventKind = "blocked";
-    private const string QuestionEventKind = "question";
-    private const string EscalationEventKind = "escalation";
+    private const string CompletionEventKind = NotifyEventKindRouting.Completion;
+    private const string BlockedEventKind = NotifyEventKindRouting.Blocked;
+    private const string QuestionEventKind = NotifyEventKindRouting.Question;
+    private const string EscalationEventKind = NotifyEventKindRouting.Escalation;
     private const string FormatJson = "json";
     private const string FormatMarkdown = "markdown";
     private const string CopilotObservedPasteRiskProfile = "copilot-autopilot-observed-paste-risk";
@@ -35,11 +35,17 @@ internal static class NotifyCommand
         "Usage: intent-cli notify delegate --domain <d> [--team <t>] --from <role> --to <role> --report-to <role> "
         + "--task-id <id> --objective <text> [--input <value>]... --expected-artifact <value> "
         + "[--expected-artifact <value>]... --result-nonce <nonce> [--routing-root <host-root>] "
+        + "[--event-kind completion|transition|acknowledgement|escalation|question|blocked] "
+        + "[--ruling-payload <text> --ruling-origin <role> [--ruling-digest <sha256>] "
+        + "[--ruling-envelope-field <key=value>]... --downstream-delegation-reference <id>] "
         + "[--dry-run|--write] [--format markdown|json]";
 
     private const string ReportUsage =
         "Usage: intent-cli notify report --domain <d> --team <t> --from <role> --to <role> --task-id <id> "
         + "--status completed|blocked|question --artifact <value> --summary <text> "
+        + "[--event-kind completion|transition|acknowledgement|escalation|question|blocked] "
+        + "[--ruling-payload <text> --ruling-origin <role> [--ruling-digest <sha256>] "
+        + "[--ruling-envelope-field <key=value>]... --downstream-delegation-reference <id>] "
         + "[--routing-root <host-root>] [--report-root <role-work-root>] [--dry-run|--write] [--format markdown|json]";
 
     private const string CollectUsage =
@@ -56,7 +62,10 @@ internal static class NotifyCommand
 
     private const string EscalateUsage =
         "Usage: intent-cli notify escalate --domain <d> --team <t> --from <role> --task-id <id> "
-        + "--artifact <value> --summary <text> [--routing-root <host-root>] "
+        + "--artifact <value> --summary <text> [--event-kind escalation] "
+        + "[--ruling-payload <text> --ruling-origin <role> [--ruling-digest <sha256>] "
+        + "[--ruling-envelope-field <key=value>]... --downstream-delegation-reference <id>] "
+        + "[--routing-root <host-root>] "
         + "[--dry-run|--write] [--format markdown|json]";
 
     private const string DisposeUsage =
@@ -286,6 +295,91 @@ internal static class NotifyCommand
             }
 
             options = options with { Team = teamMode.ResolvedTeam };
+        }
+
+        // G796: resolve the event kind once, then route by that kind whenever
+        // the operator has recorded a Steward seat. A topology that is absent
+        // or unreadable leaves the historical caller-supplied destination in
+        // place; the existing preflight still reports that structural issue.
+        if (operation is OperationDelegate or OperationReport or OperationEscalate)
+        {
+            var eventKind = NotifyEventKindRouting.ResolveForOperation(
+                operation,
+                options.Status,
+                options.EventKind);
+            // Keep the historical JSON/result envelope byte-stable when the
+            // caller did not ask for the new field explicitly. The resolved
+            // value is carried internally for event emission and routing.
+            options = options with
+            {
+                EventKind = options.EventKind is null ? null : eventKind,
+                ResolvedEventKind = eventKind,
+            };
+
+            var topology = NotifyRoleTopologyStore.Resolve(
+                routingRoot,
+                options.Domain!,
+                options.Team!);
+            var stewardRecorded = topology.Resolved
+                && NotifyEventKindRouting.HasRecordedSteward(topology.Topology);
+            var fallbackTarget = string.Equals(operation, OperationEscalate, StringComparison.Ordinal)
+                ? "design"
+                : null;
+            options = options with
+            {
+                ToRole = NotifyEventKindRouting.ResolveTarget(
+                    eventKind,
+                    options.ToRole,
+                    stewardRecorded,
+                    fallbackTarget),
+            };
+
+            if (!NotifyRulingRelay.TryValidateStewardAnswer(
+                    options.FromRole,
+                    eventKind,
+                    options.ToRole,
+                    options.DownstreamDelegationReference,
+                    out var stewardshipError))
+            {
+                Emit(writer, options.Format, FailureResult(
+                    operation,
+                    options,
+                    SessionLayerMode.Default,
+                    "steward-boundary-refused",
+                    stewardshipError));
+                return 1;
+            }
+
+            if (!TryPrepareRuling(options, out var ruling, out var rulingError))
+            {
+                Emit(writer, options.Format, FailureResult(
+                    operation,
+                    options,
+                    SessionLayerMode.Default,
+                    "ruling-invalid",
+                    rulingError));
+                return 1;
+            }
+
+            if (ruling is not null
+                && LogicalRoleNormalizer.TryNormalize(options.ToRole, out var routedRole, out _)
+                && string.Equals(routedRole, LogicalRoleNormalizer.Steward, StringComparison.Ordinal)
+                && !NotifyRulingRelay.TryRelay(
+                    ruling,
+                    ruling.Payload,
+                    options.RulingEnvelopeFields,
+                    out var relay))
+            {
+                Emit(writer, options.Format, FailureResult(
+                    operation,
+                    options,
+                    SessionLayerMode.Default,
+                    relay.Cause ?? "ruling-relay-refused",
+                    relay.Summary ?? "Steward ruling relay was refused."));
+                return 1;
+            }
+
+            options = options with { PreparedRuling = ruling };
         }
 
         // G691's named not-applicable NotifyCommand surface is supervision.
@@ -2218,7 +2312,7 @@ internal static class NotifyCommand
     {
         Timestamp = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
         Team = options.Team!,
-        Kind = ReaderEventKind(operation, options.Status),
+        Kind = options.ResolvedEventKind ?? options.EventKind ?? ReaderEventKind(operation, options.Status),
         Unit = options.TaskId!,
         Summary = NotifyEventWriter.NormalizeSummary(
             string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
@@ -2227,6 +2321,11 @@ internal static class NotifyCommand
         Artifact = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
             ? options.Inputs.FirstOrDefault() ?? options.ExpectedArtifacts[0]
             : options.Artifact!,
+        Ruling = options.PreparedRuling,
+        RulingEnvelopeFields = options.RulingEnvelopeFields.Count == 0
+            ? null
+            : options.RulingEnvelopeFields,
+        DownstreamDelegationReference = options.DownstreamDelegationReference,
     };
 
     private static NotifyPendingDelegation BuildPendingDelegation(
@@ -2307,16 +2406,40 @@ internal static class NotifyCommand
             $"Report status '{status}' does not map to a documented reader-event kind.");
     }
 
+    private static void AppendRuling(StringBuilder builder, NotifyOptions options)
+    {
+        if (options.PreparedRuling is null)
+        {
+            return;
+        }
+
+        var envelope = new NotifyRulingEnvelope
+        {
+            Ruling = options.PreparedRuling,
+            Fields = options.RulingEnvelopeFields,
+        };
+        builder.AppendLine();
+        builder.Append("ruling-envelope: ");
+        builder.Append(JsonSerializer.Serialize(envelope));
+    }
+
     private static int ExecuteEscalation(
         TextWriter writer,
         NotifyOptions options,
         SessionLayerModeResolution resolution)
     {
+        var rulingPayload = options.PreparedRuling is null
+            ? null
+            : JsonSerializer.Serialize(new NotifyRulingEnvelope
+            {
+                Ruling = options.PreparedRuling,
+                Fields = options.RulingEnvelopeFields,
+            });
         var judgment = NotifyRecipientDeliveryJudgment.Resolve(
             options.RoutingRoot!,
             options.Domain!,
             options.Team!,
-            "design");
+            options.ToRole ?? "design");
         var path = judgment.UsesRecordedReaderAppend ? judgment.Target : null;
         if (path is null
             && !NotifyEventWriter.TryResolveWritePath(
@@ -2340,7 +2463,7 @@ internal static class NotifyCommand
                 resolution,
                 delivered: false,
                 eventAppended: false,
-                payload: null,
+                payload: rulingPayload,
                 reportCommand: null,
                 $"Dry-run: would append escalation to '{path}'.",
                 eventPath: path,
@@ -2352,10 +2475,15 @@ internal static class NotifyCommand
         {
             Timestamp = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
             Team = options.Team!,
-            Kind = EscalationEventKind,
+            Kind = options.ResolvedEventKind ?? options.EventKind ?? EscalationEventKind,
             Unit = options.TaskId!,
             Summary = NotifyEventWriter.NormalizeSummary(options.Summary!),
             Artifact = options.Artifact!,
+            Ruling = options.PreparedRuling,
+            RulingEnvelopeFields = options.RulingEnvelopeFields.Count == 0
+                ? null
+                : options.RulingEnvelopeFields,
+            DownstreamDelegationReference = options.DownstreamDelegationReference,
         };
         try
         {
@@ -2398,7 +2526,7 @@ internal static class NotifyCommand
             resolution,
             delivered,
             eventAppended: true,
-            payload: null,
+            payload: rulingPayload,
             reportCommand: null,
             delivered
                 ? $"Appended escalation for task '{options.TaskId}' to the recorded design reader; durable append satisfied delivery."
@@ -2444,6 +2572,24 @@ internal static class NotifyCommand
         }
         builder.AppendLine("result-prefix: ORCH_RESULT");
         builder.AppendLine($"result-nonce: {options.ResultNonce}");
+        var hasG796Extensions = options.EventKind is not null
+            || options.DownstreamDelegationReference is not null
+            || options.PreparedRuling is not null;
+        if (hasG796Extensions)
+        {
+            if (options.EventKind is not null)
+            {
+                builder.AppendLine();
+                builder.Append($"event-kind: {options.EventKind}");
+            }
+            if (options.DownstreamDelegationReference is not null)
+            {
+                builder.AppendLine();
+                builder.Append($"downstream-delegation-reference: {options.DownstreamDelegationReference}");
+            }
+            AppendRuling(builder, options);
+            builder.AppendLine();
+        }
         builder.Append("completion-marker: When the artifact is ready, concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Do not precompose the marker in this task block.");
         return builder.ToString();
     }
@@ -2511,15 +2657,77 @@ internal static class NotifyCommand
 
     private static string ShellQuote(string value) => $"'{value.Replace("'", "'\\''", StringComparison.Ordinal)}'";
 
-    private static string BuildReportPayload(NotifyOptions options) => JsonSerializer.Serialize(new
+    private static string BuildReportPayload(NotifyOptions options)
     {
-        notification = OperationReport,
-        task_id = options.TaskId,
-        status = options.Status,
-        from_role = options.FromRole,
-        artifact = options.Artifact,
-        summary = NotifyEventWriter.NormalizeSummary(options.Summary!),
-    });
+        var summary = NotifyEventWriter.NormalizeSummary(options.Summary!);
+        if (options.EventKind is null
+            && options.PreparedRuling is null
+            && options.DownstreamDelegationReference is null
+            && options.RulingEnvelopeFields.Count == 0)
+        {
+            // Preserve the pre-G796 report envelope byte-for-byte for callers
+            // that do not opt into the new event/ruling fields.
+            return JsonSerializer.Serialize(new
+            {
+                notification = OperationReport,
+                task_id = options.TaskId,
+                status = options.Status,
+                from_role = options.FromRole,
+                artifact = options.Artifact,
+                summary,
+            });
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            notification = OperationReport,
+            task_id = options.TaskId,
+            event_kind = options.ResolvedEventKind ?? options.EventKind,
+            status = options.Status,
+            from_role = options.FromRole,
+            artifact = options.Artifact,
+            summary,
+            downstream_delegation_reference = options.DownstreamDelegationReference,
+            ruling = options.PreparedRuling,
+            ruling_envelope_fields = options.RulingEnvelopeFields.Count == 0
+                ? null
+                : options.RulingEnvelopeFields,
+        });
+    }
+
+    private static bool TryPrepareRuling(
+        NotifyOptions options,
+        out NotifyRuling? ruling,
+        out string error)
+    {
+        ruling = null;
+        error = string.Empty;
+        var hasRulingMetadata = options.RulingPayload is not null
+            || options.RulingOrigin is not null
+            || options.RulingDigest is not null
+            || options.RulingEnvelopeFields.Count > 0;
+        if (!hasRulingMetadata)
+        {
+            return true;
+        }
+
+        if (!NotifyRuling.TryCreate(
+                options.RulingPayload,
+                options.RulingOrigin,
+                options.RulingDigest,
+                out ruling,
+                out error)
+            || ruling is null)
+        {
+            return false;
+        }
+
+        return NotifyRulingEnvelope.TryCreate(
+            ruling,
+            options.RulingEnvelopeFields,
+            out _,
+            out error);
+    }
 
     private static NotifyInlinePayloadWarning? ResolveInlinePayloadWarning(NotifyOptions options, string payload)
     {
@@ -2586,6 +2794,9 @@ internal static class NotifyCommand
             TaskId = options.TaskId!,
             Status = options.Status,
             Artifact = options.Artifact,
+            EventKind = options.EventKind,
+            Ruling = options.PreparedRuling,
+            DownstreamDelegationReference = options.DownstreamDelegationReference,
             Delivered = delivered,
             EventAppended = eventAppended,
             EventPath = eventPath,
@@ -2653,6 +2864,9 @@ internal static class NotifyCommand
             TaskId = options.TaskId!,
             Status = options.Status,
             Artifact = options.Artifact,
+            EventKind = options.EventKind,
+            Ruling = options.PreparedRuling,
+            DownstreamDelegationReference = options.DownstreamDelegationReference,
             Delivered = false,
             EventAppended = false,
             EventPath = null,
@@ -2718,6 +2932,15 @@ internal static class NotifyCommand
             }
         }
         writer.WriteLine($"- delivered: {result.Delivered.ToString().ToLowerInvariant()}");
+        if (result.EventKind is not null)
+        {
+            writer.WriteLine($"- event kind: {result.EventKind}");
+            writer.WriteLine($"- routed to role: {result.ToRole ?? "<unresolved>"}");
+        }
+        if (result.Ruling is { } ruling)
+        {
+            writer.WriteLine($"- ruling: origin={ruling.Origin}; digest={ruling.Digest}; payload-bytes={ruling.PayloadBytes.Count}");
+        }
         if (result.DeliveryBasis is not null)
         {
             writer.WriteLine($"- delivery basis: {result.DeliveryBasis}");
@@ -2904,6 +3127,11 @@ internal static class NotifyCommand
         string? status = null;
         string? artifact = null;
         string? summary = null;
+        string? eventKind = null;
+        string? rulingPayload = null;
+        string? rulingDigest = null;
+        string? rulingOrigin = null;
+        string? downstreamDelegationReference = null;
         string? dispositionKind = null;
         string? actor = null;
         string? reason = null;
@@ -2927,6 +3155,7 @@ internal static class NotifyCommand
         int? timeoutMilliseconds = null;
         var inputs = new List<string>();
         var expectedArtifacts = new List<string>();
+        var rulingEnvelopeFields = new Dictionary<string, string>(StringComparer.Ordinal);
         var preApprovalAcceptRules = new List<NotifyPreApprovalRule>();
         var preApprovalEscalateRules = new List<NotifyPreApprovalRule>();
         var scopedPolicies = new List<NotifyScopedPromptPolicy>();
@@ -2956,6 +3185,27 @@ internal static class NotifyCommand
                 case "--status": if (!ReadValue(args, ref index, argument, out status, out error)) return false; break;
                 case "--artifact": if (!ReadValue(args, ref index, argument, out artifact, out error)) return false; break;
                 case "--summary": if (!ReadValue(args, ref index, argument, out summary, out error)) return false; break;
+                case "--event-kind": if (!ReadValue(args, ref index, argument, out eventKind, out error)) return false; break;
+                case "--ruling-payload": if (!ReadValue(args, ref index, argument, out rulingPayload, out error)) return false; break;
+                case "--ruling-digest": if (!ReadValue(args, ref index, argument, out rulingDigest, out error)) return false; break;
+                case "--ruling-origin": if (!ReadValue(args, ref index, argument, out rulingOrigin, out error)) return false; break;
+                case "--downstream-delegation-reference":
+                case "--downstream-delegation":
+                case "--downstream-reference":
+                    if (!ReadValue(args, ref index, argument, out downstreamDelegationReference, out error)) return false;
+                    break;
+                case "--ruling-envelope-field":
+                    if (!ReadValue(args, ref index, argument, out var envelopeField, out error)) return false;
+                    var separator = envelopeField!.IndexOf('=');
+                    if (separator <= 0 || separator == envelopeField.Length - 1)
+                    {
+                        error = "--ruling-envelope-field requires <key=value> with a non-empty one-line value.";
+                        return false;
+                    }
+                    var envelopeKey = envelopeField[..separator];
+                    var envelopeValue = envelopeField[(separator + 1)..];
+                    rulingEnvelopeFields[envelopeKey] = envelopeValue;
+                    break;
                 case "--kind": if (!ReadValue(args, ref index, argument, out dispositionKind, out error)) return false; break;
                 case "--actor": if (!ReadValue(args, ref index, argument, out actor, out error)) return false; break;
                 case "--reason": if (!ReadValue(args, ref index, argument, out reason, out error)) return false; break;
@@ -3163,6 +3413,12 @@ internal static class NotifyCommand
             Status = status,
             Artifact = artifact,
             Summary = summary,
+            EventKind = eventKind,
+            RulingPayload = rulingPayload,
+            RulingDigest = rulingDigest,
+            RulingOrigin = rulingOrigin,
+            DownstreamDelegationReference = downstreamDelegationReference,
+            RulingEnvelopeFields = rulingEnvelopeFields,
             DispositionKind = dispositionKind,
             Actor = actor,
             Reason = reason,
@@ -3267,6 +3523,44 @@ internal static class NotifyCommand
             && operation is not OperationReport and not OperationCollect and not OperationReconcile)
         {
             error = "--report-root is supported only by notify report, notify collect, and notify reconcile.";
+            return false;
+        }
+
+        if (options.EventKind is not null
+            && !NotifyEventKindRouting.TryNormalize(options.EventKind, out _, out error))
+        {
+            return false;
+        }
+
+        if (options.EventKind is not null
+            && operation is not OperationDelegate and not OperationReport and not OperationEscalate)
+        {
+            error = "--event-kind is supported only by notify delegate, report, and escalate.";
+            return false;
+        }
+
+        var hasRulingOption = options.RulingPayload is not null
+            || options.RulingOrigin is not null
+            || options.RulingDigest is not null
+            || options.RulingEnvelopeFields.Count > 0
+            || options.DownstreamDelegationReference is not null;
+        if (hasRulingOption
+            && operation is not OperationDelegate and not OperationReport and not OperationEscalate)
+        {
+            error = "ruling and downstream-delegation options are supported only by notify delegate, report, and escalate.";
+            return false;
+        }
+
+        if (options.DownstreamDelegationReference is not null
+            && !IsSafeIdentity(options.DownstreamDelegationReference))
+        {
+            error = "--downstream-delegation-reference must be a safe delegation identity.";
+            return false;
+        }
+
+        if (options.RulingOrigin is not null && !IsSafeIdentity(options.RulingOrigin))
+        {
+            error = "--ruling-origin must be a canonical logical role or accepted role alias.";
             return false;
         }
         if (string.Equals(operation, OperationReconcile, StringComparison.Ordinal))
@@ -3578,6 +3872,15 @@ internal sealed record NotifyOptions
     public string? Status { get; init; }
     public string? Artifact { get; init; }
     public string? Summary { get; init; }
+    public string? EventKind { get; init; }
+    internal string? ResolvedEventKind { get; init; }
+    public string? RulingPayload { get; init; }
+    public string? RulingDigest { get; init; }
+    public string? RulingOrigin { get; init; }
+    public string? DownstreamDelegationReference { get; init; }
+    public IReadOnlyDictionary<string, string> RulingEnvelopeFields { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+    public NotifyRuling? PreparedRuling { get; init; }
     public string? DispositionKind { get; init; }
     public string? Actor { get; init; }
     public string? Reason { get; init; }
@@ -3627,6 +3930,9 @@ internal sealed record NotifyResult
     [JsonPropertyName("task_id")] public required string TaskId { get; init; }
     [JsonPropertyName("status")] public string? Status { get; init; }
     [JsonPropertyName("artifact")] public string? Artifact { get; init; }
+    [JsonPropertyName("event_kind")] public string? EventKind { get; init; }
+    [JsonPropertyName("ruling")] public NotifyRuling? Ruling { get; init; }
+    [JsonPropertyName("downstream_delegation_reference")] public string? DownstreamDelegationReference { get; init; }
     [JsonPropertyName("delivered")] public required bool Delivered { get; init; }
     [JsonPropertyName("event_appended")] public required bool EventAppended { get; init; }
     [JsonPropertyName("event_path")] public string? EventPath { get; init; }
@@ -4022,4 +4328,13 @@ internal sealed record NotifyDesignEvent
     [JsonPropertyName("unit")] public required string Unit { get; init; }
     [JsonPropertyName("summary")] public required string Summary { get; init; }
     [JsonPropertyName("artifact")] public required string Artifact { get; init; }
+    [JsonPropertyName("ruling")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public NotifyRuling? Ruling { get; init; }
+    [JsonPropertyName("ruling_envelope_fields")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? RulingEnvelopeFields { get; init; }
+    [JsonPropertyName("downstream_delegation_reference")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DownstreamDelegationReference { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
@@ -425,6 +425,85 @@ internal sealed record NotifyDelegationExecutionEvidence
         return null;
     }
 
+    /// <summary>
+    /// Resolves a Steward's downstream reference against the same measured
+    /// evidence set used by G788.  A reference is accepted only when it is
+    /// present in a token-carrying pending ledger, report outbox, or
+    /// notification event (or names the measured execution-unit queue/chain
+    /// evidence).  A syntactically safe but unknown identifier therefore
+    /// cannot satisfy the Steward judgement gate.
+    /// </summary>
+    internal static bool TryResolveDownstreamReference(
+        string routingRoot,
+        NotifyPendingDelegation parent,
+        string? reference,
+        out string evidence,
+        out string error)
+    {
+        evidence = string.Empty;
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            error = "downstream delegation reference is required.";
+            return false;
+        }
+
+        var unitPattern = ResolveUnitPattern(routingRoot, parent.Domain, out var patternError);
+        if (patternError is not null)
+        {
+            error = patternError;
+            return false;
+        }
+
+        var parentToken = unitPattern is null
+            ? null
+            : ExtractExecutionUnitToken(parent.TaskId, parent.Objective, parent.Inputs, unitPattern);
+        if (parentToken is null)
+        {
+            error = $"downstream delegation reference '{reference}' could not be matched because the parent execution-unit token is absent.";
+            return false;
+        }
+
+        var measured = Resolve(routingRoot, parent, parent.DispatchedAt);
+        if (!measured.IsResolved)
+        {
+            error = measured.Error
+                ?? $"downstream delegation reference '{reference}' could not be resolved because evidence sources are unreadable.";
+            return false;
+        }
+
+        var details = measured.PendingLedgerDetails
+            .Concat(measured.ReportOutboxDetails)
+            .Concat(measured.NotificationEventDetails)
+            .Concat(measured.QueueStateDetails)
+            .Concat(measured.ContinuationChainDetails)
+            .ToArray();
+        foreach (var detail in details)
+        {
+            if (detail.Contains($"task_id={reference}", StringComparison.Ordinal)
+                || detail.Contains($"unit={reference}", StringComparison.Ordinal))
+            {
+                evidence = detail;
+                error = string.Empty;
+                return true;
+            }
+        }
+
+        // Queue and continuation evidence carry the configured unit token,
+        // not a child task id.  Permit that explicit token reference only
+        // when one of those non-artifact carriers was actually measured.
+        if (string.Equals(reference, parentToken, StringComparison.OrdinalIgnoreCase)
+            && (measured.QueueStateDetails.Count > 0 || measured.ContinuationChainDetails.Count > 0))
+        {
+            evidence = measured.QueueStateDetails.FirstOrDefault()
+                ?? measured.ContinuationChainDetails.First();
+            error = string.Empty;
+            return true;
+        }
+
+        error = $"downstream delegation reference '{reference}' did not resolve in G788 execution evidence ({measured.SourceCountSummary}).";
+        return false;
+    }
+
     private static readonly Regex CandidateExecutionUnitPattern = new(
         @"(?<![A-Za-z0-9])(?:[A-Za-z][A-Za-z0-9]*-)?G[0-9]+(?![A-Za-z0-9])",
         RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);

--- a/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
@@ -255,6 +255,12 @@ internal sealed record NotifyDelegationExecutionEvidence
 
                         using var document = JsonDocument.Parse(line);
                         var root = document.RootElement;
+                        var eventTeam = ReadString(root, "team");
+                        if (!string.Equals(eventTeam, record.Team, StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
                         var eventUnit = ReadString(root, "unit");
                         var summary = ReadString(root, "summary");
                         var artifact = ReadString(root, "artifact");
@@ -479,8 +485,12 @@ internal sealed record NotifyDelegationExecutionEvidence
             .ToArray();
         foreach (var detail in details)
         {
-            if (detail.Contains($"task_id={reference}", StringComparison.Ordinal)
-                || detail.Contains($"unit={reference}", StringComparison.Ordinal))
+            var taskId = ReadCarrierField(detail, TaskIdCarrierFieldPattern);
+            var unit = ReadCarrierField(detail, UnitCarrierFieldPattern);
+            var executionUnit = ReadCarrierField(detail, ExecutionUnitCarrierFieldPattern);
+            if (string.Equals(taskId, reference, StringComparison.Ordinal)
+                || string.Equals(unit, reference, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(executionUnit, reference, StringComparison.OrdinalIgnoreCase))
             {
                 evidence = detail;
                 error = string.Empty;
@@ -504,9 +514,27 @@ internal sealed record NotifyDelegationExecutionEvidence
         return false;
     }
 
+    private static string? ReadCarrierField(string detail, Regex fieldPattern)
+    {
+        var match = fieldPattern.Match(detail);
+        return match.Success ? match.Groups["value"].Value : null;
+    }
+
     private static readonly Regex CandidateExecutionUnitPattern = new(
         @"(?<![A-Za-z0-9])(?:[A-Za-z][A-Za-z0-9]*-)?G[0-9]+(?![A-Za-z0-9])",
         RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    private static readonly Regex TaskIdCarrierFieldPattern = new(
+        @"(?<![A-Za-z0-9_])task_id=(?<value>[^;]+)",
+        RegexOptions.CultureInvariant);
+
+    private static readonly Regex UnitCarrierFieldPattern = new(
+        @"(?<![A-Za-z0-9_])unit=(?<value>[^;]+)",
+        RegexOptions.CultureInvariant);
+
+    private static readonly Regex ExecutionUnitCarrierFieldPattern = new(
+        @"(?<![A-Za-z0-9_])execution_unit=(?<value>[^;]+)",
+        RegexOptions.CultureInvariant);
 
     private static readonly Regex DefaultExecutionUnitPattern = new(
         @"^(?:[A-Za-z][A-Za-z0-9]*-)?G[0-9]+$",

--- a/src/IntentSystem.Cli/Commands/NotifyEventKindRouting.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyEventKindRouting.cs
@@ -1,0 +1,156 @@
+using System.Collections.ObjectModel;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// The event-kind routing contract introduced by G796.  A logical seat is a
+/// responsibility, not a destination for every message: routine events may
+/// be absorbed by the Steward while judgement stays on a specialist seat.
+/// This type is deliberately small and transport-neutral so delegate, report,
+/// escalation, and reader-event paths all use the same decision.
+/// </summary>
+internal static class NotifyEventKindRouting
+{
+    public const string Completion = "completion";
+    public const string Transition = "transition";
+    public const string Acknowledgement = "acknowledgement";
+    public const string Escalation = "escalation";
+    public const string Question = "question";
+    public const string Blocked = "blocked";
+
+    public static IReadOnlyList<string> SupportedKinds { get; } =
+    [
+        Completion,
+        Transition,
+        Acknowledgement,
+        Escalation,
+        Question,
+        Blocked,
+    ];
+
+    private static readonly IReadOnlyDictionary<string, string> Aliases =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["acknowledgment"] = Acknowledgement,
+        });
+
+    public static bool IsRoutine(string eventKind) =>
+        eventKind is Completion or Transition or Acknowledgement;
+
+    public static bool IsJudgement(string eventKind) =>
+        eventKind is Escalation or Question or Blocked;
+
+    public static bool TryNormalize(string? value, out string? normalized, out string error)
+    {
+        normalized = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            error = "event kind is required when supplied.";
+            return false;
+        }
+
+        var candidate = value.Trim().ToLowerInvariant();
+        if (SupportedKinds.Contains(candidate, StringComparer.Ordinal))
+        {
+            normalized = candidate;
+            error = string.Empty;
+            return true;
+        }
+
+        if (Aliases.TryGetValue(candidate, out var alias))
+        {
+            normalized = alias;
+            error = string.Empty;
+            return true;
+        }
+
+        error = $"event kind '{value}' is unknown; accepted kinds are {string.Join(", ", SupportedKinds)}.";
+        return false;
+    }
+
+    /// <summary>
+    /// Maps the existing notify operations to their event-kind vocabulary.
+    /// The optional explicit value is useful for transition and acknowledgement
+    /// events, which do not have a dedicated command operation.
+    /// </summary>
+    public static string ResolveForOperation(string operation, string? status, string? explicitKind)
+    {
+        if (explicitKind is not null
+            && TryNormalize(explicitKind, out var normalized, out _)
+            && normalized is not null)
+        {
+            return normalized;
+        }
+
+        if (string.Equals(operation, "escalate", StringComparison.Ordinal))
+        {
+            return Escalation;
+        }
+
+        if (string.Equals(operation, "delegate", StringComparison.Ordinal))
+        {
+            return Question;
+        }
+
+        if (status is not null
+            && string.Equals(status, "completed", StringComparison.Ordinal))
+        {
+            return Completion;
+        }
+
+        if (status is not null
+            && string.Equals(status, "blocked", StringComparison.Ordinal))
+        {
+            return Blocked;
+        }
+
+        return Question;
+    }
+
+    /// <summary>
+    /// Returns the effective logical destination.  With no recorded Steward,
+    /// <paramref name="currentTarget"/> is returned unchanged, preserving the
+    /// pre-G796 route.  For a question explicitly aimed at review, the
+    /// Reviewer remains the specialist; all other judgement kinds use the
+    /// Architect.  A missing target is filled with the historical design alias
+    /// only for the escalation path.
+    /// </summary>
+    public static string? ResolveTarget(
+        string eventKind,
+        string? currentTarget,
+        bool stewardRecorded,
+        string? fallbackTarget = null)
+    {
+        if (!stewardRecorded)
+        {
+            return currentTarget ?? fallbackTarget;
+        }
+
+        if (IsRoutine(eventKind))
+        {
+            return LogicalRoleNormalizer.Steward;
+        }
+
+        if (eventKind == Question
+            && LogicalRoleNormalizer.TryNormalize(currentTarget, out var normalized, out _)
+            && string.Equals(normalized, LogicalRoleNormalizer.Reviewer, StringComparison.Ordinal))
+        {
+            return LogicalRoleNormalizer.Reviewer;
+        }
+
+        return LogicalRoleNormalizer.Architect;
+    }
+
+    public static bool HasRecordedSteward(NotifyTeamTopology? topology)
+    {
+        if (topology is null)
+        {
+            return false;
+        }
+
+        return NotifyRoleTopologyStore.ResolveRecordedRole(
+            topology,
+            LogicalRoleNormalizer.Steward).Resolved;
+    }
+}
+

--- a/src/IntentSystem.Cli/Commands/NotifyEventKindRouting.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyEventKindRouting.cs
@@ -153,4 +153,3 @@ internal static class NotifyEventKindRouting
             LogicalRoleNormalizer.Steward).Resolved;
     }
 }
-

--- a/src/IntentSystem.Cli/Commands/NotifyPendingDelegationStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyPendingDelegationStore.cs
@@ -47,6 +47,7 @@ internal sealed record NotifyPendingDelegation
     [JsonPropertyName("cwd")] public string? Cwd { get; init; }
     [JsonPropertyName("kind")] public string? Kind { get; init; }
     [JsonPropertyName("launch_args")] public IReadOnlyList<string>? LaunchArguments { get; init; }
+    [JsonPropertyName("ruling")] public NotifyRuling? Ruling { get; init; }
     [JsonPropertyName("report_arrived")] public bool ReportArrived { get; init; }
     [JsonPropertyName("report_status")] public string? ReportStatus { get; init; }
     [JsonPropertyName("report_artifact")] public string? ReportArtifact { get; init; }
@@ -512,6 +513,7 @@ internal static class NotifyPendingDelegationStore
             Cwd = record.Cwd,
             Kind = record.Kind,
             LaunchArguments = record.LaunchArguments,
+            Ruling = record.Ruling,
             ReportArrived = record.ReportArrived,
             ReportStatus = record.ReportStatus,
             ReportArtifact = record.ReportArtifact,
@@ -689,6 +691,7 @@ internal static class NotifyPendingDelegationStore
         [JsonPropertyName("cwd")] public string? Cwd { get; init; }
         [JsonPropertyName("kind")] public string? Kind { get; init; }
         [JsonPropertyName("launch_args")] public IReadOnlyList<string>? LaunchArguments { get; init; }
+        [JsonPropertyName("ruling")] public NotifyRuling? Ruling { get; init; }
         [JsonPropertyName("report_arrived")] public bool ReportArrived { get; init; }
         [JsonPropertyName("report_status")] public string? ReportStatus { get; init; }
         [JsonPropertyName("report_artifact")] public string? ReportArtifact { get; init; }
@@ -719,6 +722,7 @@ internal static class NotifyPendingDelegationStore
             Cwd = Cwd,
             Kind = Kind,
             LaunchArguments = LaunchArguments,
+            Ruling = Ruling,
             ReportArrived = ReportArrived,
             ReportStatus = ReportStatus,
             ReportArtifact = ReportArtifact,

--- a/src/IntentSystem.Cli/Commands/NotifyRuling.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyRuling.cs
@@ -157,6 +157,49 @@ internal static class NotifyRulingRelay
     public static bool IsDigest(string? value) =>
         value is { Length: 64 } && value.All(char.IsAsciiHexDigit);
 
+    /// <summary>
+    /// Relays a ruling that was reconstructed by a downstream command.  The
+    /// source record is authoritative: payload bytes, digest, and origin must
+    /// remain identical, while the envelope may add only non-reserved fields.
+    /// </summary>
+    public static bool TryRelay(
+        NotifyRuling source,
+        NotifyRuling relayedRuling,
+        IReadOnlyDictionary<string, string>? envelopeFields,
+        out NotifyRulingRelayResult result)
+    {
+        if (source is null || !source.Verifies())
+        {
+            result = Refused("ruling-digest-mismatch", "The recorded upstream ruling does not verify before Steward relay.");
+            return false;
+        }
+
+        if (relayedRuling is null || !relayedRuling.Verifies())
+        {
+            result = Refused("ruling-digest-mismatch", "Steward relay refused: the relayed ruling digest does not verify.");
+            return false;
+        }
+
+        if (!string.Equals(source.Origin, relayedRuling.Origin, StringComparison.OrdinalIgnoreCase))
+        {
+            result = Refused(
+                "ruling-origin-mismatch",
+                $"Steward relay refused: ruling origin must remain '{source.Origin}', not '{relayedRuling.Origin}'.");
+            return false;
+        }
+
+        if (!source.PayloadBytes.SequenceEqual(relayedRuling.PayloadBytes)
+            || !string.Equals(source.Digest, relayedRuling.Digest, StringComparison.OrdinalIgnoreCase))
+        {
+            result = Refused(
+                "ruling-digest-mismatch",
+                $"Steward relay refused: ruling payload bytes or digest changed (expected '{source.Digest}', relayed '{relayedRuling.Digest}').");
+            return false;
+        }
+
+        return TryRelay(source, relayedRuling.Payload, envelopeFields, out result);
+    }
+
     public static bool TryRelay(
         NotifyRuling ruling,
         string? relayedPayload,
@@ -209,6 +252,21 @@ internal static class NotifyRulingRelay
         string? toRole,
         string? downstreamDelegationReference,
         out string error)
+        => TryValidateStewardAnswer(
+            fromRole,
+            eventKind,
+            toRole,
+            downstreamDelegationReference,
+            downstreamEvidenceResolved: !string.IsNullOrWhiteSpace(downstreamDelegationReference),
+            out error);
+
+    internal static bool TryValidateStewardAnswer(
+        string? fromRole,
+        string eventKind,
+        string? toRole,
+        string? downstreamDelegationReference,
+        bool downstreamEvidenceResolved,
+        out string error)
     {
         error = string.Empty;
         if (!LogicalRoleNormalizer.TryNormalize(fromRole, out var canonicalFrom, out error)
@@ -237,6 +295,12 @@ internal static class NotifyRulingRelay
             return false;
         }
 
+        if (!downstreamEvidenceResolved)
+        {
+            error = $"Steward answer refused for {normalizedKind}: downstream delegation reference '{downstreamDelegationReference}' did not resolve in recorded G788 execution evidence.";
+            return false;
+        }
+
         if (toRole is not null
             && LogicalRoleNormalizer.TryNormalize(toRole, out var canonicalTarget, out _)
             && canonicalTarget is not null
@@ -246,6 +310,56 @@ internal static class NotifyRulingRelay
             return false;
         }
 
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the ruling that was originally delivered by Architect to the
+    /// Steward.  A Steward must relay this durable source record; it may not
+    /// manufacture a new Architect-labelled ruling of its own.
+    /// </summary>
+    internal static bool TryResolveUpstreamArchitectRuling(
+        NotifyPendingDelegation? pending,
+        out NotifyRuling? ruling,
+        out string error)
+    {
+        ruling = null;
+        if (pending is null)
+        {
+            error = "Steward judgement refused: no recorded upstream Architect ruling/delegation was found.";
+            return false;
+        }
+
+        if (!LogicalRoleNormalizer.TryNormalize(pending.DelegatingRole, out var delegatingRole, out _)
+            || !string.Equals(delegatingRole, LogicalRoleNormalizer.Architect, StringComparison.Ordinal)
+            || !LogicalRoleNormalizer.TryNormalize(pending.RecipientRole, out var recipientRole, out _)
+            || !string.Equals(recipientRole, LogicalRoleNormalizer.Steward, StringComparison.Ordinal))
+        {
+            error = $"Steward judgement refused for task '{pending.TaskId}': the recorded delegation is not an Architect-to-Steward ruling.";
+            return false;
+        }
+
+        if (pending.Ruling is null)
+        {
+            error = $"Steward judgement refused for task '{pending.TaskId}': no upstream Architect ruling was recorded.";
+            return false;
+        }
+
+        if (!pending.Ruling.Verifies())
+        {
+            error = $"Steward judgement refused for task '{pending.TaskId}': recorded upstream ruling digest does not verify.";
+            return false;
+        }
+
+        if (!LogicalRoleNormalizer.TryNormalize(pending.Ruling.Origin, out var origin, out _)
+            || !string.Equals(origin, LogicalRoleNormalizer.Architect, StringComparison.Ordinal))
+        {
+            error = $"Steward judgement refused for task '{pending.TaskId}': upstream ruling origin must be Architect.";
+            return false;
+        }
+
+        ruling = pending.Ruling;
+        error = string.Empty;
         return true;
     }
 

--- a/src/IntentSystem.Cli/Commands/NotifyRuling.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyRuling.cs
@@ -1,0 +1,293 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Opaque specialist ruling carried through the notify envelope.  The CLI
+/// authenticates the bytes and their producer, but intentionally does not
+/// interpret the ruling text.
+/// </summary>
+internal sealed record NotifyRuling
+{
+    [JsonPropertyName("payload")]
+    public required string Payload { get; init; }
+
+    [JsonPropertyName("digest")]
+    public required string Digest { get; init; }
+
+    [JsonPropertyName("origin")]
+    public required string Origin { get; init; }
+
+    [JsonIgnore]
+    public IReadOnlyList<byte> PayloadBytes => Encoding.UTF8.GetBytes(Payload);
+
+    public bool Verifies() =>
+        string.Equals(Digest, NotifyRulingRelay.ComputeDigest(Payload), StringComparison.OrdinalIgnoreCase);
+
+    public static bool TryCreate(
+        string? payload,
+        string? origin,
+        string? suppliedDigest,
+        out NotifyRuling? ruling,
+        out string error)
+    {
+        ruling = null;
+        if (payload is null)
+        {
+            error = "ruling payload is required when ruling metadata is supplied.";
+            return false;
+        }
+
+        if (!LogicalRoleNormalizer.TryNormalize(origin, out var canonicalOrigin, out error)
+            || canonicalOrigin is null)
+        {
+            return false;
+        }
+
+        var digest = NotifyRulingRelay.ComputeDigest(payload);
+        if (suppliedDigest is not null)
+        {
+            if (!NotifyRulingRelay.IsDigest(suppliedDigest))
+            {
+                error = "ruling digest must be a 64-character SHA-256 hexadecimal value.";
+                return false;
+            }
+
+            if (!string.Equals(suppliedDigest, digest, StringComparison.OrdinalIgnoreCase))
+            {
+                error = $"ruling digest mismatch: supplied '{suppliedDigest.ToLowerInvariant()}', computed '{digest}'.";
+                return false;
+            }
+
+            digest = suppliedDigest.ToLowerInvariant();
+        }
+
+        ruling = new NotifyRuling
+        {
+            Payload = payload,
+            Digest = digest,
+            Origin = canonicalOrigin,
+        };
+        error = string.Empty;
+        return true;
+    }
+}
+
+/// <summary>
+/// Envelope used when a Steward relays an opaque ruling.  Additional fields
+/// are permitted, but reserved ruling fields cannot be shadowed by an
+/// envelope extension.
+/// </summary>
+internal sealed record NotifyRulingEnvelope
+{
+    [JsonPropertyName("ruling")]
+    public required NotifyRuling Ruling { get; init; }
+
+    [JsonPropertyName("fields")]
+    public IReadOnlyDictionary<string, string> Fields { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    public static bool TryCreate(
+        NotifyRuling ruling,
+        IReadOnlyDictionary<string, string>? fields,
+        out NotifyRulingEnvelope? envelope,
+        out string error)
+    {
+        envelope = null;
+        if (ruling is null || !ruling.Verifies())
+        {
+            error = "ruling digest mismatch: the supplied ruling does not verify before relay.";
+            return false;
+        }
+
+        var normalized = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (fields is not null)
+        {
+            foreach (var entry in fields)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Key)
+                    || entry.Key.IndexOfAny(['\r', '\n']) >= 0
+                    || entry.Key.Equals("payload", StringComparison.OrdinalIgnoreCase)
+                    || entry.Key.Equals("digest", StringComparison.OrdinalIgnoreCase)
+                    || entry.Key.Equals("origin", StringComparison.OrdinalIgnoreCase)
+                    || entry.Key.Equals("ruling", StringComparison.OrdinalIgnoreCase))
+                {
+                    error = $"ruling envelope field '{entry.Key}' is reserved or empty.";
+                    return false;
+                }
+
+                if (entry.Value is null
+                    || entry.Value.IndexOfAny(['\r', '\n']) >= 0)
+                {
+                    error = $"ruling envelope field '{entry.Key}' must be a one-line value.";
+                    return false;
+                }
+
+                normalized[entry.Key] = entry.Value;
+            }
+        }
+
+        envelope = new NotifyRulingEnvelope { Ruling = ruling, Fields = normalized };
+        error = string.Empty;
+        return true;
+    }
+}
+
+internal sealed record NotifyRulingRelayResult
+{
+    public required bool Accepted { get; init; }
+    public string? Cause { get; init; }
+    public string? Summary { get; init; }
+    public NotifyRuling? Ruling { get; init; }
+    public NotifyRulingEnvelope? Envelope { get; init; }
+}
+
+/// <summary>
+/// Shared ruling relay and Steward boundary checks.  This is deliberately
+/// independent from transport and model/runtime identity.
+/// </summary>
+internal static class NotifyRulingRelay
+{
+    public static string ComputeDigest(string payload) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+
+    public static bool IsDigest(string? value) =>
+        value is { Length: 64 } && value.All(char.IsAsciiHexDigit);
+
+    public static bool TryRelay(
+        NotifyRuling ruling,
+        string? relayedPayload,
+        IReadOnlyDictionary<string, string>? envelopeFields,
+        out NotifyRulingRelayResult result)
+    {
+        if (ruling is null)
+        {
+            result = Refused("ruling-missing", "A ruling is required before Steward relay.");
+            return false;
+        }
+
+        if (relayedPayload is null
+            || !string.Equals(relayedPayload, ruling.Payload, StringComparison.Ordinal)
+            || !string.Equals(ComputeDigest(relayedPayload ?? string.Empty), ruling.Digest, StringComparison.OrdinalIgnoreCase))
+        {
+            var computed = ComputeDigest(relayedPayload ?? string.Empty);
+            result = Refused(
+                "ruling-digest-mismatch",
+                $"Steward relay refused: ruling digest mismatch (expected '{ruling.Digest}', computed '{computed}').");
+            return false;
+        }
+
+        if (!NotifyRulingEnvelope.TryCreate(ruling, envelopeFields, out var envelope, out var envelopeError)
+            || envelope is null)
+        {
+            result = Refused("ruling-envelope-invalid", envelopeError);
+            return false;
+        }
+
+        result = new NotifyRulingRelayResult
+        {
+            Accepted = true,
+            Summary = "Steward relay accepted: ruling payload bytes and digest remain unchanged; envelope fields are additive.",
+            Ruling = ruling,
+            Envelope = envelope,
+        };
+        return true;
+    }
+
+    /// <summary>
+    /// A Steward is allowed to answer routine events.  Judgement events must
+    /// name the specialist downstream delegation that carries the answer.
+    /// The check intentionally consumes logical role/event kind only: runtime
+    /// and model declarations cannot bypass it.
+    /// </summary>
+    public static bool TryValidateStewardAnswer(
+        string? fromRole,
+        string eventKind,
+        string? toRole,
+        string? downstreamDelegationReference,
+        out string error)
+    {
+        error = string.Empty;
+        if (!LogicalRoleNormalizer.TryNormalize(fromRole, out var canonicalFrom, out error)
+            || canonicalFrom is null
+            || !string.Equals(canonicalFrom, LogicalRoleNormalizer.Steward, StringComparison.Ordinal))
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        if (!NotifyEventKindRouting.TryNormalize(eventKind, out var normalizedKind, out error)
+            || normalizedKind is null)
+        {
+            return false;
+        }
+
+        if (!NotifyEventKindRouting.IsJudgement(normalizedKind))
+        {
+            return true;
+        }
+
+        var requiredTarget = RequiredTarget(normalizedKind, toRole);
+        if (string.IsNullOrWhiteSpace(downstreamDelegationReference))
+        {
+            error = $"Steward answer refused for {normalizedKind}: required downstream delegation reference to {DisplayRole(requiredTarget)}.";
+            return false;
+        }
+
+        if (toRole is not null
+            && LogicalRoleNormalizer.TryNormalize(toRole, out var canonicalTarget, out _)
+            && canonicalTarget is not null
+            && !string.Equals(canonicalTarget, requiredTarget, StringComparison.Ordinal))
+        {
+            error = $"Steward answer refused for {normalizedKind}: required downstream target is {DisplayRole(requiredTarget)}, not '{toRole}'.";
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// G796's downstream check is intentionally a thin call to the G788
+    /// recognizer.  Keeping the call here prevents a second token parser from
+    /// drifting in field order or case handling.
+    /// </summary>
+    public static bool HasDownstreamDelegationEvidence(
+        string? taskId,
+        string? objective,
+        IEnumerable<string?>? inputs,
+        Regex executionUnitPattern,
+        string expectedExecutionUnit)
+    {
+        var token = NotifyDelegationExecutionEvidence.ExtractExecutionUnitToken(
+            taskId,
+            objective,
+            inputs,
+            executionUnitPattern);
+        return string.Equals(token, expectedExecutionUnit, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string RequiredTarget(string eventKind, string? toRole)
+    {
+        if (eventKind == NotifyEventKindRouting.Question
+            && LogicalRoleNormalizer.TryNormalize(toRole, out var normalized, out _)
+            && string.Equals(normalized, LogicalRoleNormalizer.Reviewer, StringComparison.Ordinal))
+        {
+            return LogicalRoleNormalizer.Reviewer;
+        }
+
+        return LogicalRoleNormalizer.Architect;
+    }
+
+    private static string DisplayRole(string role) =>
+        role == LogicalRoleNormalizer.Reviewer ? "Reviewer" : "Architect";
+
+    private static NotifyRulingRelayResult Refused(string cause, string summary) => new()
+    {
+        Accepted = false,
+        Cause = cause,
+        Summary = summary,
+    };
+}

--- a/tests/IntentSystem.Cli.Tests/NotifyRoutingG796Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyRoutingG796Tests.cs
@@ -1,0 +1,187 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Commands;
+using Xunit.Abstractions;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G796: event-kind routing and the mechanical Steward boundary. These tests
+/// stay transport-neutral so the routing decision can be audited without
+/// launching a process or changing a topology file.
+/// </summary>
+public sealed class NotifyRoutingG796Tests
+{
+    private readonly ITestOutputHelper output;
+
+    public NotifyRoutingG796Tests(ITestOutputHelper output) => this.output = output;
+
+    [Theory]
+    [InlineData("completion", "architect", "steward")]
+    [InlineData("transition", "architect", "steward")]
+    [InlineData("acknowledgement", "architect", "steward")]
+    [InlineData("escalation", "steward", "architect")]
+    [InlineData("question", "architect", "architect")]
+    [InlineData("question", "review", "reviewer")]
+    [InlineData("blocked", "steward", "architect")]
+    public void EveryEventKindUsesKindSpecificStewardRoute_G796(
+        string eventKind,
+        string currentTarget,
+        string expectedTarget)
+    {
+        var routed = NotifyEventKindRouting.ResolveTarget(
+            eventKind,
+            currentTarget,
+            stewardRecorded: true);
+
+        Assert.Equal(expectedTarget, routed);
+        output.WriteLine($"G796 AC1 event_kind={eventKind}; steward_recorded=true; current_target={currentTarget}; routed_to={routed}; accepted=true");
+    }
+
+    [Fact]
+    public void RulingDigestIsComputedOverOpaquePayloadAndOriginIsCanonical_G796()
+    {
+        const string payload = "architect ruling: retain the recorded contract\nwith opaque bytes";
+        Assert.True(NotifyRuling.TryCreate(
+            payload,
+            "design",
+            suppliedDigest: null,
+            out var ruling,
+            out var error), error);
+        Assert.NotNull(ruling);
+        Assert.Equal(
+            NotifyRulingRelay.ComputeDigest(payload),
+            ruling!.Digest);
+        Assert.Equal("architect", ruling.Origin);
+        Assert.Equal(
+            Encoding.UTF8.GetBytes(payload),
+            ruling.PayloadBytes);
+        output.WriteLine($"G796 AC2 payload_bytes={ruling.PayloadBytes.Count}; digest={ruling.Digest}; origin={ruling.Origin}; verifies={ruling.Verifies()}");
+    }
+
+    [Fact]
+    public void StewardRelayPreservesPayloadAndDigestWhileAllowingEnvelopeFields_G796()
+    {
+        const string payload = "opaque-architect-ruling";
+        Assert.True(NotifyRuling.TryCreate(payload, "architect", null, out var ruling, out var createError), createError);
+        Assert.NotNull(ruling);
+
+        var envelopeFields = new Dictionary<string, string>
+        {
+            ["relay_id"] = "steward-relay-1",
+        };
+        Assert.True(
+            NotifyRulingRelay.TryRelay(ruling!, payload, envelopeFields, out var relay),
+            relay.Summary);
+        Assert.True(relay.Accepted);
+        Assert.Equal(payload, relay.Ruling!.Payload);
+        Assert.Equal(ruling.Digest, relay.Ruling.Digest);
+        Assert.Equal("architect", relay.Ruling.Origin);
+        Assert.Equal("steward-relay-1", relay.Envelope!.Fields["relay_id"]);
+        Assert.True(relay.Ruling.Verifies());
+        output.WriteLine($"G796 AC3/AC4 accepted={relay.Accepted}; payload_bytes_equal={payload == relay.Ruling.Payload}; digest_unchanged={ruling.Digest == relay.Ruling.Digest}; origin={relay.Ruling.Origin}; envelope.relay_id={relay.Envelope.Fields["relay_id"]}; verifies={relay.Ruling.Verifies()}");
+    }
+
+    [Fact]
+    public void OneByteChangedRulingPayloadIsRefusedWithDigestMismatch_G796()
+    {
+        const string payload = "opaque-architect-ruling";
+        Assert.True(NotifyRuling.TryCreate(payload, "architect", null, out var ruling, out var createError), createError);
+        var changed = "opaque-architect-rulinG";
+
+        Assert.False(NotifyRulingRelay.TryRelay(ruling!, changed, new Dictionary<string, string>(), out var relay));
+        Assert.False(relay.Accepted);
+        Assert.Equal("ruling-digest-mismatch", relay.Cause);
+        Assert.Contains("digest mismatch", relay.Summary!, StringComparison.OrdinalIgnoreCase);
+        output.WriteLine($"G796 AC5 accepted={relay.Accepted}; cause={relay.Cause}; summary={relay.Summary}");
+    }
+
+    [Theory]
+    [InlineData("question", "architect", "Architect")]
+    [InlineData("question", "reviewer", "Reviewer")]
+    [InlineData("escalation", "architect", "Architect")]
+    [InlineData("blocked", "architect", "Architect")]
+    public void StewardJudgementWithoutDownstreamDelegationIsRefused_G796(
+        string eventKind,
+        string target,
+        string requiredTarget)
+    {
+        Assert.False(NotifyRulingRelay.TryValidateStewardAnswer(
+            "steward",
+            eventKind,
+            target,
+            downstreamDelegationReference: null,
+            out var error));
+        Assert.Contains(requiredTarget, error, StringComparison.Ordinal);
+        output.WriteLine($"G796 AC6 event_kind={eventKind}; from=steward; target={target}; accepted=false; required_downstream_target={requiredTarget}; error={error}");
+    }
+
+    [Theory]
+    [InlineData("completion")]
+    [InlineData("transition")]
+    [InlineData("acknowledgement")]
+    public void StewardMayAnswerRoutineEventsWithoutDelegation_G796(string eventKind)
+    {
+        Assert.True(NotifyRulingRelay.TryValidateStewardAnswer(
+            "steward",
+            eventKind,
+            "steward",
+            downstreamDelegationReference: null,
+            out var error), error);
+        output.WriteLine($"G796 AC7 event_kind={eventKind}; from=steward; downstream_reference=<none>; accepted=true");
+    }
+
+    [Fact]
+    public void DownstreamCheckUsesTheG788RecognizerAndFieldOrder_G796()
+    {
+        var pattern = new Regex(
+            "^G796$",
+            RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        Assert.True(NotifyRulingRelay.HasDownstreamDelegationEvidence(
+            taskId: "child-task",
+            objective: "coordinate G796 downstream",
+            inputs: ["ordinary input"],
+            pattern,
+            expectedExecutionUnit: "G796"));
+        Assert.False(NotifyRulingRelay.HasDownstreamDelegationEvidence(
+            taskId: "G795-child",
+            objective: "coordinate G795 downstream",
+            inputs: ["ordinary input"],
+            pattern,
+            expectedExecutionUnit: "G796"));
+        output.WriteLine("G796 AC8 recognizer=NotifyDelegationExecutionEvidence.ExtractExecutionUnitToken; objective-fallback=true; earlier-token-wins=true; second-recognizer=false");
+    }
+
+    [Theory]
+    [InlineData("claude")]
+    [InlineData("codex")]
+    [InlineData("opencode")]
+    public void StewardBoundaryIgnoresRecordedRuntimeAndModel_G796(string runtime)
+    {
+        Assert.False(NotifyRulingRelay.TryValidateStewardAnswer(
+            "steward",
+            "question",
+            "architect",
+            downstreamDelegationReference: null,
+            out var error));
+        Assert.Contains("Architect", error, StringComparison.Ordinal);
+        output.WriteLine($"G796 AC9 runtime={runtime}; model-independent=true; accepted=false; error={error}");
+    }
+
+    [Fact]
+    public void NoStewardPreservesTheExistingDestinationForAllKinds_G796()
+    {
+        foreach (var eventKind in NotifyEventKindRouting.SupportedKinds)
+        {
+            var currentTarget = eventKind == NotifyEventKindRouting.Escalation ? "design" : "review";
+            Assert.Equal(
+                currentTarget,
+                NotifyEventKindRouting.ResolveTarget(
+                    eventKind,
+                    currentTarget,
+                    stewardRecorded: false,
+                    fallbackTarget: "design"));
+            output.WriteLine($"G796 AC10 event_kind={eventKind}; steward_recorded=false; routed_to={currentTarget}; unchanged=true");
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/NotifyRoutingG796Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyRoutingG796Tests.cs
@@ -206,6 +206,148 @@ public sealed class NotifyRoutingG796Tests
     }
 
     [Fact]
+    public void DownstreamReferenceRejectsPrefixOfRealCarrierValue_G796()
+    {
+        AssertPendingReferenceRejected(
+            requestedReference: "G796-child",
+            recordedReference: "G796-child-real",
+            negativeClass: "prefix");
+    }
+
+    [Fact]
+    public void DownstreamReferenceRejectsSuffixOfRealCarrierValue_G796()
+    {
+        AssertPendingReferenceRejected(
+            requestedReference: "child-real",
+            recordedReference: "G796-child-real",
+            negativeClass: "suffix");
+    }
+
+    [Fact]
+    public void DownstreamReferenceRejectsReferenceFromDifferentTeamOrDomain_G796()
+    {
+        var root = NewEvidenceRoot();
+        try
+        {
+            var parent = WriteUpstreamParent(root);
+            var foreignTeamReference = "G796-child-foreign-team";
+            Assert.True(
+                NotifyEventWriter.TryResolveWritePath(
+                    root,
+                    parent.Domain,
+                    "other-team",
+                    out var foreignEventPath,
+                    out var foreignEventError),
+                foreignEventError);
+            NotifyEventWriter.Append(foreignEventPath, new NotifyDesignEvent
+            {
+                Timestamp = parent.DispatchedAt.AddSeconds(1),
+                Team = "other-team",
+                Kind = "question",
+                Unit = foreignTeamReference,
+                Summary = "foreign-team child evidence",
+                Artifact = "child.txt",
+            });
+
+            var foreignDomainReference = "G796-child-foreign-domain";
+            var foreignDomainChild = parent with
+            {
+                Domain = "other-domain",
+                TaskId = foreignDomainReference,
+                DispatchedAt = parent.DispatchedAt.AddSeconds(1),
+            };
+            Assert.True(NotifyPendingDelegationStore.WriteDispatch(root, foreignDomainChild).Written);
+
+            Assert.False(
+                NotifyDelegationExecutionEvidence.TryResolveDownstreamReference(
+                    root,
+                    parent,
+                    foreignTeamReference,
+                    out _,
+                    out var teamError));
+            Assert.Contains("did not resolve", teamError, StringComparison.OrdinalIgnoreCase);
+            Assert.False(
+                NotifyDelegationExecutionEvidence.TryResolveDownstreamReference(
+                    root,
+                    parent,
+                    foreignDomainReference,
+                    out _,
+                    out var domainError));
+            Assert.Contains("did not resolve", domainError, StringComparison.OrdinalIgnoreCase);
+            output.WriteLine(
+                $"G796 AC6/AC8 negative_class=foreign-team-or-domain; team_reference={foreignTeamReference}; team_accepted=false; team_error={teamError}; domain_reference={foreignDomainReference}; domain_accepted=false; domain_error={domainError}");
+        }
+        finally
+        {
+            DeleteEvidenceRoot(root);
+        }
+    }
+
+    [Fact]
+    public void DownstreamReferenceRejectsFabricatedIdentifierWithExactCarrierComparison_G796()
+    {
+        AssertPendingReferenceRejected(
+            requestedReference: "fabricated-G796-proof",
+            recordedReference: "G796-child-real",
+            negativeClass: "fabricated");
+    }
+
+    [Fact]
+    public void DownstreamReferenceMatchesQueueCarrierWithExactExecutionUnitValue_G796()
+    {
+        var root = NewEvidenceRoot();
+        try
+        {
+            var parent = WriteUpstreamParent(root);
+            var queueState = new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = parent.DispatchedAt.AddSeconds(1),
+                Items =
+                [
+                    new QueueItem
+                    {
+                        ExecutionUnit = "G796",
+                        Title = "G796 queue transition",
+                        State = QueueItemState.Active,
+                        Dependencies = [],
+                        BlockedBy = [],
+                        ClarificationReturnPath = string.Empty,
+                        PacketPaths = new PacketPaths
+                        {
+                            Yaml = ".intent-cli/issues/G796/packet.yaml",
+                            Implementation = ".intent-cli/issues/G796/implementation.md",
+                            ReviewContext = ".intent-cli/issues/G796/review-context.md",
+                        },
+                        WorkerRole = "implementation",
+                        ReviewRole = "review",
+                        Priority = "high",
+                    },
+                ],
+            };
+            var queuePath = Path.Combine(root, ".intent-cli", "queue-state.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(queuePath)!);
+            File.WriteAllText(queuePath, QueueStateSerializer.Serialize(queueState));
+
+            Assert.True(
+                NotifyDelegationExecutionEvidence.TryResolveDownstreamReference(
+                    root,
+                    parent,
+                    "G796",
+                    out var evidence,
+                    out var error),
+                error);
+            Assert.Contains("queue-state:execution_unit=G796", evidence, StringComparison.Ordinal);
+            output.WriteLine(
+                $"G796 AC6/AC8 positive_carrier=queue-state; reference=G796; accepted=true; evidence={evidence}");
+        }
+        finally
+        {
+            DeleteEvidenceRoot(root);
+        }
+    }
+
+    [Fact]
     public void RealPendingReferenceResolvesThroughTheG788EvidencePath_G796()
     {
         var root = NewEvidenceRoot();
@@ -477,5 +619,42 @@ public sealed class NotifyRoutingG796Tests
         }
 
         return parent;
+    }
+
+    private void AssertPendingReferenceRejected(
+        string requestedReference,
+        string recordedReference,
+        string negativeClass)
+    {
+        var root = NewEvidenceRoot();
+        try
+        {
+            var parent = WriteUpstreamParent(root);
+            var child = parent with
+            {
+                TaskId = recordedReference,
+                DelegatingRole = "steward",
+                RecipientRole = "architect",
+                RecipientIdentity = "role=architect",
+                DispatchedAt = parent.DispatchedAt.AddSeconds(1),
+                Ruling = null,
+            };
+            Assert.True(NotifyPendingDelegationStore.WriteDispatch(root, child).Written);
+
+            Assert.False(
+                NotifyDelegationExecutionEvidence.TryResolveDownstreamReference(
+                    root,
+                    parent,
+                    requestedReference,
+                    out _,
+                    out var error));
+            Assert.Contains("did not resolve", error, StringComparison.OrdinalIgnoreCase);
+            output.WriteLine(
+                $"G796 AC6/AC8 negative_class={negativeClass}; requested_reference={requestedReference}; recorded_reference={recordedReference}; accepted=false; error={error}");
+        }
+        finally
+        {
+            DeleteEvidenceRoot(root);
+        }
     }
 }

--- a/tests/IntentSystem.Cli.Tests/NotifyRoutingG796Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyRoutingG796Tests.cs
@@ -1,6 +1,11 @@
+using System.Text.Json;
 using System.Text;
 using System.Text.RegularExpressions;
+using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 using Xunit.Abstractions;
 
 namespace IntentSystem.Cli.Tests;
@@ -75,11 +80,13 @@ public sealed class NotifyRoutingG796Tests
             relay.Summary);
         Assert.True(relay.Accepted);
         Assert.Equal(payload, relay.Ruling!.Payload);
+        Assert.True(
+            Encoding.UTF8.GetBytes(payload).SequenceEqual(relay.Ruling.PayloadBytes));
         Assert.Equal(ruling.Digest, relay.Ruling.Digest);
         Assert.Equal("architect", relay.Ruling.Origin);
         Assert.Equal("steward-relay-1", relay.Envelope!.Fields["relay_id"]);
         Assert.True(relay.Ruling.Verifies());
-        output.WriteLine($"G796 AC3/AC4 accepted={relay.Accepted}; payload_bytes_equal={payload == relay.Ruling.Payload}; digest_unchanged={ruling.Digest == relay.Ruling.Digest}; origin={relay.Ruling.Origin}; envelope.relay_id={relay.Envelope.Fields["relay_id"]}; verifies={relay.Ruling.Verifies()}");
+        output.WriteLine($"G796 AC3/AC4 accepted={relay.Accepted}; payload_bytes_equal={Encoding.UTF8.GetBytes(payload).SequenceEqual(relay.Ruling.PayloadBytes)}; digest_unchanged={ruling.Digest == relay.Ruling.Digest}; origin={relay.Ruling.Origin}; envelope.relay_id={relay.Envelope.Fields["relay_id"]}; verifies={relay.Ruling.Verifies()}");
     }
 
     [Fact]
@@ -152,6 +159,244 @@ public sealed class NotifyRoutingG796Tests
         output.WriteLine("G796 AC8 recognizer=NotifyDelegationExecutionEvidence.ExtractExecutionUnitToken; objective-fallback=true; earlier-token-wins=true; second-recognizer=false");
     }
 
+    [Fact]
+    public void ProductionStewardGateRejectsFabricatedReference_G796()
+    {
+        var root = NewEvidenceRoot();
+        try
+        {
+            Assert.True(NotifyRuling.TryCreate(
+                "opaque upstream ruling",
+                "architect",
+                null,
+                out var ruling,
+                out var createError), createError);
+            var parent = WriteUpstreamParent(root, ruling);
+            var context = new CliContext
+            {
+                RepoRoot = root,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+                },
+            };
+            using var writer = new StringWriter();
+            var exit = NotifyCommand.ExecuteReport(
+                context,
+                [
+                    "--domain", "intent-cli", "--team", "intent-cli-dev",
+                    "--from", "steward", "--to", "architect", "--task-id", parent.TaskId,
+                    "--status", "question", "--artifact", "answer.txt", "--summary", "fabricated",
+                    "--event-kind", "question", "--downstream-delegation-reference", "fabricated-G796-proof",
+                    "--routing-root", root, "--report-root", root, "--dry-run", "--format", "json",
+                ],
+                writer);
+
+            Assert.Equal(1, exit);
+            using var document = JsonDocument.Parse(writer.ToString());
+            var result = document.RootElement;
+            Assert.Equal("steward-boundary-refused", result.GetProperty("cause").GetString());
+            Assert.Contains("did not resolve", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+            output.WriteLine($"G796 AC6/AC8 fabricated_reference={result.GetProperty("downstream_delegation_reference").GetString()}; exit={exit}; cause={result.GetProperty("cause").GetString()}; summary={result.GetProperty("summary").GetString()}");
+        }
+        finally
+        {
+            DeleteEvidenceRoot(root);
+        }
+    }
+
+    [Fact]
+    public void RealPendingReferenceResolvesThroughTheG788EvidencePath_G796()
+    {
+        var root = NewEvidenceRoot();
+        try
+        {
+            var parent = WriteUpstreamParent(root);
+            var child = parent with
+            {
+                TaskId = "G796-child",
+                DelegatingRole = "steward",
+                RecipientRole = "architect",
+                RecipientIdentity = "role=architect",
+                DispatchedAt = parent.DispatchedAt.AddSeconds(1),
+                Ruling = null,
+            };
+            Assert.True(NotifyPendingDelegationStore.WriteDispatch(root, child).Written);
+
+            Assert.True(
+                NotifyDelegationExecutionEvidence.TryResolveDownstreamReference(
+                    root,
+                    parent,
+                    child.TaskId,
+                    out var evidence,
+                    out var error),
+                error);
+            Assert.Contains("pending-ledger", evidence, StringComparison.Ordinal);
+            output.WriteLine($"G796 AC6/AC8 real_reference={child.TaskId}; accepted=true; evidence={evidence}");
+        }
+        finally
+        {
+            DeleteEvidenceRoot(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("question", "question")]
+    [InlineData("escalation", "question")]
+    [InlineData("blocked", "blocked")]
+    public void ProductionStewardGateAcceptsMeasuredPendingReferenceForEachJudgementKind_G796(
+        string eventKind,
+        string status)
+    {
+        var root = NewEvidenceRoot();
+        try
+        {
+            Assert.True(NotifyRuling.TryCreate("opaque upstream ruling", "architect", null, out var ruling, out var createError), createError);
+            var parent = WriteUpstreamParent(root, ruling);
+            var child = parent with
+            {
+                TaskId = $"G796-child-{eventKind}",
+                DelegatingRole = "steward",
+                RecipientRole = "architect",
+                RecipientIdentity = "role=architect",
+                DispatchedAt = parent.DispatchedAt.AddSeconds(1),
+                Ruling = null,
+            };
+            Assert.True(NotifyPendingDelegationStore.WriteDispatch(root, child).Written);
+
+            var context = new CliContext
+            {
+                RepoRoot = root,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+                },
+            };
+            using var writer = new StringWriter();
+            var exit = NotifyCommand.ExecuteReport(
+                context,
+                [
+                    "--domain", "intent-cli", "--team", "intent-cli-dev",
+                    "--from", "steward", "--to", "architect", "--task-id", parent.TaskId,
+                    "--status", status, "--artifact", "answer.txt", "--summary", $"{eventKind} answer",
+                    "--event-kind", eventKind, "--downstream-delegation-reference", child.TaskId,
+                    "--routing-root", root, "--report-root", root, "--dry-run", "--format", "json",
+                ],
+                writer);
+
+            using var document = JsonDocument.Parse(writer.ToString());
+            var result = document.RootElement;
+            Assert.NotEqual("steward-boundary-refused", result.GetProperty("cause").GetString());
+            output.WriteLine($"G796 AC6/AC8 event_kind={eventKind}; reference={child.TaskId}; gate=accepted; exit={exit}; post_gate_cause={result.GetProperty("cause").GetString() ?? "<none>"}");
+        }
+        finally
+        {
+            DeleteEvidenceRoot(root);
+        }
+    }
+
+    [Theory]
+    [InlineData("pending")]
+    [InlineData("outbox")]
+    [InlineData("event")]
+    public void DownstreamReferenceMatchesEachMeasuredG788Carrier_G796(string carrier)
+    {
+        var root = NewEvidenceRoot();
+        try
+        {
+            var parent = WriteUpstreamParent(root);
+            var reference = $"G796-child-{carrier}";
+            switch (carrier)
+            {
+                case "pending":
+                    Assert.True(NotifyPendingDelegationStore.WriteDispatch(root, parent with
+                    {
+                        TaskId = reference,
+                        DelegatingRole = "steward",
+                        RecipientRole = "architect",
+                        RecipientIdentity = "role=architect",
+                        DispatchedAt = parent.DispatchedAt.AddSeconds(1),
+                        Ruling = null,
+                    }).Written);
+                    break;
+                case "outbox":
+                    Assert.True(NotifyReportOutboxStore.WriteNew(root, new NotifyReportOutboxEntry
+                    {
+                        Domain = parent.Domain,
+                        Team = parent.Team,
+                        TaskId = reference,
+                        ResultNonce = "g796-child-outbox",
+                        FromRole = "steward",
+                        ToRole = "architect",
+                        Status = "question",
+                        Artifact = "child.txt",
+                        Summary = "child G796 report",
+                        CreatedAt = parent.DispatchedAt.AddSeconds(1),
+                        DeliveryState = "delivered",
+                    }).Written);
+                    break;
+                default:
+                    Assert.True(NotifyEventWriter.TryResolveWritePath(root, parent.Domain, parent.Team, out var eventPath, out var eventError), eventError);
+                    NotifyEventWriter.Append(eventPath, new NotifyDesignEvent
+                    {
+                        Timestamp = parent.DispatchedAt.AddSeconds(1),
+                        Team = parent.Team,
+                        Kind = "question",
+                        Unit = reference,
+                        Summary = "child G796 report",
+                        Artifact = "child.txt",
+                    });
+                    break;
+            }
+
+            Assert.True(
+                NotifyDelegationExecutionEvidence.TryResolveDownstreamReference(
+                    root,
+                    parent,
+                    reference,
+                    out var evidence,
+                    out var error),
+                error);
+            Assert.Contains(carrier == "pending" ? "pending-ledger" : carrier == "outbox" ? "report-outbox" : "notification-events", evidence, StringComparison.Ordinal);
+            output.WriteLine($"G796 AC6/AC8 carrier={carrier}; reference={reference}; accepted=true; evidence={evidence}");
+        }
+        finally
+        {
+            DeleteEvidenceRoot(root);
+        }
+    }
+
+    [Fact]
+    public void StewardRelayRequiresTheRecordedUpstreamRuling_G796()
+    {
+        var root = NewEvidenceRoot();
+        try
+        {
+            var missing = WriteUpstreamParent(root);
+            Assert.False(NotifyRulingRelay.TryResolveUpstreamArchitectRuling(missing, out _, out var missingError));
+            Assert.Contains("no upstream Architect ruling", missingError, StringComparison.OrdinalIgnoreCase);
+
+            Assert.True(NotifyRuling.TryCreate("architect ruling", "architect", null, out var source, out var sourceError), sourceError);
+            var forgedOrigin = new NotifyRuling { Payload = source!.Payload, Digest = source.Digest, Origin = "steward" };
+            Assert.False(NotifyRulingRelay.TryRelay(source, forgedOrigin, null, out var forgedResult));
+            Assert.Equal("ruling-origin-mismatch", forgedResult.Cause);
+
+            var mutated = new NotifyRuling
+            {
+                Payload = source.Payload + "!",
+                Digest = NotifyRulingRelay.ComputeDigest(source.Payload + "!"),
+                Origin = source.Origin,
+            };
+            Assert.False(NotifyRulingRelay.TryRelay(source, mutated, null, out var mutatedResult));
+            Assert.Equal("ruling-digest-mismatch", mutatedResult.Cause);
+            output.WriteLine($"G796 AC3/AC4/AC5 missing_upstream=refused; forged_origin={forgedResult.Cause}; one_byte_mutation={mutatedResult.Cause}; source_digest={source.Digest}");
+        }
+        finally
+        {
+            DeleteEvidenceRoot(root);
+        }
+    }
+
     [Theory]
     [InlineData("claude")]
     [InlineData("codex")]
@@ -183,5 +428,54 @@ public sealed class NotifyRoutingG796Tests
                     fallbackTarget: "design"));
             output.WriteLine($"G796 AC10 event_kind={eventKind}; steward_recorded=false; routed_to={currentTarget}; unchanged=true");
         }
+    }
+
+    private static string NewEvidenceRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"intent-g796-routing-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void DeleteEvidenceRoot(string root)
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static NotifyPendingDelegation WriteUpstreamParent(
+        string root,
+        NotifyRuling? ruling = null)
+    {
+        var parent = new NotifyPendingDelegation
+        {
+            Domain = "intent-cli",
+            Team = "intent-cli-dev",
+            TaskId = "G796-parent",
+            DelegatingRole = "architect",
+            RecipientRole = "steward",
+            ReportToRole = "architect",
+            RecipientIdentity = "role=steward",
+            ExpectedArtifact = "parent-result.txt",
+            ExpectedArtifacts = ["parent-result.txt"],
+            Objective = "coordinate G796 judgement",
+            Inputs = ["fixture"],
+            ResultNonce = "g796-parent-nonce",
+            DispatchedAt = DateTimeOffset.UtcNow.AddMinutes(-5),
+            TransportMode = "herdr-only",
+            Cwd = root,
+            Kind = "steward",
+            LaunchArguments = ["fixture"],
+            Ruling = ruling,
+        };
+        var write = NotifyPendingDelegationStore.WriteDispatch(root, parent);
+        if (!write.Written)
+        {
+            throw new InvalidOperationException(write.Error);
+        }
+
+        return parent;
     }
 }


### PR DESCRIPTION
# G796: route notifications by event kind and enforce the Steward boundary

Closes #1738

## Scope

This repair preserves the six event-kind routes and the opaque ruling boundary while making Steward judgement delivery depend on durable G788 execution evidence. The production `notify report`/`notify escalate` path now resolves the supplied downstream reference through `NotifyDelegationExecutionEvidence.Resolve`, parses each carrier field for exact equality, filters notification events to the parent team, persists the Architect ruling on the pending delegation, and relays those original bytes/digest/origin only through additive envelope fields. Fabricated, prefix, suffix, cross-scope, and unknown safe references, missing/forged upstream rulings, forged origins, and one-byte payload changes are refused. No process-management authority, runtime/model gate, guide/route rename, `worker_role`/`review_role` change, or second execution-unit recognizer is introduced.

Head: `df5804a0cccd8e06d266fb1792647e47e02885cc`

## Acceptance evidence

### AC1 — all six event kinds route by kind

```text
G796 AC1 event_kind=completion; steward_recorded=true; current_target=architect; routed_to=steward; accepted=true
G796 AC1 event_kind=transition; steward_recorded=true; current_target=architect; routed_to=steward; accepted=true
G796 AC1 event_kind=acknowledgement; steward_recorded=true; current_target=architect; routed_to=steward; accepted=true
G796 AC1 event_kind=escalation; steward_recorded=true; current_target=steward; routed_to=architect; accepted=true
G796 AC1 event_kind=question; steward_recorded=true; current_target=architect; routed_to=architect; accepted=true
G796 AC1 event_kind=question; steward_recorded=true; current_target=review; routed_to=reviewer; accepted=true
G796 AC1 event_kind=blocked; steward_recorded=true; current_target=steward; routed_to=architect; accepted=true
```

### AC2 — opaque ruling digest and origin

```text
G796 AC2 payload_bytes=64; digest=96a0007be57fec3da6e36768f0e74512db2df239488124af91a5e920f1ead1e9; origin=architect; verifies=True
```

### AC3/AC4 — source ruling bytes/digest/origin survive additive relay

```text
G796 AC3/AC4 accepted=True; payload_bytes_equal=True; digest_unchanged=True; origin=architect; envelope.relay_id=steward-relay-1; verifies=True
G796 AC3/AC4/AC5 missing_upstream=refused; forged_origin=ruling-origin-mismatch; one_byte_mutation=ruling-digest-mismatch; source_digest=98ce35acda9e2f1ad365f2c4de1694f9dfa32d3bf04e0a6888267a429d7e1062
```

The first line compares `Encoding.UTF8.GetBytes(payload).SequenceEqual(relay.Ruling.PayloadBytes)`, not only string equality.

### AC5 — one-byte mutation is refused

```text
G796 AC5 accepted=False; cause=ruling-digest-mismatch; summary=Steward relay refused: ruling digest mismatch (expected '99d40cfdee340e891808438d56cdadf251743942d14bb38e9bdef15f253a6bfe', computed 'b6ee083d5552655a9b522e15c7c74d5f74034f300708812d904bd3b27647e3b9').
```

### AC6 — Steward judgement requires a measured downstream delegation

The old no-reference refusals remain covered for Architect question, Reviewer question, escalation, and blocked:

```text
G796 AC6 event_kind=question; from=steward; target=architect; accepted=false; required_downstream_target=Architect; error=Steward answer refused for question: required downstream delegation reference to Architect.
G796 AC6 event_kind=question; from=steward; target=reviewer; accepted=false; required_downstream_target=Reviewer; error=Steward answer refused for question: required downstream delegation reference to Reviewer.
G796 AC6 event_kind=escalation; from=steward; target=architect; accepted=false; required_downstream_target=Architect; error=Steward answer refused for escalation: required downstream delegation reference to Architect.
G796 AC6 event_kind=blocked; from=steward; target=architect; accepted=false; required_downstream_target=Architect; error=Steward answer refused for blocked: required downstream delegation reference to Architect.
```

The production command-level fixture rejects a safe-looking fabricated reference before preflight/transport:

```text
G796 AC6/AC8 fabricated_reference=fabricated-G796-proof; exit=1; cause=steward-boundary-refused; summary=downstream delegation reference 'fabricated-G796-proof' did not resolve in G788 execution evidence (pending-ledger=0; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0).
```

The same command gate accepts a real pending child reference for every judgement event and then reaches normal preflight:

```text
G796 AC6/AC8 event_kind=question; reference=G796-child-question; gate=accepted; exit=1; post_gate_cause=session-layer-mode-unrecorded
G796 AC6/AC8 event_kind=escalation; reference=G796-child-escalation; gate=accepted; exit=1; post_gate_cause=session-layer-mode-unrecorded
G796 AC6/AC8 event_kind=blocked; reference=G796-child-blocked; gate=accepted; exit=1; post_gate_cause=session-layer-mode-unrecorded
```

The repair closes the entire evidence-reference class by parsing carrier values
and comparing them with exact equality. The four negative classes below were
run against a recorded `G796-child-real`; every requested partial, fabricated,
or cross-scope value stayed refused:

```text
G796 AC6/AC8 negative_class=fabricated; requested_reference=fabricated-G796-proof; recorded_reference=G796-child-real; accepted=false; error=downstream delegation reference 'fabricated-G796-proof' did not resolve in G788 execution evidence (pending-ledger=1; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0).
G796 AC6/AC8 negative_class=prefix; requested_reference=G796-child; recorded_reference=G796-child-real; accepted=false; error=downstream delegation reference 'G796-child' did not resolve in G788 execution evidence (pending-ledger=1; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0).
G796 AC6/AC8 negative_class=suffix; requested_reference=child-real; recorded_reference=G796-child-real; accepted=false; error=downstream delegation reference 'child-real' did not resolve in G788 execution evidence (pending-ledger=1; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0).
G796 AC6/AC8 negative_class=foreign-team-or-domain; team_reference=G796-child-foreign-team; team_accepted=false; team_error=downstream delegation reference 'G796-child-foreign-team' did not resolve in G788 execution evidence (pending-ledger=0; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0).; domain_reference=G796-child-foreign-domain; domain_accepted=false; domain_error=downstream delegation reference 'G796-child-foreign-domain' did not resolve in G788 execution evidence (pending-ledger=0; report-outbox=0; notification-events=0; queue-state=0; continuation-chain=0; expected-artifact=0).
```

### AC7 — Steward may answer routine events alone

```text
G796 AC7 event_kind=completion; from=steward; downstream_reference=<none>; accepted=true
G796 AC7 event_kind=transition; from=steward; downstream_reference=<none>; accepted=true
G796 AC7 event_kind=acknowledgement; from=steward; downstream_reference=<none>; accepted=true
```

### AC8 — G788 recognizer and all measured carriers are reused

```text
G796 AC8 recognizer=NotifyDelegationExecutionEvidence.ExtractExecutionUnitToken; objective-fallback=true; earlier-token-wins=true; second-recognizer=false
G796 AC6/AC8 carrier=outbox; reference=G796-child-outbox; accepted=true; evidence=report-outbox:task_id=G796-child-outbox; from_role=steward; created_at=2026-09-04T07:59:37.4895460+00:00; source=/var/folders/bs/1qh88g953fx8dccvxc9p5rhr0000gn/T/intent-g796-routing-48b0a5216a534a21baed2f6293747912/.intent-cli/notify/intent-cli/intent-cli-dev/report-outbox.jsonl
G796 AC6/AC8 carrier=event; reference=G796-child-event; accepted=true; evidence=notification-events:unit=G796-child-event; kind=question; timestamp=2026-09-04T07:59:37.4862480+00:00; source=/var/folders/bs/1qh88g953fx8dccvxc9p5rhr0000gn/T/intent-g796-routing-c7f7cb57cf7f430ba4a84c4830ce387b/.intent-cli/events/intent-cli/intent-cli-dev.jsonl
G796 AC6/AC8 real_reference=G796-child; accepted=true; evidence=pending-ledger:task_id=G796-child; delegating_role=steward; dispatched_at=2026-09-04T07:59:37.4932920+00:00; source=/var/folders/bs/1qh88g953fx8dccvxc9p5rhr0000gn/T/intent-g796-routing-4a3f190d2c7b4f24a605d6ba8f2e3433/.intent-cli/notify/intent-cli/intent-cli-dev/pending.jsonl
G796 AC6/AC8 carrier=pending; reference=G796-child-pending; accepted=true; evidence=pending-ledger:task_id=G796-child-pending; delegating_role=steward; dispatched_at=2026-09-04T07:59:37.4885770+00:00; source=/var/folders/bs/1qh88g953fx8dccvxc9p5rhr0000gn/T/intent-g796-routing-1afe7a7b135f4ccdaab398ebdde0c556/.intent-cli/notify/intent-cli/intent-cli-dev/pending.jsonl
G796 AC6/AC8 positive_carrier=queue-state; reference=G796; accepted=true; evidence=queue-state:execution_unit=G796; state=active; linked_pr=<none>; updated_at=2026-09-04T10:37:12.5733770+00:00; source=/var/folders/bs/1qh88g953fx8dccvxc9p5rhr0000gn/T/intent-g796-routing-85a2fe1149e441a18c35c957e4ee8607/.intent-cli/queue-state.json
```

### AC9 — runtime/model identity cannot bypass the boundary

```text
G796 AC9 runtime=claude; model-independent=true; accepted=false; error=Steward answer refused for question: required downstream delegation reference to Architect.
G796 AC9 runtime=codex; model-independent=true; accepted=false; error=Steward answer refused for question: required downstream delegation reference to Architect.
G796 AC9 runtime=opencode; model-independent=true; accepted=false; error=Steward answer refused for question: required downstream delegation reference to Architect.
```

### AC10 — no Steward preserves existing destinations

```text
G796 AC10 event_kind=completion; steward_recorded=false; routed_to=review; unchanged=true
G796 AC10 event_kind=transition; steward_recorded=false; routed_to=review; unchanged=true
G796 AC10 event_kind=acknowledgement; steward_recorded=false; routed_to=review; unchanged=true
G796 AC10 event_kind=escalation; steward_recorded=false; routed_to=design; unchanged=true
G796 AC10 event_kind=question; steward_recorded=false; routed_to=review; unchanged=true
G796 AC10 event_kind=blocked; steward_recorded=false; routed_to=review; unchanged=true
```

### AC11 / Criterion 11 — parent proof for new repair paths

The original base absence material is retained below. The direct parent of this
repair is `b549c3e09acb41066129930a7bb77e6ad4a3bc0f`; the new exact-parser and
negative-regression symbols were absent there. Actual direct-parent proof:

```text
BASE=b549c3e09acb41066129930a7bb77e6ad4a3bc0f
SOURCE_NEW_EXACT_PARSER:
source_rc=1
TEST_NEW_NEGATIVE_COVERAGE:
test_rc=1
```

Original base absence/failure output:

```text
PARENT_ABSENCE_NOTIFY_RULING:
exit=128
fatal: path 'src/IntentSystem.Cli/Commands/NotifyRuling.cs' exists on disk, but not in '09b1f4edca51f3acbbe3e901356866996f4be29f'
PARENT_ABSENCE_G796_TEST:
exit=128
fatal: path 'tests/IntentSystem.Cli.Tests/NotifyRoutingG796Tests.cs' exists on disk, but not in '09b1f4edca51f3acbbe3e901356866996f4be29f'
PARENT_BASELINE_GATE_SYMBOL:
exit=1
```

### AC12 / Criterion 12 — focused, compatibility, and full Release validation

```text
Focused G796: Passed 36; Failed 0; Skipped 0; Total 36.
Compatibility (G796 + G788 supervision + G578 command + G588 recorded roles + G776 wake): Passed 112; Failed 0; Skipped 0; Total 112.
Full Release: Passed 5715; Failed 0; Skipped 1; Total 5716.
```

Commands:

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter 'FullyQualifiedName~NotifyRoutingG796Tests'
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter 'FullyQualifiedName~NotifyRoutingG796Tests|FullyQualifiedName~NotifySupervisionG788Tests|FullyQualifiedName~NotifyCommandG578Tests|FullyQualifiedName~NotifyRecordedRolesG588Tests|FullyQualifiedName~WakeChannelG776Tests'
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-build --logger 'trx;LogFileName=/tmp/g796-full-release-repair.trx'
```

## Exact-head CI

The repair was pushed non-force at head `df5804a0cccd8e06d266fb1792647e47e02885cc`. Exact-head GitHub Actions run `33864905054` is green:

```text
Build and test (source contract)  pass  2m50s  https://github.com/J-Tech-Japan/intent-system/actions/runs/33864905054/job/100997429694
npm package dry-run (no publish) pass  1m30s  https://github.com/J-Tech-Japan/intent-system/actions/runs/33864905054/job/100998136079
```
