### PR TITLE
G804: remeasure v0.32.0 preview.2 notes

### DIFF
--- a/docs/en/release-notes-v0.32.0.md
+++ b/docs/en/release-notes-v0.32.0.md
@@ -1,7 +1,7 @@
 # Release Notes — intent-cli v0.32.0
 
 > **PREPARED / NOT PUBLISHED.** This prepare-only note set records the measured
-> G795–G801 chain. It does not create a tag or GitHub Release, publish a package,
+> G795–G804 chain. It does not create a tag or GitHub Release, publish a package,
 > change a workflow or publish configuration, or change product source.
 
 No GitHub Release exists for v0.32.0; these notes are preparation evidence only.
@@ -22,14 +22,15 @@ product source change.
 
 ## Independently measured minor justification
 
-The named product base is `2a833a976688b3139678e4954162a9c00d32d0f4`. The
+The named product base is `16267f9d58af31669252186a16ce09ab0dd47ba4`. The
 minor decision follows the v0.28.0 rule: **a command-route addition is a minor
 bump; option-level additions do not count as command routes.** G796 adds
 event-kind routing to a new role and G800 adds the research-delegation route;
 those two command-surface route additions are the measured reason for this
 minor. The alias table and config repair, guide rendering, and G801 npm
 dist-tag behavior are listed as changes but explicitly **not counted** as
-routes.
+routes. G803's structured guide-field canonicalization is also listed but
+explicitly **not counted** as an additional route.
 
 The route decision is independently observable in the merged history: G796 is
 the six-kind event routing addition and G800 is the first-class research
@@ -41,11 +42,11 @@ The named base was checked with a clean Release build after the policy roll:
 
 ```text
 $ git rev-parse HEAD
-2a833a976688b3139678e4954162a9c00d32d0f4
+16267f9d58af31669252186a16ce09ab0dd47ba4
 $ dotnet build IntentSystem.sln --configuration Release --no-restore; echo BUILD_RC:$?
 BUILD_RC:0
 $ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-intent-cli 0.32.1-2a833a9-G801
+intent-cli 0.32.1-16267f9-G803
 ```
 
 That normal identity is the `nextVersion` placeholder and is **not** v0.32.0.
@@ -55,7 +56,7 @@ The same base with the explicit release property was measured separately:
 $ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.32.0; echo BUILD_RC:$?
 BUILD_RC:0
 $ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-intent-cli 0.32.0-2a833a9-G801
+intent-cli 0.32.0-16267f9-G803
 ```
 
 Published versioning is the third identity and is derived by `release.yml`,
@@ -70,10 +71,12 @@ VERSION=0.32.0
 The release workflow supplies `-p:Version=<tag>` from `RAW`; `eng/version.json`
 governs local builds and dry runs only. This prepare-only slice created no tag.
 
-## Release inventory: exactly six first-parent units
+## Release inventory: exactly seven shipped first-parent units
 
-The inventory is derived from the exact first-parent range. Git measured six
-commits, in this order, and every commit has one operator-observable outcome:
+The shipped inventory is derived from the exact first-parent range. Git measured
+eight commits; the seven shipped units below each have one operator-observable
+outcome, while the separate G802 prep commit is classified in the accounting
+table but is not counted as a shipped unit:
 
 - G795 — PR #1740 / issue #1737; merge commit `1b3c7229cfe8c8f8565034a7e2220a94ac14785b`.
   **Operator-observable outcome:** canonical Architect, Orchestrator, Builder,
@@ -99,19 +102,25 @@ commits, in this order, and every commit has one operator-observable outcome:
   **Operator-observable outcome:** npm publish calls derive `latest` for stable
   versions and a non-default prerelease dist-tag for preview, rc, beta, and
   alpha SemVer forms.
+- G803 — PR #1753 / issue #1752; merge commit `16267f9d58af31669252186a16ce09ab0dd47ba4`.
+  **Operator-observable outcome:** every structured guide field carrying a role
+  identifier emits the canonical name, with a seven-entry inventory and one
+  shared four-surface full-payload regression.
 
 ## First-parent accounting
 
 ```text
-$ git rev-list --first-parent --reverse v0.31.0..2a833a976688b3139678e4954162a9c00d32d0f4
+$ git rev-list --first-parent --reverse v0.31.0..16267f9d58af31669252186a16ce09ab0dd47ba4
 1b3c7229cfe8c8f8565034a7e2220a94ac14785b
 09b1f4edca51f3acbbe3e901356866996f4be29f
 67c8578090f1a53e8894aeff88abd6cd8b83ff15
 6e0bff220e2bf51308596c19ee258835ce509dd8
 11457187ad0f9c2c269b80de84b0fd9ea278dfe5
 2a833a976688b3139678e4954162a9c00d32d0f4
-$ git rev-list --first-parent --count v0.31.0..2a833a976688b3139678e4954162a9c00d32d0f4
-6
+b0f5354ba9a922e1676a2e654d866c2a08f60104
+16267f9d58af31669252186a16ce09ab0dd47ba4
+$ git rev-list --first-parent --count v0.31.0..16267f9d58af31669252186a16ce09ab0dd47ba4
+8
 ```
 
 | first-parent commit | classification | release inventory |
@@ -122,9 +131,12 @@ $ git rev-list --first-parent --count v0.31.0..2a833a976688b3139678e4954162a9c00
 | `6e0bff220e2bf51308596c19ee258835ce509dd8` | G800 / PR #1747 / issue #1745 | included |
 | `11457187ad0f9c2c269b80de84b0fd9ea278dfe5` | G797 / PR #1746 / issue #1739 | included |
 | `2a833a976688b3139678e4954162a9c00d32d0f4` | G801 / PR #1749 / issue #1748 | included |
+| `b0f5354ba9a922e1676a2e654d866c2a08f60104` | G802 / PR #1751 / issue #1750 | this release's own prep |
+| `16267f9d58af31669252186a16ce09ab0dd47ba4` | G803 / PR #1753 / issue #1752 | included |
 
-The first-parent range contains exactly these six merge commits and nothing
-else; the table is not a changelog of second-parent commits.
+The first-parent range contains exactly these eight merge commits and nothing
+else; the table is not a changelog of second-parent commits. G802's row is
+explicitly this release's own preparation unit, not omitted accounting.
 
 ## Alias promise and compatibility boundary
 
@@ -157,12 +169,12 @@ in new guidance.
 
 `ReleaseNotesV0320G802Tests` compares the EN/JA unit/PR/issue/merge tuples,
 asserts the four alias statements in both mirrors, checks the three measured
-identities and exact six-commit inventory, and deliberately fails on a
+identities and exact eight-commit accounting, and deliberately fails on a
 one-field mirror mutation. `ReleasePackageMetadataTests` continues to guard
 the policy shape and demanded next-version placeholder. The PR pastes actual
 parent absence/failure output for each new test, criterion-named release-policy
 output, `git diff --check`, focused Release counts, full CLI Release counts,
-and exact-head CI. The diff is limited to the EN/JA v0.32.0 notes, the
-v0.32.1 planning placeholders, `eng/version.json`, and tests; it contains no
+and exact-head CI. The diff is limited to the EN/JA v0.32.0 notes and tests;
+`eng/version.json` and the v0.32.1 placeholders are untouched. It contains no
 tag, GitHub Release, package publish, workflow/publish-config, or product
 source change.

--- a/docs/ja/release-notes-v0.32.0.md
+++ b/docs/ja/release-notes-v0.32.0.md
@@ -1,6 +1,6 @@
 # リリースノート — intent-cli v0.32.0
 
-> **PREPARED / NOT PUBLISHED。** これは測定済み G795–G801 chain の
+> **PREPARED / NOT PUBLISHED。** これは測定済み G795–G804 chain の
 > prepare-only notes です。tag / GitHub Release / package publish、workflow または
 > publish configuration、consumer follow-up、product source の変更は行いません。
 
@@ -22,12 +22,13 @@ prepare-only slice は no tag、no GitHub Release、no workflow change、no prod
 
 ## 独自に測定した minor justification
 
-named product base は `2a833a976688b3139678e4954162a9c00d32d0f4` です。minor の判断は
+named product base は `16267f9d58af31669252186a16ce09ab0dd47ba4` です。minor の判断は
 v0.28.0 の auditable rule、**a command-route addition is a minor bump; option-level additions
 do not count as command routes.** に従います。G796 は新しい role への event-kind routing、G800 は
 research-delegation route を追加し、この二つの command-surface route additions が minor の測定済み
 理由です。alias table と config repair、guide rendering、G801 npm dist-tag behavior は列挙しますが
-routes としては **not counted** です。
+routes としては **not counted** です。G803 の structured guide-field canonicalization も列挙しますが、
+additional route としては **not counted** です。
 
 merged history から route の判断を再現できます: G796 は six-kind event routing addition、G800 は
 first-class research delegation route です。他の変更は command route として数えていません。
@@ -38,11 +39,11 @@ policy roll 後の named base を clean Release build で確認しました:
 
 ```text
 $ git rev-parse HEAD
-2a833a976688b3139678e4954162a9c00d32d0f4
+16267f9d58af31669252186a16ce09ab0dd47ba4
 $ dotnet build IntentSystem.sln --configuration Release --no-restore; echo BUILD_RC:$?
 BUILD_RC:0
 $ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-intent-cli 0.32.1-2a833a9-G801
+intent-cli 0.32.1-16267f9-G803
 ```
 
 この normal identity は `nextVersion` placeholder であり、**v0.32.0 ではありません**。
@@ -52,7 +53,7 @@ intent-cli 0.32.1-2a833a9-G801
 $ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.32.0; echo BUILD_RC:$?
 BUILD_RC:0
 $ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-intent-cli 0.32.0-2a833a9-G801
+intent-cli 0.32.0-16267f9-G803
 ```
 
 published version の third identity は local policy file ではなく `release.yml` が tag から導出します:
@@ -66,10 +67,11 @@ VERSION=0.32.0
 release workflow は `RAW` から `-p:Version=<tag>` を供給し、`eng/version.json` は local builds と
 dry runs だけを管理します。この prepare-only slice は no tag（tag を作成していません）です。
 
-## Release inventory: 正確に六つの first-parent unit
+## Release inventory: 正確に七つの shipped first-parent unit
 
-exact first-parent range から inventory を導出しました。Git は merge order で六つの commit を測定し、
-各 commit に一つの operator-observable outcome を記録します:
+shipped inventory は exact first-parent range から導出しました。Git は八つの commit を測定し、
+以下の七つの shipped unit には一つずつ operator-observable outcome を記録します。別の G802 prep commit
+は accounting table で分類しますが、shipped unit には数えません:
 
 - G795 — PR #1740 / issue #1737; merge commit `1b3c7229cfe8c8f8565034a7e2220a94ac14785b`。
   **Operator-observable outcome:** canonical Architect, Orchestrator, Builder, Reviewer, Steward の
@@ -90,19 +92,24 @@ exact first-parent range から inventory を導出しました。Git は merge 
 - G801 — PR #1749 / issue #1748; merge commit `2a833a976688b3139678e4954162a9c00d32d0f4`。
   **Operator-observable outcome:** npm publish calls は stable version では `latest`、preview/rc/beta/
   alpha SemVer では non-default prerelease dist-tag を導出します。
+- G803 — PR #1753 / issue #1752; merge commit `16267f9d58af31669252186a16ce09ab0dd47ba4`。
+  **Operator-observable outcome:** structured guide fields の role identifier は canonical name を出力し、
+  seven-entry inventory と one shared four-surface full-payload regression を持ちます。
 
 ## First-parent accounting
 
 ```text
-$ git rev-list --first-parent --reverse v0.31.0..2a833a976688b3139678e4954162a9c00d32d0f4
+$ git rev-list --first-parent --reverse v0.31.0..16267f9d58af31669252186a16ce09ab0dd47ba4
 1b3c7229cfe8c8f8565034a7e2220a94ac14785b
 09b1f4edca51f3acbbe3e901356866996f4be29f
 67c8578090f1a53e8894aeff88abd6cd8b83ff15
 6e0bff220e2bf51308596c19ee258835ce509dd8
 11457187ad0f9c2c269b80de84b0fd9ea278dfe5
 2a833a976688b3139678e4954162a9c00d32d0f4
-$ git rev-list --first-parent --count v0.31.0..2a833a976688b3139678e4954162a9c00d32d0f4
-6
+b0f5354ba9a922e1676a2e654d866c2a08f60104
+16267f9d58af31669252186a16ce09ab0dd47ba4
+$ git rev-list --first-parent --count v0.31.0..16267f9d58af31669252186a16ce09ab0dd47ba4
+8
 ```
 
 | first-parent commit | classification | release inventory |
@@ -113,8 +120,11 @@ $ git rev-list --first-parent --count v0.31.0..2a833a976688b3139678e4954162a9c00
 | `6e0bff220e2bf51308596c19ee258835ce509dd8` | G800 / PR #1747 / issue #1745 | included |
 | `11457187ad0f9c2c269b80de84b0fd9ea278dfe5` | G797 / PR #1746 / issue #1739 | included |
 | `2a833a976688b3139678e4954162a9c00d32d0f4` | G801 / PR #1749 / issue #1748 | included |
+| `b0f5354ba9a922e1676a2e654d866c2a08f60104` | G802 / PR #1751 / issue #1750 | this release's own prep |
+| `16267f9d58af31669252186a16ce09ab0dd47ba4` | G803 / PR #1753 / issue #1752 | included |
 
-この first-parent range はこの六つの merge commit だけで、second-parent commit の changelog ではありません。
+この first-parent range はこの八つの merge commit だけで、second-parent commit の changelog ではありません。
+G802 の row は release 自身の preparation unit として明示的に分類し、省略していません。
 
 ## Alias promise and compatibility boundary
 
@@ -142,10 +152,10 @@ claim ではありません。
 ## Prepare-only verification
 
 `ReleaseNotesV0320G802Tests` は EN/JA の unit/PR/issue/merge tuples を比較し、両 mirror の四つの
-alias statements、三つの measured identities、exact six-commit inventory を guard し、一フィールドの
+alias statements、三つの measured identities、exact eight-commit accounting を guard し、一フィールドの
 mirror mutation で意図的に fail します。`ReleasePackageMetadataTests` は policy shape と demanded
 next-version placeholder を引き続き guard します。PR には各 new test の parent absence/failure actual
 output、criterion-named release-policy output、`git diff --check`、focused/full Release counts、exact-head
-CI を貼ります。diff は EN/JA v0.32.0 notes、v0.32.1 planning placeholders、`eng/version.json`、tests に
-限定され、tag / GitHub Release / package publish / workflow または publish-config / product source change
-は含みません。
+CI を貼ります。diff は EN/JA v0.32.0 notes と tests に限定され、`eng/version.json` と v0.32.1
+placeholders は untouched です。tag / GitHub Release / package publish / workflow または publish-config /
+product source change は含みません。

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
@@ -17,6 +17,7 @@ public sealed class ReleaseNotesV0320G802Tests
     private const string NormalPlaceholderIdentity = "intent-cli 0.32.1-16267f9-G803";
     private const string ExplicitReleaseIdentity = "intent-cli 0.32.0-16267f9-G803";
     private const string PreviousBaseFragment = "b0f5354";
+    private const string PreviousBase = "b0f5354ba9a922e1676a2e654d866c2a08f60104";
 
     private static readonly (string Unit, string Pr, string Issue, string Merge)[] Units =
     [
@@ -112,9 +113,7 @@ public sealed class ReleaseNotesV0320G802Tests
     {
         var notes = ReadNotes(language);
 
-        Assert.Contains(Base, notes, StringComparison.Ordinal);
-        Assert.Contains(NormalPlaceholderIdentity, notes, StringComparison.Ordinal);
-        Assert.Contains(ExplicitReleaseIdentity, notes, StringComparison.Ordinal);
+        Assert.True(MeasurementSegmentsAreCurrent(notes));
         Assert.Contains("dotnet build IntentSystem.sln --configuration Release", notes, StringComparison.Ordinal);
         Assert.Contains("-p:Version=0.32.0", notes, StringComparison.Ordinal);
         Assert.Contains("release.yml", notes, StringComparison.Ordinal);
@@ -124,14 +123,28 @@ public sealed class ReleaseNotesV0320G802Tests
         Assert.Contains("local builds", notes, StringComparison.Ordinal);
         Assert.Contains("dry runs", notes, StringComparison.Ordinal);
         Assert.Contains("**not** v0.32.0", Normalize(notes), StringComparison.Ordinal);
-        var identities = Regex.Matches(notes, @"(?m)^intent-cli [^\r\n]+");
-        Assert.Equal(2, identities.Count);
-        foreach (Match identity in identities)
-        {
-            Assert.DoesNotContain(PreviousBaseFragment, identity.Value, StringComparison.Ordinal);
-        }
 
-        Console.WriteLine($"G804 AC4 {language}: normal={NormalPlaceholderIdentity}; explicit={ExplicitReleaseIdentity}; published=RAW=v0.32.0 -> VERSION=0.32.0; stale_banner_fragment={PreviousBaseFragment}=0");
+        Console.WriteLine($"G804 AC4 {language}: named_base={Base}; normal={NormalPlaceholderIdentity}; explicit={ExplicitReleaseIdentity}; published=RAW=v0.32.0 -> VERSION=0.32.0; stale_measurement_fragment={PreviousBaseFragment}=0; accounting_occurrence={PreviousBaseFragment}=allowed");
+    }
+
+    [Theory]
+    [InlineData("named-base")]
+    [InlineData("normal-identity")]
+    [InlineData("explicit-identity")]
+    public void StaleMeasurementFragmentFailsTheCriterion4Guard(string segment)
+    {
+        var notes = ReadNotes("en");
+        var mutated = segment switch
+        {
+            "named-base" => notes.Replace($"`{Base}`", $"`{PreviousBase}`", StringComparison.Ordinal),
+            "normal-identity" => notes.Replace(NormalPlaceholderIdentity, "intent-cli 0.32.1-b0f5354-G803", StringComparison.Ordinal),
+            "explicit-identity" => notes.Replace(ExplicitReleaseIdentity, "intent-cli 0.32.0-b0f5354-G803", StringComparison.Ordinal),
+            _ => throw new ArgumentOutOfRangeException(nameof(segment), segment, null),
+        };
+
+        Assert.False(MeasurementSegmentsAreCurrent(mutated));
+        Assert.Contains(PreviousBaseFragment, mutated, StringComparison.Ordinal);
+        Console.WriteLine($"G804 AC4 stale mutation: segment={segment}; stale_fragment={PreviousBaseFragment}; guard_passed=False; result=FAIL (expected guard refusal)");
     }
 
     [Fact]
@@ -224,6 +237,28 @@ public sealed class ReleaseNotesV0320G802Tests
             .ToArray();
 
     private static string Normalize(string value) => Regex.Replace(value, @"\s+", " ");
+
+    private static bool MeasurementSegmentsAreCurrent(string notes)
+    {
+        var namedBase = Regex.Match(
+            notes,
+            @"(?m)^(?:The named product base is|named product base は) `(?<base>[0-9a-f]{40})`");
+        if (!namedBase.Success || namedBase.Groups["base"].Value != Base ||
+            namedBase.Value.Contains(PreviousBaseFragment, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var identities = Regex.Matches(notes, @"(?m)^intent-cli [^\r\n]+$")
+            .Select(match => match.Value)
+            .ToArray();
+        return identities.Length == 2 &&
+               identities.Contains(NormalPlaceholderIdentity, StringComparer.Ordinal) &&
+               identities.Contains(ExplicitReleaseIdentity, StringComparer.Ordinal) &&
+               identities.All(identity =>
+                   identity.Contains(Base[..7], StringComparison.Ordinal) &&
+                   !identity.Contains(PreviousBaseFragment, StringComparison.Ordinal));
+    }
 
     private static string ReadNotes(string language) => File.ReadAllText(Path.Combine(
         RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.32.0.md"));

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
@@ -4,15 +4,19 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G802: v0.32.0 is a measured, prepare-only release line. These guards keep
-/// the six first-parent units, the alias compatibility promise, the three
-/// version identities, EN/JA parity, and the version-policy roll durable.
+/// G804: v0.32.0 preview.2 is a measured, prepare-only release line. These
+/// guards keep the seven shipped units, the eight-commit first-parent
+/// accounting (including the G802 prep), the alias compatibility promise, the
+/// three version identities, EN/JA parity, and the unchanged version policy
+/// durable.
 /// </summary>
 public sealed class ReleaseNotesV0320G802Tests
 {
-    private const string Base = "2a833a976688b3139678e4954162a9c00d32d0f4";
-    private const string NormalPlaceholderIdentity = "intent-cli 0.32.1-2a833a9-G801";
-    private const string ExplicitReleaseIdentity = "intent-cli 0.32.0-2a833a9-G801";
+    private const string Base = "16267f9d58af31669252186a16ce09ab0dd47ba4";
+    private const string Range = "v0.31.0..16267f9d58af31669252186a16ce09ab0dd47ba4";
+    private const string NormalPlaceholderIdentity = "intent-cli 0.32.1-16267f9-G803";
+    private const string ExplicitReleaseIdentity = "intent-cli 0.32.0-16267f9-G803";
+    private const string PreviousBaseFragment = "b0f5354";
 
     private static readonly (string Unit, string Pr, string Issue, string Merge)[] Units =
     [
@@ -22,12 +26,25 @@ public sealed class ReleaseNotesV0320G802Tests
         ("G800", "#1747", "#1745", "6e0bff220e2bf51308596c19ee258835ce509dd8"),
         ("G797", "#1746", "#1739", "11457187ad0f9c2c269b80de84b0fd9ea278dfe5"),
         ("G801", "#1749", "#1748", "2a833a976688b3139678e4954162a9c00d32d0f4"),
+        ("G803", "#1753", "#1752", "16267f9d58af31669252186a16ce09ab0dd47ba4"),
+    ];
+
+    private static readonly string[] FirstParentCommits =
+    [
+        "1b3c7229cfe8c8f8565034a7e2220a94ac14785b",
+        "09b1f4edca51f3acbbe3e901356866996f4be29f",
+        "67c8578090f1a53e8894aeff88abd6cd8b83ff15",
+        "6e0bff220e2bf51308596c19ee258835ce509dd8",
+        "11457187ad0f9c2c269b80de84b0fd9ea278dfe5",
+        "2a833a976688b3139678e4954162a9c00d32d0f4",
+        "b0f5354ba9a922e1676a2e654d866c2a08f60104",
+        Base,
     ];
 
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void NotesCoverExactlyTheSixGitDerivedUnits(string language)
+    public void NotesCoverExactlyTheSevenShippedUnitsIncludingG803(string language)
     {
         var notes = ReadNotes(language);
         var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
@@ -35,7 +52,7 @@ public sealed class ReleaseNotesV0320G802Tests
             .ToArray();
 
         Assert.Equal(Units.Select(unit => unit.Unit), listed);
-        Assert.Equal(6, listed.Length);
+        Assert.Equal(7, listed.Length);
 
         foreach (var unit in Units)
         {
@@ -46,7 +63,27 @@ public sealed class ReleaseNotesV0320G802Tests
             Assert.Contains("Operator-observable outcome", entry, StringComparison.Ordinal);
         }
 
-        Console.WriteLine($"G802 AC1 {language}: six_units={string.Join(',', listed)}; base={Base}");
+        Console.WriteLine($"G804 AC1 {language}: seven_shipped_units={string.Join(',', listed)}; base={Base}; operator_outcomes=7");
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPinTheEightCommitRangeAndClassifyTheG802Prep(string language)
+    {
+        var notes = ReadNotes(language);
+
+        Assert.Contains($"$ git rev-list --first-parent --reverse {Range}", notes, StringComparison.Ordinal);
+        Assert.Contains($"$ git rev-list --first-parent --count {Range}\n8", notes, StringComparison.Ordinal);
+        foreach (var commit in FirstParentCommits)
+        {
+            Assert.Contains(commit, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("G802 / PR #1751 / issue #1750", notes, StringComparison.Ordinal);
+        Assert.Contains("this release's own prep", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("G803 / PR #1753 / issue #1752", notes, StringComparison.Ordinal);
+        Console.WriteLine($"G804 AC2/AC3 {language}: first_parent_count=8; commits={string.Join(',', FirstParentCommits)}; prep=b0f5354b classified=this release's own prep");
     }
 
     [Theory]
@@ -65,7 +102,7 @@ public sealed class ReleaseNotesV0320G802Tests
         Assert.Contains("existing queue-state keeps reading and displaying", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("no installed guide route changed name", notes, StringComparison.OrdinalIgnoreCase);
 
-        Console.WriteLine($"G802 AC2 {language}: legacy_aliases=design,orchestration,implementation,review; config_loading=preserved; queue_state_read_display=preserved; guide_routes=unchanged");
+        Console.WriteLine($"G804 AC8 {language}: legacy_aliases=design,orchestration,implementation,review; config_loading=preserved; queue_state_read_display=preserved; guide_routes=unchanged");
     }
 
     [Theory]
@@ -87,8 +124,14 @@ public sealed class ReleaseNotesV0320G802Tests
         Assert.Contains("local builds", notes, StringComparison.Ordinal);
         Assert.Contains("dry runs", notes, StringComparison.Ordinal);
         Assert.Contains("**not** v0.32.0", Normalize(notes), StringComparison.Ordinal);
+        var identities = Regex.Matches(notes, @"(?m)^intent-cli [^\r\n]+");
+        Assert.Equal(2, identities.Count);
+        foreach (Match identity in identities)
+        {
+            Assert.DoesNotContain(PreviousBaseFragment, identity.Value, StringComparison.Ordinal);
+        }
 
-        Console.WriteLine($"G802 AC3 {language}: normal={NormalPlaceholderIdentity}; explicit={ExplicitReleaseIdentity}; published=RAW=v0.32.0 -> VERSION=0.32.0");
+        Console.WriteLine($"G804 AC4 {language}: normal={NormalPlaceholderIdentity}; explicit={ExplicitReleaseIdentity}; published=RAW=v0.32.0 -> VERSION=0.32.0; stale_banner_fragment={PreviousBaseFragment}=0");
     }
 
     [Fact]
@@ -99,7 +142,7 @@ public sealed class ReleaseNotesV0320G802Tests
 
         Assert.Equal(Units, english);
         Assert.Equal(english, japanese);
-        Console.WriteLine($"G802 AC4 parity: en=ja; tuples={english.Count}; mutation_guard=ready");
+        Console.WriteLine($"G804 AC7 parity: en=ja; tuples={english.Count}; mutation_guard=ready");
     }
 
     [Fact]
@@ -114,7 +157,7 @@ public sealed class ReleaseNotesV0320G802Tests
         var mutated = ParseInventory(changedJapanese);
 
         Assert.False(english.SequenceEqual(mutated));
-        Console.WriteLine($"G802 AC4 parity mutation: changed=issue #1737->#9999; equal={english.SequenceEqual(mutated)}; result=FAIL (expected guard)");
+        Console.WriteLine($"G804 AC7 parity mutation: changed=issue #1737->#9999; equal={english.SequenceEqual(mutated)}; result=FAIL (expected guard)");
     }
 
     [Theory]
@@ -126,6 +169,7 @@ public sealed class ReleaseNotesV0320G802Tests
 
         Assert.Contains("G796", notes, StringComparison.Ordinal);
         Assert.Contains("G800", notes, StringComparison.Ordinal);
+        Assert.Contains("G803", notes, StringComparison.Ordinal);
         Assert.Contains("command-route addition is a minor", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("option-level additions do not count as command routes", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("not counted", notes, StringComparison.OrdinalIgnoreCase);
@@ -135,7 +179,7 @@ public sealed class ReleaseNotesV0320G802Tests
         Assert.Contains("no workflow", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("no product source", notes, StringComparison.OrdinalIgnoreCase);
 
-        Console.WriteLine($"G802 AC5 {language}: routes_counted=G796,G800; alias/config/guide/npm=not counted; prepare_only=true");
+        Console.WriteLine($"G804 AC5 {language}: routes_counted=G796,G800; G803=not counted; alias/config/guide/npm=not counted; prepare_only=true");
     }
 
     [Fact]
@@ -159,7 +203,7 @@ public sealed class ReleaseNotesV0320G802Tests
             Assert.DoesNotContain("- G", stub, StringComparison.Ordinal);
         }
 
-        Console.WriteLine("G802 AC6 policy: stableVersion=0.32.0; nextVersion=0.32.1; placeholders=en,ja; entries=0");
+        Console.WriteLine("G804 AC6 policy: stableVersion=0.32.0; nextVersion=0.32.1; placeholders=en,ja; version_policy_diff=empty");
     }
 
     private static string FindEntry(string notes, string unit)


### PR DESCRIPTION
Closes #1754

## G804 preview.2 remeasurement

This prepare-only PR remeasures the v0.32.0 notes at base `16267f9d58af31669252186a16ce09ab0dd47ba4`. It does not change `eng/version.json`, product source, workflows, publish configuration, tags, releases, or packages.

## Criterion 1 — seven shipped units and operator-observable outcomes

```text
Criterion 1 collected output:
G804 AC1 en: seven_shipped_units=G795,G798,G796,G800,G797,G801,G803; base=16267f9d58af31669252186a16ce09ab0dd47ba4; operator_outcomes=7
G804 AC1 ja: seven_shipped_units=G795,G798,G796,G800,G797,G801,G803; base=16267f9d58af31669252186a16ce09ab0dd47ba4; operator_outcomes=7
```

Both mirrors list G803 (`PR #1753 / issue #1752 / merge 16267f9d...`) with an operator-observable outcome sentence. The separate G802 prep row is not counted in this seven-unit shipped inventory.

## Criterion 2 — eight first-parent commits and explicit prep classification

```text
Criterion 2 collected output:
G804 AC2/AC3 en: first_parent_count=8; commits=1b3c7229cfe8c8f8565034a7e2220a94ac14785b,09b1f4edca51f3acbbe3e901356866996f4be29f,67c8578090f1a53e8894aeff88abd6cd8b83ff15,6e0bff220e2bf51308596c19ee258835ce509dd8,11457187ad0f9c2c269b80de84b0fd9ea278dfe5,2a833a976688b3139678e4954162a9c00d32d0f4,b0f5354ba9a922e1676a2e654d866c2a08f60104,16267f9d58af31669252186a16ce09ab0dd47ba4; prep=b0f5354b classified=this release's own prep
G804 AC2/AC3 ja: first_parent_count=8; commits=1b3c7229cfe8c8f8565034a7e2220a94ac14785b,09b1f4edca51f3acbbe3e901356866996f4be29f,67c8578090f1a53e8894aeff88abd6cd8b83ff15,6e0bff220e2bf51308596c19ee258835ce509dd8,11457187ad0f9c2c269b80de84b0fd9ea278dfe5,2a833a976688b3139678e4954162a9c00d32d0f4,b0f5354ba9a922e1676a2e654d866c2a08f60104,16267f9d58af31669252186a16ce09ab0dd47ba4; prep=b0f5354b classified=this release's own prep
```

The EN/JA accounting tables contain all eight first-parent rows, including `b0f5354b` as the release's own prep and `16267f9d` as G803.

## Criterion 3 — measured first-parent command and count

```text
Criterion 3 collected output:
$ git rev-list --first-parent --reverse v0.31.0..16267f9d58af31669252186a16ce09ab0dd47ba4
1b3c7229cfe8c8f8565034a7e2220a94ac14785b
09b1f4edca51f3acbbe3e901356866996f4be29f
67c8578090f1a53e8894aeff88abd6cd8b83ff15
6e0bff220e2bf51308596c19ee258835ce509dd8
11457187ad0f9c2c269b80de84b0fd9ea278dfe5
2a833a976688b3139678e4954162a9c00d32d0f4
b0f5354ba9a922e1676a2e654d866c2a08f60104
16267f9d58af31669252186a16ce09ab0dd47ba4
$ git rev-list --first-parent --count v0.31.0..16267f9d58af31669252186a16ce09ab0dd47ba4
8
```

## Criterion 4 — three identities rebuilt at the new base

```text
Criterion 4 collected output:
$ git rev-parse HEAD
16267f9d58af31669252186a16ce09ab0dd47ba4
$ dotnet build IntentSystem.sln --configuration Release --no-restore; echo BUILD_RC:$?
BUILD_RC:0
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.32.1-16267f9-G803
$ dotnet build IntentSystem.sln --configuration Release --no-restore -p:Version=0.32.0; echo BUILD_RC:$?
BUILD_RC:0
$ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.32.0-16267f9-G803
$ raw=v0.32.0; version="${raw#v}"; printf 'RAW=%s\nVERSION=%s\n' "$raw" "$version"
RAW=v0.32.0
VERSION=0.32.0
G804 AC4 en: named_base=16267f9d58af31669252186a16ce09ab0dd47ba4; normal=intent-cli 0.32.1-16267f9-G803; explicit=intent-cli 0.32.0-16267f9-G803; published=RAW=v0.32.0 -> VERSION=0.32.0; stale_measurement_fragment=b0f5354=0; accounting_occurrence=b0f5354=allowed
G804 AC4 ja: named_base=16267f9d58af31669252186a16ce09ab0dd47ba4; normal=intent-cli 0.32.1-16267f9-G803; explicit=intent-cli 0.32.0-16267f9-G803; published=RAW=v0.32.0 -> VERSION=0.32.0; stale_measurement_fragment=b0f5354=0; accounting_occurrence=b0f5354=allowed
G804 AC4 stale mutation: segment=named-base; stale_fragment=b0f5354; guard_passed=False; result=FAIL (expected guard refusal)
G804 AC4 stale mutation: segment=normal-identity; stale_fragment=b0f5354; guard_passed=False; result=FAIL (expected guard refusal)
G804 AC4 stale mutation: segment=explicit-identity; stale_fragment=b0f5354; guard_passed=False; result=FAIL (expected guard refusal)
```

The existing guard now extracts the named product-base sentence and both measured `intent-cli ...` lines, binds each to the exact new base/values, and rejects the stale fragment only in those measurement segments. The required `b0f5354` accounting occurrence remains allowed.

## Criterion 5 — route-addition minor rationale

```text
Criterion 5 collected output:
G804 AC5 en: routes_counted=G796,G800; G803=not counted; alias/config/guide/npm=not counted; prepare_only=true
G804 AC5 ja: routes_counted=G796,G800; G803=not counted; alias/config/guide/npm=not counted; prepare_only=true
```

The notes preserve the measured G796/G800 command-route rationale and explicitly list G803 as not counted as an additional route.

## Criterion 6 — version policy and alias compatibility preserved

```text
Criterion 6 collected output:
G804 AC6 policy: stableVersion=0.32.0; nextVersion=0.32.1; placeholders=en,ja; version_policy_diff=empty
G804 AC8 en: legacy_aliases=design,orchestration,implementation,review; config_loading=preserved; queue_state_read_display=preserved; guide_routes=unchanged
G804 AC8 ja: legacy_aliases=design,orchestration,implementation,review; config_loading=preserved; queue_state_read_display=preserved; guide_routes=unchanged
VERSION_POLICY_DIFF:
VERSION_POLICY_DIFF_RC:0
```

`eng/version.json` remains exactly `0.32.0` / `0.32.1`; only the two note files and tests are changed.

## Criterion 7 — tuple parity and demonstrated parity-red mutation

```text
Criterion 7 collected output:
G804 AC7 parity: en=ja; tuples=7; mutation_guard=ready
G804 AC7 parity mutation: changed=issue #1737->#9999; equal=False; result=FAIL (expected guard)
```

## Criterion 8 — prepare-only changed-path proof

```text
Criterion 8 collected output:
CHANGED_PATH_LIST:
docs/en/release-notes-v0.32.0.md
docs/ja/release-notes-v0.32.0.md
tests/IntentSystem.Cli.Tests/ReleaseNotesV0320G802Tests.cs
```

No tag, GitHub Release, package publish, workflow/publish-config, product-source, or version-policy file is changed.

## Criterion 9 — parent absence/failure evidence

```text
Criterion 9 collected output (parent=16267f9d58af31669252186a16ce09ab0dd47ba4):
PARENT_NEW_TEST_PROBE_RC:1
PARENT_BASE_PROBE_RC:1
PARENT_INVENTORY_RC:1
```

The new eight-commit test method and the new base/G803 inventory text are absent on the direct parent; each probe returned RC 1. The repair guard/helper are also absent on the reviewed parent:

```text
Criterion 4 parent absence output (parent=b9c0ef937504292945226caa5d1718a39fe65605):
PARENT_STALE_TEST_RC:1
PARENT_MEASUREMENT_HELPER_RC:1
```

## Criterion 10 — validation

```text
Criterion 10 collected output:
focused TRX: total=21; executed=21; passed=21; failed=0; RC=0
full Release TRX: total=5760; executed=5759; passed=5759; failed=0; RC=0; expected_skips=1
git diff --check=0
exact-head=a593f7b808c29da4f3294f205b744d4e10db100d
Build and test (source contract): pass; https://github.com/J-Tech-Japan/intent-system/actions/runs/33935835610/job/101223483742
npm package dry-run (no publish): pass; https://github.com/J-Tech-Japan/intent-system/actions/runs/33935835610/job/101224203570
```

The focused suite covers `ReleaseNotesV0320G802Tests` and `ReleasePackageMetadataTests`; the full CLI Release suite is green.
