### PR TITLE
G801: tag npm prereleases by version channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,11 +448,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          derive_npm_dist_tag() {
+            local version="$1"
+            if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([0-9A-Za-z-]+)(\.[0-9A-Za-z-]+)*(\+[0-9A-Za-z.-]+)?$ ]]; then
+              printf '%s\n' "${BASH_REMATCH[1]}"
+            else
+              printf 'latest\n'
+            fi
+          }
+
+          VERSION="${{ steps.ver.outputs.version }}"
+          NPM_DIST_TAG="$(derive_npm_dist_tag "${VERSION}")"
+          echo "version=${VERSION} npm_dist_tag=${NPM_DIST_TAG}"
+
           publish_package() {
             local package_path="$1"
             local package_name="$2"
             local publish_output
-            if ! publish_output="$(npm publish "${package_path}" --access public 2>&1)"; then
+            if ! publish_output="$(npm publish "${package_path}" --access public --tag "${NPM_DIST_TAG}" 2>&1)"; then
               printf '%s\n' "${publish_output}" >&2
               classify_publish_failure "${package_name}" "${publish_output}"
               return 1

--- a/tests/IntentSystem.Cli.Tests/ReleaseNpmDistTagG801Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNpmDistTagG801Tests.cs
@@ -1,0 +1,191 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G801: npm publish must use a dist-tag derived from the resolved release
+/// version. These tests read the workflow itself so the release-only shell
+/// helper and every package call site stay covered without publishing anything.
+/// </summary>
+public sealed class ReleaseNpmDistTagG801Tests
+{
+    [Fact]
+    public void Ac1_DerivesLatestForStableAndNonDefaultTagForPrerelease()
+    {
+        var result = RunTagHelper(
+            "0.32.0",
+            "0.32.0-preview.1");
+
+        Assert.True(result.ExitCode == 0, result.Output);
+        Assert.Equal(
+            "0.32.0 -> latest\n0.32.0-preview.1 -> preview\n",
+            result.StandardOutput.ReplaceLineEndings("\n"));
+        Console.WriteLine("G801 AC1 resolved dist-tags:\n" + result.StandardOutput);
+    }
+
+    [Fact]
+    public void Ac2_AllFourNpmPackagesUseTheDerivedTag()
+    {
+        var workflow = ReadWorkflow();
+        var publishStep = ExtractPublishStep(workflow);
+
+        Assert.Contains(
+            "npm publish \"${package_path}\" --access public --tag \"${NPM_DIST_TAG}\"",
+            publishStep,
+            StringComparison.Ordinal);
+
+        var packages = new[]
+        {
+            "@j-tech-japan/intent-cli-darwin-arm64",
+            "@j-tech-japan/intent-cli-linux-x64",
+            "@j-tech-japan/intent-cli-win32-x64",
+            "intent-system",
+        };
+        foreach (var package in packages)
+        {
+            Assert.Contains($"\"{package}\"", publishStep, StringComparison.Ordinal);
+        }
+
+        var callCount = Regex.Matches(
+            publishStep,
+            @"(?m)^\s*publish_package \\\s*$").Count;
+        Assert.Equal(4, callCount);
+        var callNames = Regex.Matches(
+                publishStep,
+                @"(?ms)^\s*publish_package \\\s*\n\s+[^\r\n]+\n\s+""(?<name>[^""]+)""")
+            .Select(match => match.Groups["name"].Value)
+            .ToArray();
+        Assert.Equal(packages, callNames);
+        Console.WriteLine(
+            $"G801 AC2 publish call-sites: package_count={packages.Length}; calls={callCount}; tag=\"${{NPM_DIST_TAG}}\"; packages={string.Join(",", callNames)}");
+    }
+
+    [Fact]
+    public void Ac3_ResolvedVersionStillStripsOnlyLeadingV()
+    {
+        var workflow = ReadWorkflow();
+        var stripCount = Regex.Matches(workflow, Regex.Escape("VERSION=\"${RAW#v}\"")).Count;
+
+        Assert.Equal(3, stripCount);
+        var result = RunBash(
+            "for raw in v0.32.0-preview.1 v0.32.0; do VERSION=\"${raw#v}\"; printf '%s -> %s\\n' \"$raw\" \"$VERSION\"; done");
+        Assert.True(result.ExitCode == 0, result.Output);
+        Assert.Equal(
+            "v0.32.0-preview.1 -> 0.32.0-preview.1\nv0.32.0 -> 0.32.0\n",
+            result.StandardOutput.ReplaceLineEndings("\n"));
+        Console.WriteLine($"G801 AC3 version derivation occurrences={stripCount}:\n{result.StandardOutput}");
+    }
+
+    [Fact]
+    public void Ac4_DetectsEverySupportedPrereleaseFormIndividually()
+    {
+        var result = RunTagHelper(
+            "0.32.0-preview.1",
+            "0.32.0-rc.2",
+            "0.32.0-beta.3",
+            "0.32.0-alpha.4",
+            "0.32.0");
+
+        Assert.True(result.ExitCode == 0, result.Output);
+        Assert.Equal(
+            "0.32.0-preview.1 -> preview\n"
+            + "0.32.0-rc.2 -> rc\n"
+            + "0.32.0-beta.3 -> beta\n"
+            + "0.32.0-alpha.4 -> alpha\n"
+            + "0.32.0 -> latest\n",
+            result.StandardOutput.ReplaceLineEndings("\n"));
+        Console.WriteLine("G801 AC4 semver detection cases:\n" + result.StandardOutput);
+    }
+
+    [Fact]
+    public void Ac5_NuGetVersionAndPublishHandlingRemainPresentAndUntagged()
+    {
+        var workflow = ReadWorkflow();
+        var nugetStart = workflow.IndexOf("  nupkg:\n", StringComparison.Ordinal);
+        var nugetEnd = workflow.IndexOf("\n  binaries:\n", nugetStart, StringComparison.Ordinal);
+        Assert.True(nugetStart >= 0 && nugetEnd > nugetStart, "Could not isolate the NuGet job.");
+        var nuget = workflow[nugetStart..nugetEnd];
+
+        Assert.Contains("VERSION=\"${RAW#v}\"", nuget, StringComparison.Ordinal);
+        Assert.Contains("dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj", nuget, StringComparison.Ordinal);
+        Assert.Contains("dotnet nuget push", nuget, StringComparison.Ordinal);
+        Assert.DoesNotContain("npm publish", nuget, StringComparison.Ordinal);
+        Console.WriteLine("G801 AC5 NuGet job: version_strip=true; pack=true; nuget_publish=true; npm_tag_changes=none");
+    }
+
+    private static CommandResult RunTagHelper(params string[] versions)
+    {
+        var helper = ExtractTagHelper(ReadWorkflow());
+        var loop = "for version in "
+            + string.Join(" ", versions.Select(version => $"'{version}'"))
+            + "; do printf '%s -> %s\\n' \"$version\" \"$(derive_npm_dist_tag \"$version\")\"; done";
+        return RunBash(helper + "\n" + loop);
+    }
+
+    private static string ExtractTagHelper(string workflow)
+    {
+        var match = Regex.Match(
+            workflow,
+            @"(?ms)^\s*derive_npm_dist_tag\(\) \{(?<body>.*?)^\s*\}\s*$");
+        Assert.True(match.Success, "Could not locate derive_npm_dist_tag in release.yml.");
+        var body = match.Groups["body"].Value;
+        var lines = body.Split('\n').Select(line => line.StartsWith("          ", StringComparison.Ordinal)
+            ? line[10..]
+            : line);
+        return "derive_npm_dist_tag() {\n" + string.Join('\n', lines) + "}\n";
+    }
+
+    private static string ExtractPublishStep(string workflow)
+    {
+        var start = workflow.IndexOf("      - name: Publish npm packages through OIDC trusted publishing", StringComparison.Ordinal);
+        Assert.True(start >= 0, "Could not locate npm publish step.");
+        return workflow[start..];
+    }
+
+    private static string ReadWorkflow() => File.ReadAllText(Path.Combine(FindRepoRoot(), ".github", "workflows", "release.yml"));
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, ".github", "workflows", "release.yml")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate .github/workflows/release.yml");
+    }
+
+    private static CommandResult RunBash(string script)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "bash",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(script);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start bash.");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        return new CommandResult(
+            process.ExitCode,
+            standardOutput.GetAwaiter().GetResult(),
+            standardError.GetAwaiter().GetResult());
+    }
+
+    private sealed record CommandResult(int ExitCode, string StandardOutput, string StandardError)
+    {
+        public string Output => StandardOutput + StandardError;
+    }
+}


### PR DESCRIPTION
Closes #1748

## G801 implementation

The npm publish helper now derives `NPM_DIST_TAG` from the resolved `VERSION`: the first SemVer prerelease identifier (`preview`, `rc`, `beta`, `alpha`, or another valid identifier) is used as a non-default tag, while a stable version uses `latest`. The existing version, NuGet, binary, upload, failure-classifier, and helper flow remain unchanged.

## Acceptance evidence

### AC 1 — stable and prerelease tags are derived from VERSION

```text
G801 AC1 resolved dist-tags:
0.32.0 -> latest
0.32.0-preview.1 -> preview
```

Focused command: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~ReleaseNpmDistTagG801Tests --logger "console;verbosity=normal"`

```text
Test Run Successful.
Total tests: 5
     Passed: 5
RC:0
```

### AC 2 — all four package call sites receive the derived tag

```text
G801 AC2 publish call-sites: package_count=4; calls=4; tag="${NPM_DIST_TAG}"; packages=@j-tech-japan/intent-cli-darwin-arm64,@j-tech-japan/intent-cli-linux-x64,@j-tech-japan/intent-cli-win32-x64,intent-system
```

The complete workflow diff below shows the shared publish invocation carrying `--tag "${NPM_DIST_TAG}"`; the four parsed call names above are the exact four package arguments.

### AC 3 — resolved version derivation is unchanged

```text
G801 AC3 version derivation occurrences=3:
v0.32.0-preview.1 -> 0.32.0-preview.1
v0.32.0 -> 0.32.0
```

### AC 4 — every required SemVer prerelease form is detected

```text
G801 AC4 semver detection cases:
0.32.0-preview.1 -> preview
0.32.0-rc.2 -> rc
0.32.0-beta.3 -> beta
0.32.0-alpha.4 -> alpha
0.32.0 -> latest
```

### AC 5 — NuGet handling remains unchanged

```text
G801 AC5 NuGet job: version_strip=true; pack=true; nuget_publish=true; npm_tag_changes=none
```

### AC 6 — complete `.github/workflows/release.yml` diff

```diff
diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
index 08ccf82e..fa286d5d 100644
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,11 +448,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          derive_npm_dist_tag() {
+            local version="$1"
+            if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([0-9A-Za-z-]+)(\.[0-9A-Za-z-]+)*(\+[0-9A-Za-z.-]+)?$ ]]; then
+              printf '%s\n' "${BASH_REMATCH[1]}"
+            else
+              printf 'latest\n'
+            fi
+          }
+
+          VERSION="${{ steps.ver.outputs.version }}"
+          NPM_DIST_TAG="$(derive_npm_dist_tag "${VERSION}")"
+          echo "version=${VERSION} npm_dist_tag=${NPM_DIST_TAG}"
+
           publish_package() {
             local package_path="$1"
             local package_name="$2"
             local publish_output
-            if ! publish_output="$(npm publish "${package_path}" --access public 2>&1)"; then
+            if ! publish_output="$(npm publish "${package_path}" --access public --tag "${NPM_DIST_TAG}" 2>&1)"; then
               printf '%s\n' "${publish_output}" >&2
               classify_publish_failure "${package_name}" "${publish_output}"
               return 1
```

### AC 7 — each new test was absent on the parent

```text
git_show_exit=128
fatal: path 'tests/IntentSystem.Cli.Tests/ReleaseNpmDistTagG801Tests.cs' exists on disk, but not in 'origin/main'
Ac1_DerivesLatestForStableAndNonDefaultTagForPrerelease=absent
Ac2_AllFourNpmPackagesUseTheDerivedTag=absent
Ac3_ResolvedVersionStillStripsOnlyLeadingV=absent
Ac4_DetectsEverySupportedPrereleaseFormIndividually=absent
Ac5_NuGetVersionAndPublishHandlingRemainPresentAndUntagged=absent
```

### AC 8 — full Release validation

```text
<ResultSummary outcome="Completed">
    <Counters total="5743" executed="5742" passed="5742" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
RC:0
```

Focused Release: 5 total, 5 executed, 5 passed, 0 failed, 0 skipped (RC 0).
Full Release: 5743 total, 5742 executed/passed, 0 failed, 1 expected skip (RC 0).
Final commit: `e964155a8813222b1afeb534addc191efed54557`.
