### PR TITLE
G802: prepare v0.32.0 release evidence

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2812,7 +2812,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0311)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0321)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -3018,69 +3018,62 @@ rotated by this command; the result and `shrink-audit.jsonl` say so explicitly.
 out of scope. Use `--dry-run` to inspect the measured plan without writing the
 manifest, JSONL files, or audit.
 
-### Next release readiness (v0.31.1)
+### Next release readiness (v0.32.1)
 
 **RELEASE PREPARED / NOT PUBLISHED.**
 
-G792 measured the v0.31.0 preparation from the exact named product base
-`79a245c655e17ac654ac440fda31709ee38e28b8` after the four first-parent merges
-G788, G789, G791, and G790. A normal clean Release build reports
-`intent-cli 0.31.1-79a245c-G791`; this is the new `nextVersion` placeholder
-identity, **not** v0.31.0. The same base with explicit `-p:Version=0.31.0`
-reports `intent-cli 0.31.0-79a245c-G791`. Published v0.31.0 derives `VERSION`
+G802 measured the v0.32.0 preparation from the exact named product base
+`2a833a976688b3139678e4954162a9c00d32d0f4` after six first-parent merges:
+G795, G798, G796, G800, G797, and G801. A normal clean Release build reports
+`intent-cli 0.32.1-2a833a9-G801`; this is the new `nextVersion` placeholder
+identity, **not** v0.32.0. The same base with explicit `-p:Version=0.32.0`
+reports `intent-cli 0.32.0-2a833a9-G801`. Published v0.32.0 derives `VERSION`
 from the release tag's `RAW` value in `release.yml`; `eng/version.json` governs
 local builds and dry runs only.
 
-The prepared files are `release-notes-v0.31.0.md` and the
-`release-notes-v0.31.1.md` DRAFT stub. The current policy is:
+The prepared files are `release-notes-v0.32.0.md` and the
+`release-notes-v0.32.1.md` DRAFT stub. The current policy is:
 
 ```json
 {
-  "stableVersion": "0.31.0",
-  "nextVersion": "0.31.1"
+  "stableVersion": "0.32.0",
+  "nextVersion": "0.32.1"
 }
 ```
 
-`0.31.1` is a replaceable development placeholder, not the next real release
+`0.32.1` is a replaceable development placeholder, not the next real release
 number. No tag, GitHub Release, package publish, workflow change, or product
 source change belongs to this prepare-only slice.
 
-The active package-policy evidence is `stableVersion 0.31.0`, `nextVersion 0.31.1`,
-and local candidate `JTechJapan.IntentSystem.Cli.0.31.1.nupkg`.
-The host-only release-prep claim boundary is `release-prep:<owner/repo>:0.31.0`;
+The active package-policy evidence is `stableVersion 0.32.0`, `nextVersion 0.32.1`,
+and local candidate `JTechJapan.IntentSystem.Cli.0.32.1.nupkg`.
+The host-only release-prep claim boundary is `release-prep:<owner/repo>:0.32.0`;
 this child release-prep uses supplied authority and does not inspect or mutate host state.
-The exact four-unit inventory is G788, G789, G791, and G790; its EN/JA
-unit/PR/issue/merge tuple and consumer-follow-up parity is guarded by
-`ReleaseNotesV0310DocsTests`, alongside measured identities, truthfulness, and
-placeholder checks; `ReleasePackageMetadataTests` continues to guard the
-release-policy shape and demanded next-version note.
-G788's evidence sources, G789's guide blocks, and G791's nested-pointer-drift
-classification are explicitly option/behavior additions, not extra command routes.
-The current readiness record also preserves `metadata_write_branch` topology
-evidence and the `--verify`, `--accept-evidence-gap`, and `--shell-policy`
-option-level surfaces; no GitHub Release exists yet.
+The exact six-unit inventory is G795, G798, G796, G800, G797, and G801; its EN/JA
+unit/PR/issue/merge tuple is guarded by `ReleaseNotesV0320G802Tests`, alongside
+measured identities, alias promises, and placeholder checks; `ReleasePackageMetadataTests`
+continues to guard the release-policy shape and demanded next-version note.
+G796 and G800 are command-route additions and are counted for the minor bump;
+the alias table/config repair, guide rendering, and npm dist-tag behavior are
+listed but explicitly not counted as routes. The current readiness record keeps
+all existing route names and option-level surfaces unchanged; no GitHub Release exists yet.
 The policy-derived next-version placeholder boundary remains
-`release-prep:<owner/repo>:0.31.1`; the prepared release target above is
-`release-prep:<owner/repo>:0.31.0`.
+`release-prep:<owner/repo>:0.32.1`; the prepared release target above is
+`release-prep:<owner/repo>:0.32.0`.
 
-The measured minor decision uses the v0.28.0 rule: **a command-route addition is
-a minor bump; option-level additions do not count as command routes.** The
-tagged v0.30.0 tool did not expose `session-layer inspect`; the named base adds
-that one read-only command route. G788 evidence sources/informational output,
-G789 guide text, and G791 nested-pointer-drift classification are listed but
-explicitly not counted as routes.
+The readiness record also preserves the `metadata_write_branch` topology
+evidence and the `--verify`, `--accept-evidence-gap`, and `--shell-policy`
+option-level surfaces.
 
-G792 truthfulness is deliberately bounded: the delivered-never-executed finding
-counts a downstream delegation, a child report carrying the same execution-unit
-token, or a queue transition as execution evidence, still fires on a true stall,
-and lists what was checked rather than asserting absence. `session-layer inspect`
-is read-only, resolves targets only from recorded topology or explicit `--role`,
-has no focus default, exits 0 when the session layer is unavailable, and does not
-answer dialogs; `notify adjudicate` remains that path. The host guard proceeds on
-another domain's nested pointer drift only when every nested checkout is clean,
-refuses uncommitted nested content, and writes to no other domain submodule. The
-G789 design-thread Orca block is non-normative; intent-cli neither launches nor
-manages Orca.
+G802's compatibility promise is deliberately bounded: the legacy names
+`design`, `orchestration`, `implementation`, and `review` still work as aliases;
+existing roles configuration keeps loading; existing queue-state keeps reading
+and displaying; and no installed guide route changed name. These are not new
+routes. G795 canonicalizes role values and refuses unknown roles, G798 leaves
+queue role fields as read/display values, G796 keeps ruling bytes/digest/origin
+opaque, G800 requires sourced findings and refuses ruling-bearing research while
+leaving direct research ungated, and G801 derives prerelease npm tags by SemVer
+class. No size threshold, model name, or runtime check is used.
 
 ### Previous v0.29.0 release-prep evidence (retained in history only)
 

--- a/docs/en/release-notes-v0.32.0.md
+++ b/docs/en/release-notes-v0.32.0.md
@@ -1,0 +1,168 @@
+# Release Notes — intent-cli v0.32.0
+
+> **PREPARED / NOT PUBLISHED.** This prepare-only note set records the measured
+> G795–G801 chain. It does not create a tag or GitHub Release, publish a package,
+> change a workflow or publish configuration, or change product source.
+
+No GitHub Release exists for v0.32.0; these notes are preparation evidence only.
+The matching install query is `JTechJapan.IntentSystem.Cli --version 0.32.0`.
+The policy after this preparation is:
+
+```json
+{
+  "stableVersion": "0.32.0",
+  "nextVersion": "0.32.1"
+}
+```
+
+`0.32.1` is a replaceable development placeholder, not a decision about the
+next real release. The EN and JA v0.32.1 files are planning scaffolds, not
+changelogs. This prepare-only slice makes no tag, no workflow change, and no
+product source change.
+
+## Independently measured minor justification
+
+The named product base is `2a833a976688b3139678e4954162a9c00d32d0f4`. The
+minor decision follows the v0.28.0 rule: **a command-route addition is a minor
+bump; option-level additions do not count as command routes.** G796 adds
+event-kind routing to a new role and G800 adds the research-delegation route;
+those two command-surface route additions are the measured reason for this
+minor. The alias table and config repair, guide rendering, and G801 npm
+dist-tag behavior are listed as changes but explicitly **not counted** as
+routes.
+
+The route decision is independently observable in the merged history: G796 is
+the six-kind event routing addition and G800 is the first-class research
+delegation route. No other listed change is counted as a command route.
+
+## Measured version identities
+
+The named base was checked with a clean Release build after the policy roll:
+
+```text
+$ git rev-parse HEAD
+2a833a976688b3139678e4954162a9c00d32d0f4
+$ dotnet build IntentSystem.sln --configuration Release --no-restore; echo BUILD_RC:$?
+BUILD_RC:0
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.32.1-2a833a9-G801
+```
+
+That normal identity is the `nextVersion` placeholder and is **not** v0.32.0.
+The same base with the explicit release property was measured separately:
+
+```text
+$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.32.0; echo BUILD_RC:$?
+BUILD_RC:0
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.32.0-2a833a9-G801
+```
+
+Published versioning is the third identity and is derived by `release.yml`,
+not by the local policy file:
+
+```text
+$ raw=v0.32.0; version="${raw#v}"; printf 'RAW=%s\nVERSION=%s\n' "$raw" "$version"
+RAW=v0.32.0
+VERSION=0.32.0
+```
+
+The release workflow supplies `-p:Version=<tag>` from `RAW`; `eng/version.json`
+governs local builds and dry runs only. This prepare-only slice created no tag.
+
+## Release inventory: exactly six first-parent units
+
+The inventory is derived from the exact first-parent range. Git measured six
+commits, in this order, and every commit has one operator-observable outcome:
+
+- G795 — PR #1740 / issue #1737; merge commit `1b3c7229cfe8c8f8565034a7e2220a94ac14785b`.
+  **Operator-observable outcome:** canonical Architect, Orchestrator, Builder,
+  Reviewer, and Steward role values accept the four legacy aliases while
+  unknown roles are refused.
+- G798 — PR #1742 / issue #1741; merge commit `09b1f4edca51f3acbbe3e901356866996f4be29f`.
+  **Operator-observable outcome:** recorded role configuration loads through
+  the canonical normalizer while queue-state role fields remain read/display
+  values without runtime semantics.
+- G796 — PR #1743 / issue #1738; merge commit `67c8578090f1a53e8894aeff88abd6cd8b83ff15`.
+  **Operator-observable outcome:** six event kinds route to Steward or
+  Architect and an opaque ruling payload is relayed byte-identically with its
+  digest and origin boundary.
+- G800 — PR #1747 / issue #1745; merge commit `6e0bff220e2bf51308596c19ee258835ce509dd8`.
+  **Operator-observable outcome:** Architect or Reviewer can delegate sourced
+  research to Orchestrator or Steward; ruling-bearing research is refused at
+  the judgement seat while direct research remains ungated.
+- G797 — PR #1746 / issue #1739; merge commit `11457187ad0f9c2c269b80de84b0fd9ea278dfe5`.
+  **Operator-observable outcome:** guides teach canonical roles, describe
+  Steward, retain the retired-name glossary, and preserve all installed route
+  names without vendor/runtime role coupling.
+- G801 — PR #1749 / issue #1748; merge commit `2a833a976688b3139678e4954162a9c00d32d0f4`.
+  **Operator-observable outcome:** npm publish calls derive `latest` for stable
+  versions and a non-default prerelease dist-tag for preview, rc, beta, and
+  alpha SemVer forms.
+
+## First-parent accounting
+
+```text
+$ git rev-list --first-parent --reverse v0.31.0..2a833a976688b3139678e4954162a9c00d32d0f4
+1b3c7229cfe8c8f8565034a7e2220a94ac14785b
+09b1f4edca51f3acbbe3e901356866996f4be29f
+67c8578090f1a53e8894aeff88abd6cd8b83ff15
+6e0bff220e2bf51308596c19ee258835ce509dd8
+11457187ad0f9c2c269b80de84b0fd9ea278dfe5
+2a833a976688b3139678e4954162a9c00d32d0f4
+$ git rev-list --first-parent --count v0.31.0..2a833a976688b3139678e4954162a9c00d32d0f4
+6
+```
+
+| first-parent commit | classification | release inventory |
+| --- | --- | --- |
+| `1b3c7229cfe8c8f8565034a7e2220a94ac14785b` | G795 / PR #1740 / issue #1737 | included |
+| `09b1f4edca51f3acbbe3e901356866996f4be29f` | G798 / PR #1742 / issue #1741 | included |
+| `67c8578090f1a53e8894aeff88abd6cd8b83ff15` | G796 / PR #1743 / issue #1738 | included |
+| `6e0bff220e2bf51308596c19ee258835ce509dd8` | G800 / PR #1747 / issue #1745 | included |
+| `11457187ad0f9c2c269b80de84b0fd9ea278dfe5` | G797 / PR #1746 / issue #1739 | included |
+| `2a833a976688b3139678e4954162a9c00d32d0f4` | G801 / PR #1749 / issue #1748 | included |
+
+The first-parent range contains exactly these six merge commits and nothing
+else; the table is not a changelog of second-parent commits.
+
+## Alias promise and compatibility boundary
+
+The role-renaming release is safe for existing hosts: the four legacy names
+`design`, `orchestration`, `implementation`, and `review` still work as aliases
+for Architect, Orchestrator, Builder, and Reviewer. Existing roles
+configuration keeps loading, existing queue-state keeps reading and
+displaying, and no installed guide route changed name. These are compatibility
+promises, not new route claims; the release only teaches canonical role values
+in new guidance.
+
+## Truthfulness and prepare-only boundaries
+
+- G795's five canonical roles and four aliases are normalized once; unknown
+  role values are refused rather than silently persisted.
+- G798's roles configuration remains loadable and queue-state `worker_role` /
+  `review_role` values remain read/display fields, not runtime behavior.
+- G796's ruling payload remains opaque: bytes, digest, and origin are retained;
+  only the specified relay envelope may be added.
+- G800's research delegation requires a source-bearing finding and refuses a
+  ruling-bearing report while naming the judgement seat that must rule. Direct
+  Architect and Reviewer research is successful and is not a gate. Visibility
+  counts are measurements without grading, and no size threshold, model name,
+  or runtime condition is used.
+- No tag, GitHub Release, package publish, workflow or publish-configuration
+  change, consumer follow-up, or product-source change belongs to this
+  prepare-only slice.
+
+## Prepare-only verification
+
+`ReleaseNotesV0320G802Tests` compares the EN/JA unit/PR/issue/merge tuples,
+asserts the four alias statements in both mirrors, checks the three measured
+identities and exact six-commit inventory, and deliberately fails on a
+one-field mirror mutation. `ReleasePackageMetadataTests` continues to guard
+the policy shape and demanded next-version placeholder. The PR pastes actual
+parent absence/failure output for each new test, criterion-named release-policy
+output, `git diff --check`, focused Release counts, full CLI Release counts,
+and exact-head CI. The diff is limited to the EN/JA v0.32.0 notes, the
+v0.32.1 planning placeholders, `eng/version.json`, and tests; it contains no
+tag, GitHub Release, package publish, workflow/publish-config, or product
+source change.

--- a/docs/en/release-notes-v0.32.1.md
+++ b/docs/en/release-notes-v0.32.1.md
@@ -1,0 +1,8 @@
+# Release Notes — intent-cli v0.32.1
+
+> **DRAFT / UNRELEASED.** This replaceable planning scaffold is not a changelog.
+> The next release-prep packet will replace this placeholder after measuring the next release.
+
+This placeholder intentionally contains no release entries. No tag, GitHub
+Release, or package publish exists for v0.32.1. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.32.1`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3051,63 +3051,56 @@ result は literal bytes の削減、追加した reference bytes、record の n
 `shrink-audit.jsonl` に明記します。`.intent-cli/runs/*.provider.jsonl` は別の provider-run state なので
 scope 外です。`--dry-run` なら manifest、JSONL、audit を書き込まずに測定済み plan だけを確認できます。
 
-### 次リリース準備(v0.31.1)
+### 次リリース準備(v0.32.1)
 
 **RELEASE PREPARED / NOT PUBLISHED。**
 
-G792 は G788、G789、G791、G790 の四つの first-parent merge 後の exact named
-product base `79a245c655e17ac654ac440fda31709ee38e28b8` から v0.31.0 preparation を測定しました。
-normal clean Release build は `intent-cli 0.31.1-79a245c-G791` を返します。これは新しい
-`nextVersion` placeholder identity であり、**v0.31.0 ではありません**。同じ base を
-explicit `-p:Version=0.31.0` で build すると `intent-cli 0.31.0-79a245c-G791` を返します。
-published v0.31.0 は `release.yml` の release tag の `RAW` から `VERSION` を導出し、
+G802 は G795、G798、G796、G800、G797、G801 の六つの first-parent merge 後の exact named
+product base `2a833a976688b3139678e4954162a9c00d32d0f4` から v0.32.0 preparation を測定しました。
+normal clean Release build は `intent-cli 0.32.1-2a833a9-G801` を返します。これは新しい
+`nextVersion` placeholder identity であり、**v0.32.0 ではありません**。同じ base を
+explicit `-p:Version=0.32.0` で build すると `intent-cli 0.32.0-2a833a9-G801` を返します。
+published v0.32.0 は `release.yml` の release tag の `RAW` から `VERSION` を導出し、
 `eng/version.json` は local builds と dry runs だけを管理します。
 
-prepared files は `release-notes-v0.31.0.md` と
-`release-notes-v0.31.1.md` の DRAFT stub です。current policy は次のとおりです:
+prepared files は `release-notes-v0.32.0.md` と
+`release-notes-v0.32.1.md` の DRAFT stub です。current policy は次のとおりです:
 
 ```json
 {
-  "stableVersion": "0.31.0",
-  "nextVersion": "0.31.1"
+  "stableVersion": "0.32.0",
+  "nextVersion": "0.32.1"
 }
 ```
 
-`0.31.1` は replaceable development placeholder であり、次の real release number
+`0.32.1` は replaceable development placeholder であり、次の real release number
 ではありません。tag、GitHub Release、package publish、workflow change、product source
 change はこの prepare-only slice に含みません。
 
-active package-policy evidence は `stableVersion 0.31.0`、`nextVersion 0.31.1`、local
-candidate `JTechJapan.IntentSystem.Cli.0.31.1.nupkg` です。host-only release-prep claim boundary は
-`release-prep:<owner/repo>:0.31.0` で、この child release-prep は提供済みの権限を使い、
-host state を inspect/mutate しません。exact four-unit inventory は G788、G789、G791、G790
-で、EN/JA の unit/PR/issue/merge tuple と consumer-follow-up parity、measured identity、
-truthfulness、placeholder check は `ReleaseNotesV0310DocsTests` が guard し、
-`ReleasePackageMetadataTests` は release-policy shape と next-version note を引き続き guard します。
-G788 の evidence source、G789 の guide block、G791 の nested-pointer-drift classification は
-extra command route ではなく option/behavior addition です。
-
-minor の測定判断は v0.28.0 の rule に従います: **a command-route addition is a minor bump;
-option-level additions do not count as command routes.** tagged v0.30.0 tool には
-`session-layer inspect` がなく、named base がこの read-only command route を一つ追加しました。
-G788 evidence source/informational output、G789 guide text、G791 nested-pointer-drift
-classification は列挙しますが route としては数えません。
-current readiness record は `metadata_write_branch` topology evidence と
-`--verify`、`--accept-evidence-gap`、`--shell-policy` の option-level surface も保持します。
-まだ GitHub Release は存在しません。
+active package-policy evidence は `stableVersion 0.32.0`、`nextVersion 0.32.1`、local
+candidate `JTechJapan.IntentSystem.Cli.0.32.1.nupkg` です。host-only release-prep claim boundary は
+`release-prep:<owner/repo>:0.32.0` で、この child release-prep は提供済みの権限を使い、
+host state を inspect/mutate しません。exact six-unit inventory は G795、G798、G796、G800、G797、G801
+で、EN/JA の unit/PR/issue/merge tuple、measured identity、alias promise、placeholder check は
+`ReleaseNotesV0320G802Tests` が guard し、`ReleasePackageMetadataTests` は release-policy shape と
+next-version note を引き続き guard します。
+G796 と G800 は command-route additions なので minor として数え、alias table/config repair、guide
+rendering、npm dist-tag behavior は列挙しますが routes としては **not counted** です。既存の route names
+と option-level surfaces は変更せず、GitHub Release はまだ存在しません。
 policy-derived next-version placeholder boundary は
-`release-prep:<owner/repo>:0.31.1` のままで、prepared release target は
-`release-prep:<owner/repo>:0.31.0` です。
+`release-prep:<owner/repo>:0.32.1` のままで、prepared release target は
+`release-prep:<owner/repo>:0.32.0` です。
 
-G792 の truthfulness boundary は次のとおりです。delivered-never-executed finding は downstream
-delegation、同じ execution-unit token を持つ child report、または queue transition を execution
-evidence として数え、true stall では引き続き発火し、absence を断定せず checked list を示します。
-`session-layer inspect` は read-only で、recorded topology または明示的 `--role` からだけ target
-を解決し、focus default を持たず、session layer unavailable のとき exit 0 となり、dialog に回答しません。
-その経路は `notify adjudicate` のままです。host guard は別 domain の nested pointer drift に対して、
-すべての nested checkout が clean の場合だけ進み、uncommitted nested content は拒否し、他 domain の
-submodule には書き込みません。G789 design-thread の Orca block は non-normative で、intent-cli は
-Orca を launch も manage もしません。
+readiness record は `metadata_write_branch` topology evidence と
+`--verify`、`--accept-evidence-gap`、`--shell-policy` の option-level surface も保持します。
+
+G802 の compatibility promise は次のとおりです。legacy names `design`、`orchestration`、
+`implementation`、`review` の四つは Architect、Orchestrator、Builder、Reviewer の aliases として
+still work します。Existing roles configuration keeps loading、existing queue-state keeps reading and
+displaying、no installed guide route changed name です。これは compatibility promise であり、new route
+claim ではありません。G795 canonical role/unknown-role refusal、G798 の read/display queue fields、
+G796 の ruling bytes/digest/origin boundary、G800 の sourced-finding/no-ruling/direct-research boundary、
+G801 の SemVer prerelease tag behavior もそのままです。size threshold、model name、runtime check は使いません。
 
 ### previous v0.29.0 release-prep evidence (history のみ)
 

--- a/docs/ja/release-notes-v0.32.0.md
+++ b/docs/ja/release-notes-v0.32.0.md
@@ -1,0 +1,151 @@
+# リリースノート — intent-cli v0.32.0
+
+> **PREPARED / NOT PUBLISHED。** これは測定済み G795–G801 chain の
+> prepare-only notes です。tag / GitHub Release / package publish、workflow または
+> publish configuration、consumer follow-up、product source の変更は行いません。
+
+v0.32.0 の GitHub Release はまだ存在せず、この notes は preparation evidence だけです。
+matching install query は `JTechJapan.IntentSystem.Cli --version 0.32.0` です。
+この preparation 後の policy は次のとおりです:
+
+```json
+{
+  "stableVersion": "0.32.0",
+  "nextVersion": "0.32.1"
+}
+```
+
+`0.32.1` は replaceable development placeholder であり、次の real release number の決定では
+ありません。EN/JA の v0.32.1 file は planning scaffold であり、changelog ではありません。
+normal identity は placeholder であり **not** v0.32.0（v0.32.0 ではありません）。この
+prepare-only slice は no tag、no GitHub Release、no workflow change、no product source change です。
+
+## 独自に測定した minor justification
+
+named product base は `2a833a976688b3139678e4954162a9c00d32d0f4` です。minor の判断は
+v0.28.0 の auditable rule、**a command-route addition is a minor bump; option-level additions
+do not count as command routes.** に従います。G796 は新しい role への event-kind routing、G800 は
+research-delegation route を追加し、この二つの command-surface route additions が minor の測定済み
+理由です。alias table と config repair、guide rendering、G801 npm dist-tag behavior は列挙しますが
+routes としては **not counted** です。
+
+merged history から route の判断を再現できます: G796 は six-kind event routing addition、G800 は
+first-class research delegation route です。他の変更は command route として数えていません。
+
+## 測定した version identities
+
+policy roll 後の named base を clean Release build で確認しました:
+
+```text
+$ git rev-parse HEAD
+2a833a976688b3139678e4954162a9c00d32d0f4
+$ dotnet build IntentSystem.sln --configuration Release --no-restore; echo BUILD_RC:$?
+BUILD_RC:0
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.32.1-2a833a9-G801
+```
+
+この normal identity は `nextVersion` placeholder であり、**v0.32.0 ではありません**。
+同じ base を explicit release property で測定しました:
+
+```text
+$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.32.0; echo BUILD_RC:$?
+BUILD_RC:0
+$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+intent-cli 0.32.0-2a833a9-G801
+```
+
+published version の third identity は local policy file ではなく `release.yml` が tag から導出します:
+
+```text
+$ raw=v0.32.0; version="${raw#v}"; printf 'RAW=%s\nVERSION=%s\n' "$raw" "$version"
+RAW=v0.32.0
+VERSION=0.32.0
+```
+
+release workflow は `RAW` から `-p:Version=<tag>` を供給し、`eng/version.json` は local builds と
+dry runs だけを管理します。この prepare-only slice は no tag（tag を作成していません）です。
+
+## Release inventory: 正確に六つの first-parent unit
+
+exact first-parent range から inventory を導出しました。Git は merge order で六つの commit を測定し、
+各 commit に一つの operator-observable outcome を記録します:
+
+- G795 — PR #1740 / issue #1737; merge commit `1b3c7229cfe8c8f8565034a7e2220a94ac14785b`。
+  **Operator-observable outcome:** canonical Architect, Orchestrator, Builder, Reviewer, Steward の
+  role values は四つの legacy aliases を受け入れ、unknown role は拒否します。
+- G798 — PR #1742 / issue #1741; merge commit `09b1f4edca51f3acbbe3e901356866996f4be29f`。
+  **Operator-observable outcome:** recorded role configuration は canonical normalizer 経由で
+  load され、queue-state role fields は runtime semantics なしに read/display されます。
+- G796 — PR #1743 / issue #1738; merge commit `67c8578090f1a53e8894aeff88abd6cd8b83ff15`。
+  **Operator-observable outcome:** six event kinds は Steward または Architect に route され、opaque
+  ruling payload は digest と origin の境界を保ったまま byte-identically relay されます。
+- G800 — PR #1747 / issue #1745; merge commit `6e0bff220e2bf51308596c19ee258835ce509dd8`。
+  **Operator-observable outcome:** Architect または Reviewer は sourced research を Orchestrator
+  または Steward へ delegate でき、ruling-bearing research は judgement seat で拒否されます。
+  direct research は ungated です。
+- G797 — PR #1746 / issue #1739; merge commit `11457187ad0f9c2c269b80de84b0fd9ea278dfe5`。
+  **Operator-observable outcome:** guides は canonical roles と Steward を説明し、retired-name
+  glossary を保持し、vendor/runtime role coupling なしに installed route names を保存します。
+- G801 — PR #1749 / issue #1748; merge commit `2a833a976688b3139678e4954162a9c00d32d0f4`。
+  **Operator-observable outcome:** npm publish calls は stable version では `latest`、preview/rc/beta/
+  alpha SemVer では non-default prerelease dist-tag を導出します。
+
+## First-parent accounting
+
+```text
+$ git rev-list --first-parent --reverse v0.31.0..2a833a976688b3139678e4954162a9c00d32d0f4
+1b3c7229cfe8c8f8565034a7e2220a94ac14785b
+09b1f4edca51f3acbbe3e901356866996f4be29f
+67c8578090f1a53e8894aeff88abd6cd8b83ff15
+6e0bff220e2bf51308596c19ee258835ce509dd8
+11457187ad0f9c2c269b80de84b0fd9ea278dfe5
+2a833a976688b3139678e4954162a9c00d32d0f4
+$ git rev-list --first-parent --count v0.31.0..2a833a976688b3139678e4954162a9c00d32d0f4
+6
+```
+
+| first-parent commit | classification | release inventory |
+| --- | --- | --- |
+| `1b3c7229cfe8c8f8565034a7e2220a94ac14785b` | G795 / PR #1740 / issue #1737 | included |
+| `09b1f4edca51f3acbbe3e901356866996f4be29f` | G798 / PR #1742 / issue #1741 | included |
+| `67c8578090f1a53e8894aeff88abd6cd8b83ff15` | G796 / PR #1743 / issue #1738 | included |
+| `6e0bff220e2bf51308596c19ee258835ce509dd8` | G800 / PR #1747 / issue #1745 | included |
+| `11457187ad0f9c2c269b80de84b0fd9ea278dfe5` | G797 / PR #1746 / issue #1739 | included |
+| `2a833a976688b3139678e4954162a9c00d32d0f4` | G801 / PR #1749 / issue #1748 | included |
+
+この first-parent range はこの六つの merge commit だけで、second-parent commit の changelog ではありません。
+
+## Alias promise and compatibility boundary
+
+role-renaming release は existing host と互換です。legacy names `design`、`orchestration`、
+`implementation`、`review` の四つは Architect、Orchestrator、Builder、Reviewer の aliases として
+still work します。Existing roles configuration keeps loading、existing queue-state keeps reading and
+displaying、no installed guide route changed name です。これは compatibility promise であり、new route
+claim ではありません。
+
+## Truthfulness と prepare-only boundaries
+
+- G795 の five canonical roles と four aliases は一つの normalizer で処理し、unknown role は黙って
+  persist せず refusal します。
+- G798 の roles configuration は loadable のまま、queue-state `worker_role` / `review_role` は
+  runtime behavior ではなく read/display fields のままです。
+- G796 の ruling payload は opaque で、bytes、digest、origin を保持し、指定された relay envelope
+  だけを追加できます。
+- G800 の research delegation は source-bearing finding を要求し、ruling-bearing report は finding
+  を rule すべき judgement seat を名前にして拒否します。Direct Architect/Reviewer research は成功し、
+  gate ではありません。Visibility counts は grading なしの measurement で、size threshold、model name、
+  runtime condition は使いません。
+- この prepare-only slice には tag、GitHub Release、package publish、workflow/publish configuration、
+  consumer follow-up、product source の変更はありません。
+
+## Prepare-only verification
+
+`ReleaseNotesV0320G802Tests` は EN/JA の unit/PR/issue/merge tuples を比較し、両 mirror の四つの
+alias statements、三つの measured identities、exact six-commit inventory を guard し、一フィールドの
+mirror mutation で意図的に fail します。`ReleasePackageMetadataTests` は policy shape と demanded
+next-version placeholder を引き続き guard します。PR には各 new test の parent absence/failure actual
+output、criterion-named release-policy output、`git diff --check`、focused/full Release counts、exact-head
+CI を貼ります。diff は EN/JA v0.32.0 notes、v0.32.1 planning placeholders、`eng/version.json`、tests に
+限定され、tag / GitHub Release / package publish / workflow または publish-config / product source change
+は含みません。

--- a/docs/ja/release-notes-v0.32.1.md
+++ b/docs/ja/release-notes-v0.32.1.md
@@ -1,0 +1,8 @@
+# リリースノート — intent-cli v0.32.1
+
+> **DRAFT / 未リリース。** これは replaceable planning scaffold であり、changelog ではありません。
+> 次の release-prep packet が次の release を測定した後にこの placeholder を置き換えます。
+
+この placeholder には release entry を記録しません。v0.32.1 の tag、GitHub
+Release、package publish はまだ存在しません。matching install query は
+`JTechJapan.IntentSystem.Cli --version 0.32.1` です。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.31.0",
-  "nextVersion": "0.31.1"
+  "stableVersion": "0.32.0",
+  "nextVersion": "0.32.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
@@ -169,8 +169,8 @@ public sealed class ReleaseNotesV0240DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -198,7 +198,7 @@ public sealed class ReleaseNotesV0240DocsTests
             Assert.DoesNotContain("release-notes-v0.27.0.md", reference, StringComparison.Ordinal);
             Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
             Assert.Contains(
-                language == "en" ? "Next release readiness (v0.31.1)" : "次リリース準備(v0.31.1)",
+                language == "en" ? "Next release readiness (v0.32.1)" : "次リリース準備(v0.32.1)",
                 reference,
                 StringComparison.Ordinal);
             Assert.Contains("intent-cli 0.29.0-65e02d8-G772", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
@@ -165,8 +165,8 @@ public sealed class ReleaseNotesV0250DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
 
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -193,7 +193,7 @@ public sealed class ReleaseNotesV0250DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.31.1)" : "次リリース準備(v0.31.1)",
+            language == "en" ? "Next release readiness (v0.32.1)" : "次リリース準備(v0.32.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(CurrentStableInstallDisplayIdentity, reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
@@ -214,12 +214,12 @@ public sealed class ReleaseNotesV0260DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policyPath = Path.Combine(root, "eng", "version.json");
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.32.0\",\n  \"nextVersion\": \"0.32.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
@@ -155,12 +155,12 @@ public sealed class ReleaseNotesV0270DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.32.0\",\n  \"nextVersion\": \"0.32.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
@@ -18,12 +18,12 @@ public sealed class ReleaseNotesV0271DocsTests
         var policyPath = Path.Combine(root, "eng", "version.json");
 
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.32.0\",\n  \"nextVersion\": \"0.32.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
@@ -156,12 +156,12 @@ public sealed class ReleaseNotesV0280DocsTests
         var policyPath = Path.Combine(root, "eng", "version.json");
 
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.32.0\",\n  \"nextVersion\": \"0.32.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
@@ -124,12 +124,12 @@ public sealed class ReleaseNotesV0290DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.32.0\",\n  \"nextVersion\": \"0.32.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -151,7 +151,7 @@ public sealed class ReleaseNotesV0290DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "### Next release readiness (v0.31.1)" : "### 次リリース準備(v0.31.1)",
+            language == "en" ? "### Next release readiness (v0.32.1)" : "### 次リリース準備(v0.32.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(NormalBaseIdentity, reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
@@ -179,17 +179,17 @@ public sealed class ReleaseNotesV0300DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.32.0\",\n  \"nextVersion\": \"0.32.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.30.0.md")));
-            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.31.1.md"));
+            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.32.1.md"));
             Assert.Contains("DRAFT", stub, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(language == "en" ? "not a changelog" : "changelog ではありません", stub, StringComparison.OrdinalIgnoreCase);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
@@ -14,8 +14,8 @@ public sealed class ReleaseNotesV0310DocsTests
     private const string Base = "fed2bbc74449b389565b8241732fe376b7a1c421";
     private const string NormalPlaceholderIdentity = "intent-cli 0.31.1-fed2bbc-G793";
     private const string ExplicitReleaseIdentity = "intent-cli 0.31.0-fed2bbc-G793";
-    private const string DeveloperReferenceNormalIdentity = "intent-cli 0.31.1-79a245c-G791";
-    private const string DeveloperReferenceExplicitIdentity = "intent-cli 0.31.0-79a245c-G791";
+    private const string DeveloperReferenceNormalIdentity = "intent-cli 0.32.1-2a833a9-G801";
+    private const string DeveloperReferenceExplicitIdentity = "intent-cli 0.32.0-2a833a9-G801";
     private const string TaggedIdentity = "intent-cli 0.30.0-f4b01c2-G772";
 
     private static readonly (string Unit, string Pr, string Issue, string Merge)[] Units =
@@ -186,17 +186,17 @@ public sealed class ReleaseNotesV0310DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.31.0\",\n  \"nextVersion\": \"0.31.1\"\n}\n",
+            "{\n  \"stableVersion\": \"0.32.0\",\n  \"nextVersion\": \"0.32.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.31.0", policy.StableVersion);
-        Assert.Equal("0.31.1", policy.NextVersion);
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.31.0.md")));
-            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.31.1.md"));
+            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.32.1.md"));
             Assert.Contains("DRAFT", stub, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(language == "en" ? "not a changelog" : "changelog ではありません", stub, StringComparison.OrdinalIgnoreCase);
@@ -213,14 +213,14 @@ public sealed class ReleaseNotesV0310DocsTests
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "### Next release readiness (v0.31.1)" : "### 次リリース準備(v0.31.1)",
+            language == "en" ? "### Next release readiness (v0.32.1)" : "### 次リリース準備(v0.32.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(DeveloperReferenceNormalIdentity, reference, StringComparison.Ordinal);
         Assert.Contains(DeveloperReferenceExplicitIdentity, reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.31.0.md", reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.31.1.md", reference, StringComparison.Ordinal);
-        Assert.Contains("ReleaseNotesV0310DocsTests", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.32.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.32.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0320G802Tests", reference, StringComparison.Ordinal);
         Assert.Contains("ReleasePackageMetadataTests", reference, StringComparison.Ordinal);
     }
 

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
@@ -1,0 +1,186 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G802: v0.32.0 is a measured, prepare-only release line. These guards keep
+/// the six first-parent units, the alias compatibility promise, the three
+/// version identities, EN/JA parity, and the version-policy roll durable.
+/// </summary>
+public sealed class ReleaseNotesV0320G802Tests
+{
+    private const string Base = "2a833a976688b3139678e4954162a9c00d32d0f4";
+    private const string NormalPlaceholderIdentity = "intent-cli 0.32.1-2a833a9-G801";
+    private const string ExplicitReleaseIdentity = "intent-cli 0.32.0-2a833a9-G801";
+
+    private static readonly (string Unit, string Pr, string Issue, string Merge)[] Units =
+    [
+        ("G795", "#1740", "#1737", "1b3c7229cfe8c8f8565034a7e2220a94ac14785b"),
+        ("G798", "#1742", "#1741", "09b1f4edca51f3acbbe3e901356866996f4be29f"),
+        ("G796", "#1743", "#1738", "67c8578090f1a53e8894aeff88abd6cd8b83ff15"),
+        ("G800", "#1747", "#1745", "6e0bff220e2bf51308596c19ee258835ce509dd8"),
+        ("G797", "#1746", "#1739", "11457187ad0f9c2c269b80de84b0fd9ea278dfe5"),
+        ("G801", "#1749", "#1748", "2a833a976688b3139678e4954162a9c00d32d0f4"),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyTheSixGitDerivedUnits(string language)
+    {
+        var notes = ReadNotes(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(6, listed.Length);
+
+        foreach (var unit in Units)
+        {
+            var entry = FindEntry(notes, unit.Unit);
+            Assert.NotEmpty(entry);
+            Assert.Contains($"PR {unit.Pr} / issue {unit.Issue};", entry, StringComparison.Ordinal);
+            Assert.Contains($"merge commit `{unit.Merge}`", entry, StringComparison.Ordinal);
+            Assert.Contains("Operator-observable outcome", entry, StringComparison.Ordinal);
+        }
+
+        Console.WriteLine($"G802 AC1 {language}: six_units={string.Join(',', listed)}; base={Base}");
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void AliasPromiseRendersAllFourStatements(string language)
+    {
+        var notes = Normalize(ReadNotes(language));
+
+        Assert.Contains("design", notes, StringComparison.Ordinal);
+        Assert.Contains("orchestration", notes, StringComparison.Ordinal);
+        Assert.Contains("implementation", notes, StringComparison.Ordinal);
+        Assert.Contains("review", notes, StringComparison.Ordinal);
+        Assert.Contains("still work", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("existing roles configuration keeps loading", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("existing queue-state keeps reading and displaying", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no installed guide route changed name", notes, StringComparison.OrdinalIgnoreCase);
+
+        Console.WriteLine($"G802 AC2 {language}: legacy_aliases=design,orchestration,implementation,review; config_loading=preserved; queue_state_read_display=preserved; guide_routes=unchanged");
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinThreeMeasuredVersionIdentities(string language)
+    {
+        var notes = ReadNotes(language);
+
+        Assert.Contains(Base, notes, StringComparison.Ordinal);
+        Assert.Contains(NormalPlaceholderIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains(ExplicitReleaseIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains("dotnet build IntentSystem.sln --configuration Release", notes, StringComparison.Ordinal);
+        Assert.Contains("-p:Version=0.32.0", notes, StringComparison.Ordinal);
+        Assert.Contains("release.yml", notes, StringComparison.Ordinal);
+        Assert.Contains("RAW=v0.32.0", notes, StringComparison.Ordinal);
+        Assert.Contains("VERSION=0.32.0", notes, StringComparison.Ordinal);
+        Assert.Contains("eng/version.json", notes, StringComparison.Ordinal);
+        Assert.Contains("local builds", notes, StringComparison.Ordinal);
+        Assert.Contains("dry runs", notes, StringComparison.Ordinal);
+        Assert.Contains("**not** v0.32.0", Normalize(notes), StringComparison.Ordinal);
+
+        Console.WriteLine($"G802 AC3 {language}: normal={NormalPlaceholderIdentity}; explicit={ExplicitReleaseIdentity}; published=RAW=v0.32.0 -> VERSION=0.32.0");
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseMirrorsHaveIdenticalUnitPrIssueAndMergeTuples()
+    {
+        var english = ParseInventory(ReadNotes("en"));
+        var japanese = ParseInventory(ReadNotes("ja"));
+
+        Assert.Equal(Units, english);
+        Assert.Equal(english, japanese);
+        Console.WriteLine($"G802 AC4 parity: en=ja; tuples={english.Count}; mutation_guard=ready");
+    }
+
+    [Fact]
+    public void MirrorParityDetectsSingleFieldMutation()
+    {
+        var english = ParseInventory(ReadNotes("en"));
+        var japanese = ReadNotes("ja");
+        var changedJapanese = japanese.Replace(
+            "issue #1737",
+            "issue #9999",
+            StringComparison.Ordinal);
+        var mutated = ParseInventory(changedJapanese);
+
+        Assert.False(english.SequenceEqual(mutated));
+        Console.WriteLine($"G802 AC4 parity mutation: changed=issue #1737->#9999; equal={english.SequenceEqual(mutated)}; result=FAIL (expected guard)");
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinMinorRouteDecisionAndPrepareOnlyBoundary(string language)
+    {
+        var notes = Normalize(ReadNotes(language));
+
+        Assert.Contains("G796", notes, StringComparison.Ordinal);
+        Assert.Contains("G800", notes, StringComparison.Ordinal);
+        Assert.Contains("command-route addition is a minor", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("option-level additions do not count as command routes", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not counted", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("PREPARED / NOT PUBLISHED", notes, StringComparison.Ordinal);
+        Assert.Contains("no tag", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no GitHub Release", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no workflow", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no product source", notes, StringComparison.OrdinalIgnoreCase);
+
+        Console.WriteLine($"G802 AC5 {language}: routes_counted=G796,G800; alias/config/guide/npm=not counted; prepare_only=true");
+    }
+
+    [Fact]
+    public void VersionPolicyRollAndPlaceholderNotesAreExact()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        Assert.Equal(
+            "{\n  \"stableVersion\": \"0.32.0\",\n  \"nextVersion\": \"0.32.1\"\n}\n",
+            File.ReadAllText(Path.Combine(root, "eng", "version.json")));
+
+        var policy = RepoVersionPolicySource.Read();
+        Assert.Equal("0.32.0", policy.StableVersion);
+        Assert.Equal("0.32.1", policy.NextVersion);
+
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.32.1.md"));
+            Assert.Contains("DRAFT", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("changelog", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("- G", stub, StringComparison.Ordinal);
+        }
+
+        Console.WriteLine("G802 AC6 policy: stableVersion=0.32.0; nextVersion=0.32.1; placeholders=en,ja; entries=0");
+    }
+
+    private static string FindEntry(string notes, string unit)
+    {
+        var match = Regex.Match(notes, $"(?ms)^- {Regex.Escape(unit)} —.*?(?=^- |^## |\\z)");
+        return match.Success ? match.Value : string.Empty;
+    }
+
+    private static IReadOnlyList<(string Unit, string Pr, string Issue, string Merge)> ParseInventory(string notes) =>
+        Regex.Matches(
+                notes,
+                @"(?ms)^- (G\d+) — PR (#\d+) / issue (#\d+); merge commit `([0-9a-f]{40})`.*?(?=^- |^## |\z)")
+            .Select(match => (
+                match.Groups[1].Value,
+                match.Groups[2].Value,
+                match.Groups[3].Value,
+                match.Groups[4].Value))
+            .ToArray();
+
+    private static string Normalize(string value) => Regex.Replace(value, @"\s+", " ");
+
+    private static string ReadNotes(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.32.0.md"));
+}


### PR DESCRIPTION
Closes #1750

# G802 — prepare-only v0.32.0 release

This PR prepares the v0.32.0 policy/version-note roll only. It does not tag, create a GitHub Release, publish packages, change workflows, or alter product source.

## Criterion 1 (AC1) — exact first-parent merge inventory

Base: `v0.31.0`; current first-parent base: `2a833a976688b3139678e4954162a9c00d32d0f4`.

Measured command:

```text
git rev-list --first-parent --count v0.31.0..origin/main
6
```

The six first-parent units, in order, are:

```text
1b3c7229cfe8c8f8565034a7e2220a94ac14785b  G795  #1737  PR #1740
09b1f4edca51f3acbbe3e901356866996f4be29f  G798  #1741  PR #1742
67c8578090f1a53e8894aeff88abd6cd8b83ff15  G796  #1738  PR #1743
6e0bff220e2bf51308596c19ee258835ce509dd8  G800  #1745  PR #1747
11457187ad0f9c2c269b80de84b0fd9ea278dfe5  G797  #1739  PR #1746
2a833a976688b3139678e4954162a9c00d32d0f4  G801  #1748  PR #1749
```

Focused test output:

```text
Criterion 1 actual collected output:
G802 AC1 ja: six_units=G795,G798,G796,G800,G797,G801; base=2a833a976688b3139678e4954162a9c00d32d0f4
G802 AC1 en: six_units=G795,G798,G796,G800,G797,G801; base=2a833a976688b3139678e4954162a9c00d32d0f4
```

## Criterion 2 (AC2) — legacy aliases and compatibility promises

The EN/JA rendered notes state the four aliases `design`, `orchestration`, `implementation`, and `review`, and preserve roles configuration loading, queue-state read/display, and all guide route names.

```text
Criterion 2 actual collected output:
G802 AC2 en/ja: legacy_aliases=design,orchestration,implementation,review; config_loading=preserved; queue_state_read_display=preserved; guide_routes=unchanged
```

## Criterion 3 (AC3) — three version identities and publish derivation

The measured identities are:

```text
Criterion 3 actual collected output:
G802 AC3 en/ja: normal=intent-cli 0.32.1-2a833a9-G801; explicit=intent-cli 0.32.0-2a833a9-G801; published=RAW=v0.32.0 -> VERSION=0.32.0
```

## Criterion 4 (AC4) — EN/JA tuple parity and mutation guard

```text
Criterion 4 actual collected output:
G802 AC4 parity: en=ja; tuples=6; mutation_guard=ready
G802 AC4 parity mutation: changed=issue #1737->#9999; equal=False; result=FAIL (expected guard)
```

The mutation intentionally changes one issue tuple; the parity guard fails as required.

## Criterion 5 (AC5) — measured minor rationale and prepare-only boundary

```text
Criterion 5 actual collected output:
G802 AC5 en/ja: routes_counted=G796,G800; alias/config/guide/npm=not counted; prepare_only=true
```

The route-addition rationale counts only the G796/G800 route additions. Alias/configuration/guide wording and npm publish behavior are explicitly not counted. No release or publish action is performed by this PR.

## Criterion 6 (AC6) — policy roll and placeholders

```text
Criterion 6 actual collected output:
G802 AC6 policy: stableVersion=0.32.0; nextVersion=0.32.1; placeholders=en,ja; entries=0
```

`eng/version.json` is the only policy source rolled. The required EN/JA v0.32.1 placeholders are draft/replaceable and contain no release entries.

## Criterion 7 (AC7) — changed-path and scope evidence

The committed path inventory is exactly:

```text
Criterion 7 actual collected output:
docs/en/09-developer-reference.md
docs/en/release-notes-v0.32.0.md
docs/en/release-notes-v0.32.1.md
docs/ja/09-developer-reference.md
docs/ja/release-notes-v0.32.0.md
docs/ja/release-notes-v0.32.1.md
eng/version.json
tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0280DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0290DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0300DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0310DocsTests.cs
tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
```

Measured scope checks:

```text
$ git diff --name-only origin/main...HEAD -- src
(no output)
$ git diff -- .github/workflows/release.yml
(no output)
$ git diff --check
(no output)
```

The developer-reference edits only update current-policy readiness documentation and preserve the existing compatibility markers and routes.

## Criterion 8 (AC8) — parent absence/failure evidence

The new G802 tests and notes are absent from the direct parent; the unchanged parent policy is shown separately:

```text
Criterion 8 actual collected output:
$ git show origin/main:tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs' exists on disk, but not in 'origin/main'
PARENT_G802_TEST_RC:128
$ git show origin/main:docs/en/release-notes-v0.32.0.md
fatal: path 'docs/en/release-notes-v0.32.0.md' exists on disk, but not in 'origin/main'
PARENT_EN_NOTES_RC:128
$ git show origin/main:eng/version.json
{
  "stableVersion": "0.31.0",
  "nextVersion": "0.31.1"
}
PARENT_POLICY_RC:0
```

## Criterion 9 (AC9) — focused and full Release validation

Focused G802 TRX (`ReleaseNotesV0320G802Tests`): total 11, executed 11, passed 11, failed 0.

Compatibility regression set: total 150, passed 150, failed 0.

Final full CLI Release TRX (authoritative):

```text
Criterion 9 actual collected output:
RC:0
<ResultSummary outcome="Completed">
<Counters total="5754" executed="5753" passed="5753" failed="0" error="0" ... />
```

The single non-executed test is the expected skip; all 5,753 executed tests passed. The exact pushed implementation head is `72bb975e00e326c993e3346c81126f0b196d177f`.
