### PR TITLE
G799: expose live adjudication CAS pair and diagnostics

### DIFF
--- a/src/IntentSystem.Cli/Commands/NotifyAdjudicateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyAdjudicateCommand.cs
@@ -15,12 +15,28 @@ internal static class NotifyAdjudicateCommand
         "Usage: intent-cli notify adjudicate --domain <d> --team <t> --actor-role <role> "
         + "--agent-kind <kind> --prompt-class <class> --pane <pane> --state-sequence <n> "
         + "--text-hash <sha256> --routing-root <host-root> [--cycle-id <id>] "
-        + "[--herdr-executable <path>] [--dry-run|--write] [--format markdown|json]";
+        + "[--herdr-executable <path>] [--dry-run|--write] [--format markdown|json]\n"
+        + "Derive --state-sequence from the recorded pane's state_change_seq field in `herdr agent list`. "
+        + "Derive --text-hash as SHA-256 of the UTF-8 bytes of the trimmed output from "
+        + "`herdr agent read <pane> --source detection --lines 200`.\n"
+        + "Usage: intent-cli notify adjudicate live-pair --domain <d> --team <t> --pane <pane> "
+        + "--routing-root <host-root> [--herdr-executable <path>] [--format markdown|json]";
+
+    private const string LivePairUsage =
+        "Usage: intent-cli notify adjudicate live-pair --domain <d> --team <t> --pane <pane> "
+        + "--routing-root <host-root> [--herdr-executable <path>] [--format markdown|json]\n"
+        + "Returns state_change_seq from herdr agent list and the SHA-256 text hash of the trimmed "
+        + "herdr agent read <pane> --source detection --lines 200 output.";
 
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
+        if (args.Length > 0 && string.Equals(args[0], "live-pair", StringComparison.Ordinal))
+        {
+            return ExecuteLivePair(context, args[1..], writer);
+        }
+
         if (args is ["--help"])
         {
             writer.WriteLine(Usage);
@@ -91,7 +107,22 @@ internal static class NotifyAdjudicateCommand
             live.TextHash);
         if (!initialCas.Matches)
         {
-            return Emit(writer, options, Refused(options.ActorRole, "stale-dialog-cas-refused", initialCas.Summary));
+            if (string.Equals(initialCas.Cause, PromptDialogCas.TextHashMismatch, StringComparison.Ordinal))
+            {
+                var rereadForDiagnosis = ReadLive(runner, executable, topology.Topology.WorkspaceId, options.Pane!);
+                var diagnosis = PromptDialogCas.ClassifyTextHashMismatch(
+                    options.Pane!,
+                    live.Agent.StateChangeSequence,
+                    rereadForDiagnosis.Agent?.StateChangeSequence,
+                    live.TextHash,
+                    rereadForDiagnosis.TextHash);
+                return Emit(writer, options, Refused(options.ActorRole, diagnosis.Cause!, diagnosis.Summary));
+            }
+
+            return Emit(writer, options, Refused(
+                options.ActorRole,
+                initialCas.Cause ?? "stale-dialog-cas-refused",
+                initialCas.Summary));
         }
 
         var classified = AgentLaunchRecipeRegistry.Classify(options.AgentKind!, live.Text);
@@ -195,7 +226,8 @@ internal static class NotifyAdjudicateCommand
                 live.Agent.StateChangeSequence,
                 reread.Agent.StateChangeSequence,
                 live.TextHash,
-                reread.TextHash)
+                reread.TextHash,
+                expectedHashIsCanonical: true)
             : new PromptDialogCasResult
             {
                 Matches = false,
@@ -209,7 +241,10 @@ internal static class NotifyAdjudicateCommand
                 write: true);
             return Emit(writer, options, Result(authorization, live, audited: true, executed: false)
                 with
-            { Summary = authorization.Summary + $" No key was sent: {cas.Summary}" },
+            {
+                Rule = cas.Cause ?? "stale-dialog-cas-refused",
+                Summary = authorization.Summary + $" No key was sent: {cas.Summary}",
+            },
                 exitCode: 1);
         }
 
@@ -259,6 +294,181 @@ internal static class NotifyAdjudicateCommand
                     : authorization.Summary + $" The bounded answer failed: {execution.StandardError}",
         },
             exitCode: execution.ExitCode == 0 ? 0 : 1);
+    }
+
+    private static int ExecuteLivePair(CliContext context, string[] args, TextWriter writer)
+    {
+        if (args is ["--help"])
+        {
+            writer.WriteLine(LivePairUsage);
+            return 0;
+        }
+
+        if (!TryParseLivePair(args, out var options, out var error))
+        {
+            writer.WriteLine($"invalid-adjudicate-live-pair: {error}");
+            writer.WriteLine(LivePairUsage);
+            return 1;
+        }
+
+        try
+        {
+            if (TeamModeStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!).IsAuthoringOnly)
+            {
+                return EmitLivePair(writer, LivePairResult.Failure(
+                    options.Pane!,
+                    "not-applicable-team-mode",
+                    "authoring-only teams have no supervision or worker adjudication lifecycle."),
+                    options.Format);
+            }
+        }
+        catch (InvalidOperationException exception)
+        {
+            return EmitLivePair(writer, LivePairResult.Failure(options.Pane!, "team-mode-unreadable", exception.Message), options.Format);
+        }
+
+        var topology = NotifyRoleTopologyStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!);
+        if (!topology.Resolved || topology.Topology is null)
+        {
+            return EmitLivePair(writer, LivePairResult.Failure(options.Pane!, "topology-unresolved", topology.Summary), options.Format);
+        }
+
+        var roleRecord = topology.Topology.Roles.Values.FirstOrDefault(role =>
+            string.Equals(role.PaneId, options.Pane, StringComparison.Ordinal)
+            && string.Equals(role.Resident, NotifyRecordedRole.HerdrResident, StringComparison.Ordinal));
+        if (roleRecord is null)
+        {
+            return EmitLivePair(writer, LivePairResult.Failure(
+                options.Pane!,
+                "pane-unrecorded",
+                $"Pane '{options.Pane}' is not a recorded herdr pane in the requested topology."),
+                options.Format);
+        }
+
+        var runner = NotifyCommand.ProcessRunnerFactory?.Invoke() ?? new NotifyProcessRunner();
+        var executable = options.HerdrExecutable
+            ?? NotifyCommand.HerdrExecutableFactory?.Invoke()
+            ?? NotifyTransportPaths.ResolveHerdrExecutable();
+        var live = ReadLive(runner, executable, topology.Topology.WorkspaceId, options.Pane!);
+        if (!live.Resolved || live.Agent is null)
+        {
+            return EmitLivePair(writer, LivePairResult.Failure(
+                options.Pane!,
+                "live-pair-unavailable",
+                live.Error ?? "The live dialog could not be read."),
+                options.Format);
+        }
+
+        if (live.Agent.StateChangeSequence is not { } stateSequence || string.IsNullOrWhiteSpace(live.TextHash))
+        {
+            return EmitLivePair(writer, LivePairResult.Failure(
+                options.Pane!,
+                "live-pair-incomplete",
+                "herdr agent list/read did not expose both state_change_seq and canonical text hash; refusing to provide an incomplete CAS pair."),
+                options.Format);
+        }
+
+        return EmitLivePair(writer, new LivePairResult
+        {
+            Pane = options.Pane,
+            StateSequence = stateSequence,
+            TextHash = live.TextHash,
+            TextSource = $"herdr agent read {options.Pane} --source detection --lines 200",
+            TextNormalization = "trim leading/trailing whitespace, then SHA-256 the UTF-8 bytes",
+            Summary = "Returned the live CAS pair for the recorded pane; pass state_sequence and text_hash to notify adjudicate.",
+        }, options.Format);
+    }
+
+    private static bool TryParseLivePair(string[] args, out LivePairOptions options, out string error)
+    {
+        options = new LivePairOptions();
+        string? domain = null, team = null, pane = null, routingRoot = null, herdr = null;
+        var format = "markdown";
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (!Read(args, ref index, out var value, out error))
+            {
+                return false;
+            }
+
+            switch (argument)
+            {
+                case "--domain": domain = value; break;
+                case "--team": team = value; break;
+                case "--pane": pane = value; break;
+                case "--routing-root": routingRoot = value; break;
+                case "--herdr-executable": herdr = value; break;
+                case "--format":
+                    format = value;
+                    if (format is not ("json" or "markdown"))
+                    {
+                        error = "--format must be markdown or json.";
+                        return false;
+                    }
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        var missing = new (string Name, string? Value)[]
+        {
+            ("--domain", domain), ("--team", team), ("--pane", pane), ("--routing-root", routingRoot),
+        }.FirstOrDefault(item => string.IsNullOrWhiteSpace(item.Value));
+        if (missing.Name is not null)
+        {
+            error = $"{missing.Name} is required.";
+            return false;
+        }
+
+        if (new[] { domain!, team!, pane! }.Any(value => !Safe(value)))
+        {
+            error = "domain, team, and pane values must be safe identifiers.";
+            return false;
+        }
+
+        options = new LivePairOptions
+        {
+            Domain = domain,
+            Team = team,
+            Pane = pane,
+            RoutingRoot = Path.GetFullPath(routingRoot!),
+            HerdrExecutable = herdr,
+            Format = format,
+        };
+        return true;
+    }
+
+    private static int EmitLivePair(TextWriter writer, LivePairResult result, string format)
+    {
+        var exitCode = result.Error is null ? 0 : 1;
+        if (format == "json")
+        {
+            writer.WriteLine(JsonSerializer.Serialize(new
+            {
+                command = "notify adjudicate live-pair",
+                exit_code = exitCode,
+                result,
+            }, JsonOptions));
+        }
+        else
+        {
+            writer.WriteLine("# Prompt adjudication live pair");
+            writer.WriteLine();
+            writer.WriteLine($"- exit-code: {exitCode}");
+            writer.WriteLine($"- pane: {result.Pane}");
+            writer.WriteLine($"- state-sequence: {result.StateSequence?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}");
+            writer.WriteLine($"- text-hash: {result.TextHash ?? "<unknown>"}");
+            writer.WriteLine($"- text-source: {result.TextSource ?? "<unknown>"}");
+            writer.WriteLine($"- text-normalization: {result.TextNormalization ?? "<unknown>"}");
+            writer.WriteLine($"- rule: {result.Error ?? "live-pair"}");
+            writer.WriteLine($"- summary: {result.Summary}");
+        }
+        return exitCode;
     }
 
     private static DateTimeOffset Now() =>
@@ -517,6 +727,47 @@ internal static class NotifyAdjudicateCommand
     private static bool IsSafeCycleIdentity(string value) =>
         value.Length > 0
         && value.All(character => char.IsAsciiLetterOrDigit(character) || character is '-' or '_' or '.');
+
+    private sealed record LivePairOptions
+    {
+        public string? Domain { get; init; }
+        public string? Team { get; init; }
+        public string? Pane { get; init; }
+        public string? RoutingRoot { get; init; }
+        public string? HerdrExecutable { get; init; }
+        public string Format { get; init; } = "markdown";
+    }
+
+    private sealed record LivePairResult
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("pane")]
+        public string? Pane { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("state_sequence")]
+        public long? StateSequence { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("text_hash")]
+        public string? TextHash { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("text_source")]
+        public string? TextSource { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("text_normalization")]
+        public string? TextNormalization { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("summary")]
+        public string Summary { get; init; } = string.Empty;
+
+        [System.Text.Json.Serialization.JsonPropertyName("error")]
+        public string? Error { get; init; }
+
+        public static LivePairResult Failure(string pane, string error, string summary) => new()
+        {
+            Pane = pane,
+            Error = error,
+            Summary = summary,
+        };
+    }
 
     private sealed record Options
     {

--- a/src/IntentSystem.Cli/Commands/NotifyAdjudicateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyAdjudicateCommand.cs
@@ -242,7 +242,14 @@ internal static class NotifyAdjudicateCommand
             return Emit(writer, options, Result(authorization, live, audited: true, executed: false)
                 with
             {
+                Decision = "escalate",
                 Rule = cas.Cause ?? "stale-dialog-cas-refused",
+                MechanicalExecutor = null,
+                AnswerableBy = null,
+                ScopeOrRuleId = null,
+                MatchedScopes = [],
+                AnswerKeys = [],
+                ExactAnswerScope = null,
                 Summary = authorization.Summary + $" No key was sent: {cas.Summary}",
             },
                 exitCode: 1);

--- a/src/IntentSystem.Cli/Commands/PromptAdjudication.cs
+++ b/src/IntentSystem.Cli/Commands/PromptAdjudication.cs
@@ -257,36 +257,50 @@ internal sealed record PromptDialogCasResult
 {
     public required bool Matches { get; init; }
     public required string Summary { get; init; }
+    public string? Cause { get; init; }
 }
 
 internal static class PromptDialogCas
 {
+    public const string TextHashMismatch = "text-hash-mismatch";
+    public const string DialogChangedHashMismatch = "dialog-changed-hash-mismatch";
+    public const string WrongProjectionHashMismatch = "wrong-projection-hash-mismatch";
+
     public static PromptDialogCasResult Verify(
         string expectedPane,
         string actualPane,
         long? expectedStateChangeSequence,
         long? actualStateChangeSequence,
         string expectedObservedTextHash,
-        string actualObservedTextHash)
+        string actualObservedTextHash,
+        bool expectedHashIsCanonical = false)
     {
         if (!string.Equals(expectedPane, actualPane, StringComparison.Ordinal))
         {
-            return Refused("The live dialog pane changed before execution.");
+            return Refused("pane-changed", "The live dialog pane changed before execution.");
         }
 
         if (expectedStateChangeSequence is null || actualStateChangeSequence is null)
         {
-            return Refused("The live dialog has no comparable state-change sequence; CAS refuses an unaudited answer.");
+            return Refused(
+                "state-sequence-unavailable",
+                "The live dialog has no comparable state-change sequence; derive --state-sequence from herdr agent list's state_change_seq for the pane. CAS refuses an unaudited answer.");
         }
 
         if (expectedStateChangeSequence != actualStateChangeSequence)
         {
-            return Refused($"The live dialog state-change sequence changed from {expectedStateChangeSequence} to {actualStateChangeSequence}.");
+            return Refused(
+                "dialog-changed-sequence",
+                $"The live dialog state-change sequence changed from {expectedStateChangeSequence} to {actualStateChangeSequence}; derive --state-sequence from herdr agent list's state_change_seq for the pane and refresh both CAS inputs.");
         }
 
         if (!string.Equals(expectedObservedTextHash, actualObservedTextHash, StringComparison.OrdinalIgnoreCase))
         {
-            return Refused("The live dialog text hash changed before execution.");
+            return Refused(
+                expectedHashIsCanonical ? DialogChangedHashMismatch : TextHashMismatch,
+                expectedHashIsCanonical
+                    ? "The live dialog changed before execution; refresh --state-sequence from herdr agent list's state_change_seq and --text-hash from the current trimmed detection read."
+                    : "The supplied --text-hash does not match the canonical detection projection; the caller must hash the trimmed UTF-8 output of herdr agent read for the recorded pane.");
         }
 
         return new PromptDialogCasResult
@@ -296,13 +310,34 @@ internal static class PromptDialogCas
         };
     }
 
+    public static PromptDialogCasResult ClassifyTextHashMismatch(
+        string pane,
+        long? initialStateChangeSequence,
+        long? rereadStateChangeSequence,
+        string initialCanonicalTextHash,
+        string rereadCanonicalTextHash)
+    {
+        if (initialStateChangeSequence == rereadStateChangeSequence
+            && string.Equals(initialCanonicalTextHash, rereadCanonicalTextHash, StringComparison.OrdinalIgnoreCase))
+        {
+            return Refused(
+                WrongProjectionHashMismatch,
+                $"The live dialog is unchanged, but the supplied --text-hash does not match the canonical detection projection for pane '{pane}'. Hash the trimmed UTF-8 output of herdr agent read {pane} --source detection --lines 200.");
+        }
+
+        return Refused(
+            DialogChangedHashMismatch,
+            "The live dialog changed before execution; refresh --state-sequence from herdr agent list's state_change_seq and --text-hash from the current trimmed detection read.");
+    }
+
     public static string HashText(string text) =>
         Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(text)))
             .ToLowerInvariant();
 
-    private static PromptDialogCasResult Refused(string summary) => new()
+    private static PromptDialogCasResult Refused(string cause, string summary) => new()
     {
         Matches = false,
+        Cause = cause,
         Summary = summary,
     };
 }

--- a/tests/IntentSystem.Cli.Tests/PromptAdjudicationG799Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PromptAdjudicationG799Tests.cs
@@ -1,0 +1,323 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class PromptAdjudicationG799Tests : IDisposable
+{
+    private const string Domain = "g799-cas";
+    private const string Team = "g799-team";
+    private const string Workspace = "wG799";
+    private const string Pane = "wG799:p2";
+    private const long StateSequence = 7;
+    private const string Prompt = "Allow GitHub to add a comment to a pull request?";
+
+    public void Dispose() => NotifyCommand.ProcessRunnerFactory = null;
+
+    [Fact]
+    public void Help_DocumentsCasDerivationAndCanonicalLivePairSurface_G799()
+    {
+        using var writer = new StringWriter();
+        var exit = CommandRouter.Execute(
+            ["notify", "adjudicate", "--help"],
+            CreateContext(Directory.GetCurrentDirectory()),
+            writer);
+
+        Assert.Equal(0, exit);
+        var output = writer.ToString();
+        Assert.Contains("state_change_seq", output, StringComparison.Ordinal);
+        Assert.Contains("herdr agent read <pane> --source detection --lines 200", output, StringComparison.Ordinal);
+        Assert.Contains("SHA-256", output, StringComparison.Ordinal);
+        Assert.Contains("notify adjudicate live-pair", output, StringComparison.Ordinal);
+        Console.WriteLine($"G799 AC1 help derivation evidence:\n{output}");
+    }
+
+    [Fact]
+    public void LivePair_DerivesInputsThatAuthorizeSubsequentAdjudication_G799()
+    {
+        using var fixture = CreateFixture();
+        NotifyCommand.ProcessRunnerFactory = () => fixture.Runner;
+
+        using var pairWriter = new StringWriter();
+        var pairExit = NotifyAdjudicateCommand.Execute(
+            fixture.Context,
+            [
+                "live-pair",
+                "--domain", Domain,
+                "--team", Team,
+                "--pane", Pane,
+                "--routing-root", fixture.Root,
+                "--herdr-executable", "fake-herdr",
+                "--format", "json",
+            ],
+            pairWriter);
+
+        Assert.Equal(0, pairExit);
+        using var pairDocument = JsonDocument.Parse(pairWriter.ToString());
+        var pair = pairDocument.RootElement.GetProperty("result");
+        Assert.Equal(Pane, pair.GetProperty("pane").GetString());
+        Assert.Equal(StateSequence, pair.GetProperty("state_sequence").GetInt64());
+        Assert.Equal(PromptDialogCas.HashText(Prompt), pair.GetProperty("text_hash").GetString());
+        Assert.Contains("agent read", pair.GetProperty("text_source").GetString(), StringComparison.Ordinal);
+
+        using var adjudicationWriter = new StringWriter();
+        var adjudicationExit = NotifyAdjudicateCommand.Execute(
+            fixture.Context,
+            AdjudicationArguments(
+                fixture.Root,
+                StateSequence.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                pair.GetProperty("text_hash").GetString()!),
+            adjudicationWriter);
+
+        Assert.Equal(0, adjudicationExit);
+        using var adjudicationDocument = JsonDocument.Parse(adjudicationWriter.ToString());
+        var result = adjudicationDocument.RootElement.GetProperty("result");
+        Assert.Equal("accept", result.GetProperty("Decision").GetString());
+        Assert.DoesNotContain(fixture.Runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "send-keys"]));
+        Console.WriteLine($"G799 AC2/AC6 live-pair evidence:\n{pairWriter}{adjudicationWriter}");
+    }
+
+    [Fact]
+    public void HashMismatch_DistinguishesWrongProjectionFromDialogChange_G799()
+    {
+        using var unchanged = CreateFixture();
+        NotifyCommand.ProcessRunnerFactory = () => unchanged.Runner;
+        using var wrongWriter = new StringWriter();
+        var wrongExit = NotifyAdjudicateCommand.Execute(
+            unchanged.Context,
+            AdjudicationArguments(
+                unchanged.Root,
+                StateSequence.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                PromptDialogCas.HashText(Prompt + " projected differently")),
+            wrongWriter);
+
+        using var wrongDocument = JsonDocument.Parse(wrongWriter.ToString());
+        var wrong = wrongDocument.RootElement.GetProperty("result");
+        Assert.Equal(1, wrongExit);
+        Assert.Equal("wrong-projection-hash-mismatch", wrong.GetProperty("Rule").GetString());
+        Assert.Contains("unchanged", wrong.GetProperty("Summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(unchanged.Runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "send-keys"]));
+
+        using var changed = CreateFixture(changedPrompt: Prompt + " changed");
+        NotifyCommand.ProcessRunnerFactory = () => changed.Runner;
+        using var changedWriter = new StringWriter();
+        var changedExit = NotifyAdjudicateCommand.Execute(
+            changed.Context,
+            AdjudicationArguments(
+                changed.Root,
+                StateSequence.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                PromptDialogCas.HashText(Prompt),
+                write: true),
+            changedWriter);
+
+        using var changedDocument = JsonDocument.Parse(changedWriter.ToString());
+        var changedResult = changedDocument.RootElement.GetProperty("result");
+        Assert.Equal(1, changedExit);
+        Assert.Equal("dialog-changed-hash-mismatch", changedResult.GetProperty("Rule").GetString());
+        Assert.Contains("changed", changedResult.GetProperty("Summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(changed.Runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "send-keys"]));
+        Assert.NotEqual(wrong.GetProperty("Rule").GetString(), changedResult.GetProperty("Rule").GetString());
+        Console.WriteLine($"G799 AC4 hash diagnosis evidence:\nwrong_projection={wrongWriter}\ndialog_changed={changedWriter}");
+    }
+
+    [Fact]
+    public void SequenceMismatch_NamesStateChangeSourceAndRefusesBeforeExecution_G799()
+    {
+        using var fixture = CreateFixture();
+        NotifyCommand.ProcessRunnerFactory = () => fixture.Runner;
+        using var writer = new StringWriter();
+        var exit = NotifyAdjudicateCommand.Execute(
+            fixture.Context,
+            AdjudicationArguments(
+                fixture.Root,
+                (StateSequence - 1).ToString(System.Globalization.CultureInfo.InvariantCulture),
+                PromptDialogCas.HashText(Prompt)),
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var result = document.RootElement.GetProperty("result");
+        Assert.Equal(1, exit);
+        Assert.Equal("dialog-changed-sequence", result.GetProperty("Rule").GetString());
+        Assert.Contains("state_change_seq", result.GetProperty("Summary").GetString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(fixture.Runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "send-keys"]));
+        Console.WriteLine($"G799 AC3 sequence evidence:\n{writer}");
+    }
+
+    [Fact]
+    public void StrictCas_HasNoForceBypassAndNoWarningFallback_G799()
+    {
+        using var writer = new StringWriter();
+        var exit = CommandRouter.Execute(
+            ["notify", "adjudicate", "--help"],
+            CreateContext(Directory.GetCurrentDirectory()),
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("--force", writer.ToString(), StringComparison.Ordinal);
+        var sequence = PromptDialogCas.Verify(Pane, Pane, StateSequence, StateSequence + 1, "hash", "hash");
+        var hash = PromptDialogCas.Verify(Pane, Pane, StateSequence, StateSequence, "hash", "other");
+        Assert.False(sequence.Matches);
+        Assert.False(hash.Matches);
+        Assert.Contains("ref", sequence.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(PromptDialogCas.TextHashMismatch, hash.Cause);
+        Assert.Contains("caller must hash", hash.Summary, StringComparison.OrdinalIgnoreCase);
+        Console.WriteLine($"G799 AC5 strict CAS evidence:\nsequence={sequence.Cause}: {sequence.Summary}\nhash={hash.Cause}: {hash.Summary}");
+    }
+
+    private static string[] AdjudicationArguments(
+        string root,
+        string stateSequence,
+        string textHash,
+        bool write = false) =>
+    [
+        "--domain", Domain,
+        "--team", Team,
+        "--actor-role", "orchestration",
+        "--agent-kind", "codex",
+        "--prompt-class", "github-comment-post",
+        "--pane", Pane,
+        "--state-sequence", stateSequence,
+        "--text-hash", textHash,
+        "--routing-root", root,
+        "--herdr-executable", "fake-herdr",
+        write ? "--write" : "--dry-run",
+        "--format", "json",
+    ];
+
+    private static CliContext CreateContext(string root) => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = Domain, ArtifactRoot = ".intent-cli" },
+            Supervision = new SupervisionConfig { ArtifactRoot = Path.Combine(root, "supervision") },
+        },
+    };
+
+    private static Fixture CreateFixture(string? changedPrompt = null)
+    {
+        var root = Directory.CreateTempSubdirectory("intent-g799-").FullName;
+        var context = CreateContext(root);
+
+        using var modeWriter = new StringWriter();
+        Assert.Equal(0, SessionLayerCommand.ExecuteSet(
+            context,
+            ["--domain", Domain, "--team", Team, "--mode", "herdr-only", "--write", "--format", "json"],
+            modeWriter));
+
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(root, Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(topologyPath)!);
+        File.WriteAllText(topologyPath, JsonSerializer.Serialize(new
+        {
+            domain = Domain,
+            team = Team,
+            workspace_id = Workspace,
+            roles = new Dictionary<string, object>
+            {
+                ["review"] = new
+                {
+                    resident = "herdr",
+                    workspace_id = Workspace,
+                    pane_id = Pane,
+                    kind = "codex",
+                },
+            },
+        }));
+
+        var cyclePath = NotifySupervisionStore.ResolveCyclePath(
+            context.ResolveSupervisionArtifactRootPath(), Domain, Team);
+        var cycle = NotifySupervisionStore.RecordCycle(
+            cyclePath,
+            new NotifySupervisionCycle
+            {
+                CycleId = "g799-cycle",
+                StartedAt = DateTimeOffset.UtcNow,
+                CompletedAt = DateTimeOffset.UtcNow,
+                IntervalSeconds = 60,
+            },
+            write: true);
+        Assert.True(cycle.Applied, cycle.Error);
+
+        var policy = NotifyPreApprovalPolicyStore.Record(
+            context.ResolveSupervisionArtifactRootPath(),
+            new NotifyPreApprovalPolicy
+            {
+                Domain = Domain,
+                Team = Team,
+                RecordedAt = DateTimeOffset.UtcNow,
+                Accept = [new NotifyPreApprovalRule { AgentKind = "codex", PromptClass = "github-comment-post" }],
+                Escalate = [],
+            },
+            write: true);
+        Assert.True(policy.Applied, policy.Error);
+
+        return new Fixture(root, context, new G799Runner(Workspace, Pane, Prompt, changedPrompt));
+    }
+
+    private sealed class Fixture(string root, CliContext context, G799Runner runner) : IDisposable
+    {
+        public string Root { get; } = root;
+        public CliContext Context { get; } = context;
+        public G799Runner Runner { get; } = runner;
+
+        public void Dispose()
+        {
+            NotifyCommand.ProcessRunnerFactory = null;
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+    }
+
+    private sealed class G799Runner(
+        string workspace,
+        string pane,
+        string initialPrompt,
+        string? changedPrompt) : INotifyProcessRunner
+    {
+        private int readCount;
+
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            if (arguments.SequenceEqual(["agent", "list"]))
+            {
+                return new NotifyProcessResult(0, JsonSerializer.Serialize(new
+                {
+                    result = new
+                    {
+                        agents = new[]
+                        {
+                            new
+                            {
+                                name = "review",
+                                workspace_id = workspace,
+                                pane_id = pane,
+                                agent = "codex",
+                                agent_session = new { id = "review" },
+                                agent_status = "working",
+                                interactive_ready = true,
+                                state_change_seq = StateSequence,
+                            },
+                        },
+                    },
+                }), string.Empty);
+            }
+
+            if (arguments.Take(3).SequenceEqual(["agent", "read", pane]))
+            {
+                readCount++;
+                var prompt = changedPrompt is not null && readCount > 1 ? changedPrompt : initialPrompt;
+                return new NotifyProcessResult(0, prompt, string.Empty);
+            }
+
+            throw new InvalidOperationException($"Unexpected fixture transport call: {fileName} {string.Join(' ', arguments)}");
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/PromptAdjudicationG799Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PromptAdjudicationG799Tests.cs
@@ -164,7 +164,7 @@ public sealed class PromptAdjudicationG799Tests : IDisposable
         Assert.Contains("ref", sequence.Summary, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(PromptDialogCas.TextHashMismatch, hash.Cause);
         Assert.Contains("caller must hash", hash.Summary, StringComparison.OrdinalIgnoreCase);
-        Console.WriteLine($"G799 AC5 strict CAS evidence:\nsequence={sequence.Cause}: {sequence.Summary}\nhash={hash.Cause}: {hash.Summary}");
+        Console.WriteLine($"G799 AC5 strict CAS evidence:\nforce_flag_present={writer.ToString().Contains("--force", StringComparison.Ordinal)}\nsequence={sequence.Cause}: {sequence.Summary}\nhash={hash.Cause}: {hash.Summary}");
     }
 
     private static string[] AdjudicationArguments(

--- a/tests/IntentSystem.Cli.Tests/PromptAdjudicationG799Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PromptAdjudicationG799Tests.cs
@@ -116,8 +116,11 @@ public sealed class PromptAdjudicationG799Tests : IDisposable
         using var changedDocument = JsonDocument.Parse(changedWriter.ToString());
         var changedResult = changedDocument.RootElement.GetProperty("result");
         Assert.Equal(1, changedExit);
+        Assert.Equal("escalate", changedResult.GetProperty("Decision").GetString());
         Assert.Equal("dialog-changed-hash-mismatch", changedResult.GetProperty("Rule").GetString());
         Assert.Contains("changed", changedResult.GetProperty("Summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(changedResult.GetProperty("AnswerKeys").EnumerateArray());
+        Assert.Null(changedResult.GetProperty("MechanicalExecutor").GetString());
         Assert.DoesNotContain(changed.Runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "send-keys"]));
         Assert.NotEqual(wrong.GetProperty("Rule").GetString(), changedResult.GetProperty("Rule").GetString());
         Console.WriteLine($"G799 AC4 hash diagnosis evidence:\nwrong_projection={wrongWriter}\ndialog_changed={changedWriter}");


### PR DESCRIPTION
Closes #1744

## Summary

- Documents the exact live sources and normalization for both adjudication CAS inputs.
- Adds `notify adjudicate live-pair` so a caller can obtain the current pair and feed it to `notify adjudicate`.
- Keeps CAS refusal strict and reports sequence, dialog-change, and wrong-projection causes distinctly.
- Scope is limited to `src/IntentSystem.Cli/` and `tests/IntentSystem.Cli.Tests/`; no force/bypass or keystroke-relay path was added.

## Acceptance evidence

### AC 1 — documented state sequence and text-hash derivation

```text
G799 AC1 help derivation evidence:
Usage: intent-cli notify adjudicate --domain <d> --team <t> --actor-role <role> --agent-kind <kind> --prompt-class <class> --pane <pane> --state-sequence <n> --text-hash <sha256> --routing-root <host-root> [--cycle-id <id>] [--herdr-executable <path>] [--dry-run|--write] [--format markdown|json]
Derive --state-sequence from the recorded pane's state_change_seq field in `herdr agent list`. Derive --text-hash as SHA-256 of the UTF-8 bytes of the trimmed output from `herdr agent read <pane> --source detection --lines 200`.
Usage: intent-cli notify adjudicate live-pair --domain <d> --team <t> --pane <pane> --routing-root <host-root> [--herdr-executable <path>] [--format markdown|json]
```

### AC 2 — first-class live pair feeds adjudication

```json
G799 AC2/AC6 live-pair evidence:
{
  "command": "notify adjudicate live-pair",
  "exit_code": 0,
  "result": {
    "pane": "wG799:p2",
    "state_sequence": 7,
    "text_hash": "5f2fdb0e64d8595cff7fc9c6d97a5e1a0259d5bd6fed23d8e149c13e3b3e99af",
    "text_source": "herdr agent read wG799:p2 --source detection --lines 200",
    "text_normalization": "trim leading/trailing whitespace, then SHA-256 the UTF-8 bytes",
    "summary": "Returned the live CAS pair for the recorded pane; pass state_sequence and text_hash to notify adjudicate.",
    "error": null
  }
}
{
  "command": "notify adjudicate",
  "exit_code": 0,
  "result": {
    "Decision": "accept",
    "Rule": "codex:github-comment-post",
    "Summary": "The exact literal class and recorded accept rule match the declared authority capability. Dry-run: no audit or key sequence was written.",
    "StateChangeSequence": 7,
    "ObservedTextHash": "5f2fdb0e64d8595cff7fc9c6d97a5e1a0259d5bd6fed23d8e149c13e3b3e99af",
    "Audited": false,
    "Executed": false
  }
}
```

### AC 3 — sequence mismatch identifies the source field

```json
G799 AC3 sequence evidence:
{
  "command": "notify adjudicate",
  "exit_code": 1,
  "result": {
    "Decision": "escalate",
    "Rule": "dialog-changed-sequence",
    "Summary": "The live dialog state-change sequence changed from 6 to 7; derive --state-sequence from herdr agent list's state_change_seq for the pane and refresh both CAS inputs."
  }
}
```

### AC 4 — dialog-change and wrong-projection hash refusals are distinct

```text
G799 AC4 hash diagnosis evidence:
wrong_projection={
  "command": "notify adjudicate",
  "exit_code": 1,
  "result": {
    "Decision": "escalate",
    "Rule": "wrong-projection-hash-mismatch",
    "Summary": "The live dialog is unchanged, but the supplied --text-hash does not match the canonical detection projection for pane 'wG799:p2'. Hash the trimmed UTF-8 output of herdr agent read wG799:p2 --source detection --lines 200."
  }
}
dialog_changed={
  "command": "notify adjudicate",
  "exit_code": 1,
  "result": {
    "Decision": "escalate",
    "Rule": "dialog-changed-hash-mismatch",
    "Summary": "The exact literal class and recorded accept rule match the declared authority capability. No key was sent: The live dialog changed before execution; refresh --state-sequence from herdr agent list's state_change_seq and --text-hash from the current trimmed detection read.",
    "AnswerKeys": [],
    "MechanicalExecutor": null,
    "Executed": false
  }
}
```

### AC 5 — strict CAS remains refusal-only with no bypass flag

```text
G799 AC5 strict CAS evidence:
force_flag_present=False
sequence=dialog-changed-sequence: The live dialog state-change sequence changed from 7 to 8; derive --state-sequence from herdr agent list's state_change_seq for the pane and refresh both CAS inputs.
hash=text-hash-mismatch: The supplied --text-hash does not match the canonical detection projection; the caller must hash the trimmed UTF-8 output of herdr agent read for the recorded pane.
```

### AC 6 — derive then adjudicate reaches a decision

```text
G799 AC6 derive-then-adjudicate evidence:
{
  "command": "notify adjudicate",
  "exit_code": 0,
  "result": {
    "Decision": "accept",
    "Rule": "codex:github-comment-post",
    "StateChangeSequence": 7,
    "ObservedTextHash": "5f2fdb0e64d8595cff7fc9c6d97a5e1a0259d5bd6fed23d8e149c13e3b3e99af",
    "Audited": false,
    "Executed": false
  }
}
```

### AC 7 — each new test is absent on the parent

```text
PARENT_HEAD:1f4f94155914c9f6097ec8f6bbad916f13e7817b
Help_DocumentsCasDerivationAndCanonicalLivePairSurface_G799: ABSENT_ON_PARENT
LivePair_DerivesInputsThatAuthorizeSubsequentAdjudication_G799: ABSENT_ON_PARENT
HashMismatch_DistinguishesWrongProjectionFromDialogChange_G799: ABSENT_ON_PARENT
SequenceMismatch_NamesStateChangeSourceAndRefusesBeforeExecution_G799: ABSENT_ON_PARENT
StrictCas_HasNoForceBypassAndNoWarningFallback_G799: ABSENT_ON_PARENT
live-pair surface: ABSENT_ON_PARENT
```

### AC 8 — Release validation

```text
Focused command:
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter FullyQualifiedName~PromptAdjudicationG799Tests
TRX Counters: total=5 executed=5 passed=5 failed=0 skipped=0 RC=0

Full command:
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore
TRX Counters: total=5765 executed=5764 passed=5764 failed=0 skipped=1 RC=0
```

## Validation and scope

- `git diff --check` passed before commit.
- Exact head: `5c2a17307e6e956264e15279607a97bc76685423`.
- Existing `.artifacts/` remains untracked and was not staged.
- No release/tag/publish/workflow or host metadata changes.
