### PR TITLE
G803: canonicalize structured guide role identifiers

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideRoleVocabulary.cs
+++ b/src/IntentSystem.Cli/Commands/GuideRoleVocabulary.cs
@@ -85,7 +85,19 @@ internal static class GuideRoleVocabulary
                 projected = projected.Replace($"{flag} {alias}", $"{flag} {canonical}", StringComparison.Ordinal);
             }
 
-            foreach (var property in new[] { "role", "from", "to", "report_to", "thread", "owner_role" })
+            // Structured guide payloads carry role identifiers in more than
+            // the original command-envelope fields. Keep this list at the
+            // one rendering boundary so every structured role value still
+            // resolves through LogicalRoleNormalizer, while human-facing
+            // herdr pane labels remain untouched.
+            foreach (var property in new[]
+            {
+                "role", "from", "to", "report_to", "thread", "owner_role",
+                "answerable_by", "decision_actor_role", "adjudication_target_role",
+                "subject_role", "wake_target_role", "agent_role", "role_identifier",
+                "logical_role", "review_role", "worker_role", "sender_role",
+                "recipient_role", "destination_role",
+            })
             {
                 projected = projected.Replace($"\"{property}\":\"{alias}\"", $"\"{property}\":\"{canonical}\"", StringComparison.Ordinal);
                 projected = projected.Replace($"\"{property}\": \"{alias}\"", $"\"{property}\": \"{canonical}\"", StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/GuideRoleNamesG797Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideRoleNamesG797Tests.cs
@@ -265,6 +265,15 @@ public sealed class GuideRoleNamesG797Tests
             $@"(?ix)(?:\b{roleMarker}\b[^\r\n]{{0,120}}\bdefault(?:ed|s)?\b[^\r\n]{{0,120}}\b{vendor}\b|\b{vendor}\b[^\r\n]{{0,120}}\bdefault(?:ed|s)?\b[^\r\n]{{0,120}}\b{roleMarker}\b)",
             RegexOptions.Compiled);
 
+        using (var legacyStructuredFixture = JsonDocument.Parse("{\"answerable_by\":\"orchestration\"}"))
+        {
+            var fixtureFields = new List<string>();
+            CollectStructuredRoleFields(legacyStructuredFixture.RootElement, "$", fixtureFields);
+            var fixtureLegacyFields = fixtureFields.Where(IsLegacyStructuredRoleValue).ToArray();
+            Assert.Single(fixtureLegacyFields);
+            Console.WriteLine($"G797 AC6/G803 structured-fixture: legacy_field={fixtureLegacyFields[0]}; scan_result=FAIL (expected guard)");
+        }
+
         foreach (var (name, render) in surfaces)
         {
             foreach (var format in new[] { "markdown", "json" })
@@ -277,14 +286,108 @@ public sealed class GuideRoleNamesG797Tests
 
                 Assert.Empty(fusedMatches);
                 Assert.Empty(defaultMatches);
+                string[] structuredLegacyFields;
+                if (format == "json")
+                {
+                    using var jsonDocument = JsonDocument.Parse(output);
+                    var jsonFields = new List<string>();
+                    CollectStructuredRoleFields(jsonDocument.RootElement, "$", jsonFields);
+                    structuredLegacyFields = jsonFields.Where(IsLegacyStructuredRoleValue).ToArray();
+                }
+                else
+                {
+                    structuredLegacyFields = Regex.Matches(
+                            output,
+                            @"\\?""(?:role|from|to|report_to|thread|owner_role|answerable_by|decision_actor_role|adjudication_target_role|subject_role|wake_target_role|agent_role|role_identifier|logical_role|review_role|worker_role|sender_role|recipient_role|destination_role)\\?""\s*:\s*\\?""(?:design|orchestration|implementation|review)\\?""",
+                            RegexOptions.IgnoreCase)
+                        .Select(match => match.Value)
+                        .ToArray();
+                }
+                Assert.Empty(structuredLegacyFields);
                 if (name == "guide orchestrator-thread")
                 {
                     Assert.Contains("running on a sandboxed Codex runtime", output, StringComparison.Ordinal);
                 }
 
-                Console.WriteLine($"G797 AC6 round5 full-payload-scan {name} format={format}: fused_role_vendor={fusedMatches.Length}; vendor_defaults={defaultMatches.Length}; matches=<none>");
+                Console.WriteLine($"G797 AC6/G803 round5 full-payload-scan {name} format={format}: fused_role_vendor={fusedMatches.Length}; vendor_defaults={defaultMatches.Length}; structured_legacy={structuredLegacyFields.Length}; matches=<none>");
             }
         }
+    }
+
+    [Fact]
+    public void StructuredRoleInventoryAndCanonicalProjection_G803()
+    {
+        var context = CreateContext();
+        var surfaces = new (string Name, Func<TextWriter, int> Render)[]
+        {
+            ("guide design-thread", writer => GuideDesignThreadCommand.Execute(context, ["--format", "json"], writer)),
+            ("guide orchestrator-thread", writer => GuideOrchestratorThreadCommand.Execute(context, ["--format", "json"], writer)),
+            ("guide workflow task implementation-loop", writer => GuideWorkflowTaskImplementationLoopCommand.Execute(context, ["--format", "json"], writer)),
+            ("guide workflow task review-next-slice-loop", writer => GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(context, ["--format", "json"], writer)),
+        };
+
+        var expectedInventory = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "guide orchestrator-thread:$.guide_reachability.routes[].role",
+            "guide orchestrator-thread:$.topology_workspace_move.routes[].role",
+            "guide orchestrator-thread:$.herdr_standard_layout.panes[].role",
+            "guide orchestrator-thread:$.terminal_workspace_provisioning.folder_provisioning.roles[].role",
+            "guide orchestrator-thread:$.terminal_workspace_provisioning.unattended_launch_recipes.copilot_recipe.prompt_classes[].answerable_by",
+            "guide orchestrator-thread:$.terminal_workspace_provisioning.unattended_launch_recipes.codex_recipe.prompt_classes[].answerable_by",
+            "guide orchestrator-thread:$.threads[].role",
+        };
+        var actualInventory = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (name, render) in surfaces)
+        {
+            using var writer = new StringWriter();
+            Assert.Equal(0, render(writer));
+            using var document = JsonDocument.Parse(writer.ToString());
+            var fields = new List<string>();
+            CollectStructuredRoleFields(document.RootElement, "$", fields);
+            var legacyFields = fields.Where(IsLegacyStructuredRoleValue).ToArray();
+            Assert.Empty(legacyFields);
+            foreach (var field in fields)
+            {
+                var separator = field.IndexOf('=');
+                Assert.True(separator > 0, $"Malformed structured inventory item: {field}");
+                actualInventory.Add($"{name}:{NormalizeInventoryPath(field[..separator])}");
+            }
+
+            if (name == "guide orchestrator-thread")
+            {
+                var panes = document.RootElement
+                    .GetProperty("herdr_standard_layout")
+                    .GetProperty("panes")
+                    .EnumerateArray()
+                    .Select(pane => pane.GetProperty("label").GetString() ?? string.Empty)
+                    .ToArray();
+                Assert.Equal(["orchestration", "implementation", "review"], panes);
+                var canonicalAnswerableCount = fields.Count(field => field.EndsWith(".answerable_by=orchestrator", StringComparison.Ordinal));
+                Assert.Equal(4, canonicalAnswerableCount);
+                Assert.DoesNotContain(fields, field => field.EndsWith(".answerable_by=orchestration", StringComparison.Ordinal));
+                Console.WriteLine($"G803 AC3 answerable_by: before=orchestration×4; after=orchestrator×{canonicalAnswerableCount}; legacy_after=0");
+                Console.WriteLine($"G803 AC4 herdr_pane_labels: {string.Join(",", panes)}; unchanged=true");
+            }
+
+            Console.WriteLine($"G803 AC1/AC2 inventory {name}: occurrence_count={fields.Count}; fields={(fields.Count == 0 ? "<none>" : string.Join("; ", fields))}; legacy_values={legacyFields.Length}");
+        }
+
+        Assert.Equal(expectedInventory, actualInventory);
+        Console.WriteLine($"G803 AC1 inventory_entry_count={actualInventory.Count}; expected=7; all_four_surfaces=covered");
+
+        foreach (var (alias, canonical) in LogicalRoleNormalizer.Aliases)
+        {
+            var projected = GuideRoleVocabulary.ProjectRenderedRoleValues($"{{\"answerable_by\":\"{alias}\"}}");
+            Assert.Contains($"\"answerable_by\":\"{canonical}\"", projected, StringComparison.Ordinal);
+            Assert.DoesNotContain($"\"answerable_by\":\"{alias}\"", projected, StringComparison.Ordinal);
+        }
+
+        var vocabularySource = File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "src", "IntentSystem.Cli", "Commands", "GuideRoleVocabulary.cs"));
+        Assert.Contains("LogicalRoleNormalizer.Aliases", vocabularySource, StringComparison.Ordinal);
+        Assert.DoesNotContain("new Dictionary<string, string>", vocabularySource, StringComparison.Ordinal);
+        Console.WriteLine("G803 AC5 projection: GuideRoleVocabulary.Identifier -> LogicalRoleNormalizer; second_alias_table=false");
     }
 
     [Fact]
@@ -420,5 +523,66 @@ public sealed class GuideRoleNamesG797Tests
             .ToArray();
         Assert.Empty(matches);
         Console.WriteLine($"G797 role-bearing canonical projection {surface}: retired_value_matches=0");
+    }
+
+    private static void CollectStructuredRoleFields(JsonElement element, string path, List<string> fields)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    var propertyPath = $"{path}.{property.Name}";
+                    if (IsStructuredRoleProperty(property.Name)
+                        && property.Value.ValueKind == JsonValueKind.String
+                        && IsRecognizedRoleValue(property.Value.GetString()))
+                    {
+                        fields.Add($"{propertyPath}={property.Value.GetString()}");
+                    }
+
+                    CollectStructuredRoleFields(property.Value, propertyPath, fields);
+                }
+
+                break;
+            case JsonValueKind.Array:
+                var index = 0;
+                foreach (var item in element.EnumerateArray())
+                {
+                    CollectStructuredRoleFields(item, $"{path}[{index}]", fields);
+                    index++;
+                }
+
+                break;
+        }
+    }
+
+    private static bool IsStructuredRoleProperty(string name) =>
+        name.Contains("role", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("answerable_by", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("thread", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("destination_thread", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("from", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("to", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("report_to", StringComparison.OrdinalIgnoreCase)
+        || name.Equals("owner", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsLegacyStructuredRoleValue(string field) =>
+        field.EndsWith("=design", StringComparison.OrdinalIgnoreCase)
+        || field.EndsWith("=orchestration", StringComparison.OrdinalIgnoreCase)
+        || field.EndsWith("=implementation", StringComparison.OrdinalIgnoreCase)
+        || field.EndsWith("=review", StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizeInventoryPath(string path) =>
+        Regex.Replace(path, @"\[\d+\]", "[]", RegexOptions.CultureInvariant);
+
+    private static bool IsRecognizedRoleValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var role = value.Split('@', 2)[0];
+        return LogicalRoleNormalizer.TryNormalize(role, out _, out _);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideRoleNamesG797Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideRoleNamesG797Tests.cs
@@ -241,13 +241,7 @@ public sealed class GuideRoleNamesG797Tests
     public void FullRenderedPayloads_MarkdownAndJsonRejectVendorRoleFusionsAndDefaults_G797Round5()
     {
         var context = CreateContext();
-        var surfaces = new (string Name, Func<string, TextWriter, int> Render)[]
-        {
-            ("guide design-thread", (format, writer) => GuideDesignThreadCommand.Execute(context, ["--format", format], writer)),
-            ("guide orchestrator-thread", (format, writer) => GuideOrchestratorThreadCommand.Execute(context, ["--format", format], writer)),
-            ("guide workflow task implementation-loop", (format, writer) => GuideWorkflowTaskImplementationLoopCommand.Execute(context, ["--format", format], writer)),
-            ("guide workflow task review-next-slice-loop", (format, writer) => GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(context, ["--format", format], writer)),
-        };
+        var surfaces = CreateG797RoundFiveSurfaceRenderers(context);
 
         // AC6 is a class-level rule over the complete compiled payload. A
         // runtime may be mentioned conditionally, but it must never become a
@@ -318,13 +312,7 @@ public sealed class GuideRoleNamesG797Tests
     public void StructuredRoleInventoryAndCanonicalProjection_G803()
     {
         var context = CreateContext();
-        var surfaces = new (string Name, Func<TextWriter, int> Render)[]
-        {
-            ("guide design-thread", writer => GuideDesignThreadCommand.Execute(context, ["--format", "json"], writer)),
-            ("guide orchestrator-thread", writer => GuideOrchestratorThreadCommand.Execute(context, ["--format", "json"], writer)),
-            ("guide workflow task implementation-loop", writer => GuideWorkflowTaskImplementationLoopCommand.Execute(context, ["--format", "json"], writer)),
-            ("guide workflow task review-next-slice-loop", writer => GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(context, ["--format", "json"], writer)),
-        };
+        var surfaces = CreateG797RoundFiveSurfaceRenderers(context);
 
         var expectedInventory = new HashSet<string>(StringComparer.Ordinal)
         {
@@ -341,7 +329,7 @@ public sealed class GuideRoleNamesG797Tests
         foreach (var (name, render) in surfaces)
         {
             using var writer = new StringWriter();
-            Assert.Equal(0, render(writer));
+            Assert.Equal(0, render("json", writer));
             using var document = JsonDocument.Parse(writer.ToString());
             var fields = new List<string>();
             CollectStructuredRoleFields(document.RootElement, "$", fields);
@@ -492,6 +480,14 @@ public sealed class GuideRoleNamesG797Tests
         Assert.Contains("archived artifacts", glossary, StringComparison.Ordinal);
         Console.WriteLine("G797 AC5 retired_glossary: design→architect; orchestration→orchestrator; implementation→builder; review→reviewer; stopped=2026-09-03; archived_artifacts=stated");
     }
+
+    private static (string Name, Func<string, TextWriter, int> Render)[] CreateG797RoundFiveSurfaceRenderers(CliContext context) =>
+    [
+        ("guide design-thread", (format, writer) => GuideDesignThreadCommand.Execute(context, ["--format", format], writer)),
+        ("guide orchestrator-thread", (format, writer) => GuideOrchestratorThreadCommand.Execute(context, ["--format", format], writer)),
+        ("guide workflow task implementation-loop", (format, writer) => GuideWorkflowTaskImplementationLoopCommand.Execute(context, ["--format", format], writer)),
+        ("guide workflow task review-next-slice-loop", (format, writer) => GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(context, ["--format", format], writer)),
+    ];
 
     private static CliContext CreateContext() => new()
     {


### PR DESCRIPTION
Closes #1752

## Summary

G803 routes structured role-identifier fields through the existing `LogicalRoleNormalizer` projection at the shared guide rendering boundary. The change extends the existing G797 round-five full-payload regression; it does not add a sibling scan, alter prose, rename routes, or change the herdr pane label.

## Criterion 1 — structured-field inventory

Actual Release test output from `GuideRoleNamesG797Tests`:

```text
Criterion 1 collected output:
G803 AC1/AC2 inventory guide design-thread: occurrence_count=0; fields=<none>; legacy_values=0
G803 AC1/AC2 inventory guide orchestrator-thread: occurrence_count=15; fields=$.guide_reachability.routes[0].role=reviewer; $.topology_workspace_move.routes[1].role=orchestrator; $.herdr_standard_layout.panes[0].role=orchestrator; $.herdr_standard_layout.panes[1].role=builder; $.herdr_standard_layout.panes[2].role=reviewer; $.terminal_workspace_provisioning.folder_provisioning.roles[0].role=orchestrator; $.terminal_workspace_provisioning.folder_provisioning.roles[1].role=reviewer; $.terminal_workspace_provisioning.folder_provisioning.roles[2].role=builder; $.terminal_workspace_provisioning.unattended_launch_recipes.copilot_recipe.prompt_classes[0].answerable_by=orchestrator; $.terminal_workspace_provisioning.unattended_launch_recipes.codex_recipe.prompt_classes[0].answerable_by=orchestrator; $.terminal_workspace_provisioning.unattended_launch_recipes.codex_recipe.prompt_classes[1].answerable_by=orchestrator; $.terminal_workspace_provisioning.unattended_launch_recipes.codex_recipe.prompt_classes[2].answerable_by=orchestrator; $.threads[0].role=orchestrator; $.threads[1].role=builder; $.threads[2].role=reviewer; legacy_values=0
G803 AC1/AC2 inventory guide workflow task implementation-loop: occurrence_count=0; fields=<none>; legacy_values=0
G803 AC1/AC2 inventory guide workflow task review-next-slice-loop: occurrence_count=0; fields=<none>; legacy_values=0
G803 AC1 inventory_entry_count=7; expected=7; all_four_surfaces=covered
```

The seven normalized field paths are the two route-role fields, herdr pane role, folder-provisioning role, two recipe `answerable_by` fields, and thread role. The inventory scans all four named JSON surfaces and records zero legacy structured values.

## Criterion 2 — canonical structured output

```text
Criterion 2 collected output:
G803 AC3 answerable_by: before=orchestration×4; after=orchestrator×4; legacy_after=0
```

The four adjudication `answerable_by` values now emit `orchestrator`; no `answerable_by=orchestration` remains.

## Criterion 3 — pane-label compatibility

```text
Criterion 3 collected output:
G803 AC4 herdr_pane_labels: orchestration,implementation,review; unchanged=true
```

The herdr pane `label` values remain the intentionally compatible labels and are not included in role projection.

## Criterion 4 — shared normalizer / no second mapping

```text
Criterion 4 collected output:
G803 AC5 projection: GuideRoleVocabulary.Identifier -> LogicalRoleNormalizer; second_alias_table=false
G797 AC3 G795_identifier_projection: architect=architect; orchestrator=orchestrator; builder=builder; reviewer=reviewer; steward=steward; aliases=accepted-input-only
```

The regression exercises every existing alias through `GuideRoleVocabulary.ProjectRenderedRoleValues` and checks the source uses `LogicalRoleNormalizer.Aliases` without a second dictionary.

## Criterion 5 — extended G797 full-payload regression

The existing G797 round-five test now scans every complete Markdown and JSON payload for structured legacy values in addition to its existing vendor-fused/default checks:

```text
Criterion 5 collected output:
G797 AC6/G803 structured-fixture: legacy_field=$.answerable_by=orchestration; scan_result=FAIL (expected guard)
G797 AC6/G803 round5 full-payload-scan guide design-thread format=markdown: fused_role_vendor=0; vendor_defaults=0; structured_legacy=0; matches=<none>
G797 AC6/G803 round5 full-payload-scan guide design-thread format=json: fused_role_vendor=0; vendor_defaults=0; structured_legacy=0; matches=<none>
G797 AC6/G803 round5 full-payload-scan guide orchestrator-thread format=markdown: fused_role_vendor=0; vendor_defaults=0; structured_legacy=0; matches=<none>
G797 AC6/G803 round5 full-payload-scan guide orchestrator-thread format=json: fused_role_vendor=0; vendor_defaults=0; structured_legacy=0; matches=<none>
G797 AC6/G803 round5 full-payload-scan guide workflow task implementation-loop format=markdown: fused_role_vendor=0; vendor_defaults=0; structured_legacy=0; matches=<none>
G797 AC6/G803 round5 full-payload-scan guide workflow task implementation-loop format=json: fused_role_vendor=0; vendor_defaults=0; structured_legacy=0; matches=<none>
G797 AC6/G803 round5 full-payload-scan guide workflow task review-next-slice-loop format=markdown: fused_role_vendor=0; vendor_defaults=0; structured_legacy=0; matches=<none>
G797 AC6/G803 round5 full-payload-scan guide workflow task review-next-slice-loop format=json: fused_role_vendor=0; vendor_defaults=0; structured_legacy=0; matches=<none>
```

The fixture intentionally produces `scan_result=FAIL` so the regression proves the guard, while all current compiled payloads pass it.

## Criterion 6 — unchanged routes and payload contracts

The existing route and parent-key regressions remain green:

```text
Criterion 6 collected output:
G797 AC2 route=guide design-thread; exit_code=0; warning=false
G797 AC2 route=guide orchestrator-thread; exit_code=0; warning=false
G797 AC2 route=guide workflow task implementation-loop; exit_code=0; warning=false
G797 AC2 route=guide workflow task review-next-slice-loop; exit_code=0; warning=false
G797 AC7 parent_key_set design-thread: required=process,preview_status,agent_kind_neutral,session_layer_rule,routing_root,reachability,wake_rule,provenance,approval,dialog_answering_rule,residual_approval,merge_authority,delegation_verification,observation_boundary,team_and_duty_split,monitoring,reporting,negative_invariants,packet_authoring_check,external_residence_operating_contract,unreadable_repair_response; present=True
G797 AC7 parent_key_set orchestrator-thread: required=host_state_discovery,session_layer_switch_checklist,setup_intake,guide_reachability,topology_workspace_move,herdr_standard_layout,dialog_answering_rule,closeout_runs_contract,summary,mode_separation,role_boundary,claim_routing,domain_routing,scheduling,ci_wait_state,draft_pr_reviewability,next_slice_publication,end_of_wake_check,dispatch_verification,dependency_planning,stale_thread_health_check,design_thread_escalation,design_receiver,design_handoff,design_watchdog,orchestrator_automation_alternative,monitor_recovery,monitor_tool_distinction,codex_bridge_guidance,intake_form,terminal_workspace_provisioning,design_workspace_supervision,design_decision_holds,cross_project_isolation,design_traffic_controller,pre_delegation_prerequisites,worktree_management,review_delegation_contract,setup,preflight,troubleshooting,receiver_readiness,threads,agmsg_reply_contract,orchestrator_first_wake,safety_boundaries,detailed_guide_commands; present=True
G797 AC7 parent_key_set implementation-loop: required=mode,kind,target,frequency_guidance,forbidden_sources,first_calls,prompt,agent,base_branch_policy,expected_base_branch; present=True
G797 AC7 parent_key_set review-next-slice-loop: required=mode,kind,target,frequency_guidance,forbidden_sources,first_calls,prompt,agent,base_branch_policy,expected_base_branch; present=True
```

## Criterion 7 — parent absence/failure evidence

These probes ran against `origin/main` before the change:

```text
Criterion 7 collected output:
PARENT_G803_TEST_SYMBOL:
PARENT_G803_TEST_SYMBOL_RC:1
PARENT_ANSWERABLE_PROJECTION:
PARENT_ANSWERABLE_PROJECTION_RC:1
PARENT_G803_SCAN_SYMBOLS:
PARENT_G803_SCAN_SYMBOLS_RC:1
```

The parent has neither the G803 inventory test nor an `answerable_by` projection property nor any G803 scan symbols.

## Criterion 8 — validation

Focused Release (`GuideRoleNamesG797Tests`):

```text
Criterion 8 collected output:
<Counters total="11" executed="11" passed="11" failed="0" error="0" timeout="0" aborted="0" />
RC:0
```

Full CLI Release:

```text
<Counters total="5755" executed="5754" passed="5754" failed="0" error="0" timeout="0" aborted="0" />
RC:0
```

The single non-executed test is the existing expected skip. `git diff --check` passed. Changed paths are limited to `src/IntentSystem.Cli/Commands/GuideRoleVocabulary.cs` and the existing `tests/IntentSystem.Cli.Tests/GuideRoleNamesG797Tests.cs`.

## Exact head / CI

```text
reviewed_head_sha=c4d426d85c82ab9ddcf447c3cd096430ec5c029d
prior_run=33929804381
Build and test (source contract)=pass (4m52s): https://github.com/J-Tech-Japan/intent-system/actions/runs/33929804381/job/101205921606
npm package dry-run (no publish)=pass (1m37s): https://github.com/J-Tech-Japan/intent-system/actions/runs/33929804381/job/101206832014
```

## G803 repair-v1 — AC6 shared maintenance walk

The requested maintenance correction is limited to the existing G797 regression file. Both the G797 round-five full-payload scan and the G803 inventory now consume the same renderer helper; no second four-surface renderer list remains between those two walks.

```text
Criterion 6 collected repair output:
244:        var surfaces = CreateG797RoundFiveSurfaceRenderers(context);
315:        var surfaces = CreateG797RoundFiveSurfaceRenderers(context);
484:    private static (string Name, Func<string, TextWriter, int> Render)[] CreateG797RoundFiveSurfaceRenderers(CliContext context) =>
targeted_walks_share_renderer_helper=1
shared_renderer_set=guide design-thread, guide orchestrator-thread, guide workflow task implementation-loop, guide workflow task review-next-slice-loop
```

Repair validation after the shared-helper change:

```text
Criterion 8 collected repair output:
focused TRX: total=2; executed=2; passed=2; failed=0; RC=0
full Release TRX: total=5755; executed=5754; passed=5754; failed=0; RC=0; expected_skips=1
git diff --check=0
repair_head=ac3c8a424e0c9dd9b04f17d15ffc50b2040a9ab7
```

## Exact repair head / CI

```text
Criterion 8 exact-head CI output:
head_sha=ac3c8a424e0c9dd9b04f17d15ffc50b2040a9ab7
run=33931663242
Build and test (source contract)=pass (4m40s): https://github.com/J-Tech-Japan/intent-system/actions/runs/33931663242/job/101211339245
npm package dry-run (no publish)=pass (1m35s): https://github.com/J-Tech-Japan/intent-system/actions/runs/33931663242/job/101212145746
```
