### PR TITLE
G805: detect review verdicts ahead of labels

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -121,15 +121,21 @@ namespace IntentSystem.Cli.Commands;
 ///   open count.</item>
 /// </list>
 ///
+/// G805 adds <c>review-verdict-ahead-of-label</c>: it is an informational
+/// observation of an open PR whose newest durable approval or request-update
+/// review is newer than the last <c>intent-pr-*</c> label transition. The
+/// recommended action is the existing transition command only; this command
+/// never applies it.
+///
 /// G546: <c>repair-pending</c> and <c>rereview-pending</c> stay exactly as
 /// described above INSIDE <c>--repair-silent-minutes</c>; past it they are
 /// promoted to the actionable <c>repair-stalled</c> kind above.
 ///
 /// Age is approximated from the relevant GitHub entity's `createdAt` /
-/// `updatedAt` timestamp (GitHub does not expose per-label-application
-/// timestamps, or per-issue timeline events without a dedicated per-issue
-/// fetch this slice does not add), which is the closest available proxy for
-/// "how long has this been pending" / "how long has this been silent".
+/// `updatedAt` timestamp. G805's verdict-ahead detector additionally reads
+/// the PR's durable review summaries and the issue timeline's
+/// `labeled`/`unlabeled` events for `intent-pr-*` labels; it never
+/// writes either surface.
 ///
 /// Strictly read-only: no GitHub mutation, no queue-state/runs.jsonl write,
 /// no label change, no message sent — informational kinds recommend a
@@ -259,6 +265,9 @@ internal static class AutomationStalledWorkCommand
     /// </summary>
     public const string KindDelegationSettledByOutcome = "delegation-settled-by-outcome";
 
+    /// <summary>G805: a review verdict is ahead of its workflow label.</summary>
+    public const string KindReviewVerdictAheadOfLabel = "review-verdict-ahead-of-label";
+
     /// <summary>
     /// G533: an issue claimed via <c>intent-issue-in-progress</c> (with no
     /// PR yet created) showing no observable activity for longer than the
@@ -375,6 +384,13 @@ internal static class AutomationStalledWorkCommand
     /// by more than thirtyfold).
     /// </summary>
     public const int DefaultRepairSilentMinutes = 180;
+
+    /// <summary>
+    /// G805: default quiet period after a durable review verdict before the
+    /// detector reports that the corresponding label transition is owed.
+    /// Operators may override it with <c>--review-verdict-ahead-minutes</c>.
+    /// </summary>
+    public const int DefaultReviewVerdictAheadMinutes = 5;
 
     /// <summary>
     /// G532 review repair: a title matched more than one distinct packet's
@@ -530,7 +546,7 @@ internal static class AutomationStalledWorkCommand
     };
 
     private const string UsageLine =
-        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--team <name>] [--role <architect|orchestrator|builder|reviewer|steward|design|orchestration|implementation|review>] [--stale-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] [--repair-silent-minutes <m>] [--knowledge-writeback-since <iso-8601>] [--guide-reachability-since <iso-8601>] [--format json|markdown]";
+        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--team <name>] [--role <architect|orchestrator|builder|reviewer|steward|design|orchestration|implementation|review>] [--stale-minutes <m>] [--review-verdict-ahead-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] [--repair-silent-minutes <m>] [--knowledge-writeback-since <iso-8601>] [--guide-reachability-since <iso-8601>] [--format json|markdown]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -544,7 +560,7 @@ internal static class AutomationStalledWorkCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var domain, out var repo, out var team, out var recordingRole, out var staleMinutes, out var claimedSilentMinutes, out var backlogIdleMinutes, out var repairSilentMinutes, out var knowledgeWriteBackSince, out var guideReachabilitySince, out var format, out var error))
+        if (!TryParseArguments(args, out var domain, out var repo, out var team, out var recordingRole, out var staleMinutes, out var reviewVerdictAheadMinutes, out var claimedSilentMinutes, out var backlogIdleMinutes, out var repairSilentMinutes, out var knowledgeWriteBackSince, out var guideReachabilitySince, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -554,7 +570,7 @@ internal static class AutomationStalledWorkCommand
         AutomationStalledWorkResult result;
         try
         {
-            result = Analyze(context, domain!, repo!, staleMinutes, claimedSilentMinutes, backlogIdleMinutes, repairSilentMinutes, knowledgeWriteBackSince, guideReachabilitySince, team, recordingRole);
+            result = Analyze(context, domain!, repo!, staleMinutes, claimedSilentMinutes, backlogIdleMinutes, repairSilentMinutes, knowledgeWriteBackSince, guideReachabilitySince, team, recordingRole, reviewVerdictAheadMinutes);
         }
         catch (TeamModeResolutionException exception)
         {
@@ -606,7 +622,8 @@ internal static class AutomationStalledWorkCommand
         DateTimeOffset? knowledgeWriteBackSince = null,
         DateTimeOffset? guideReachabilitySince = null,
         string? team = null,
-        string? recordingRole = null)
+        string? recordingRole = null,
+        int reviewVerdictAheadMinutes = DefaultReviewVerdictAheadMinutes)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(domain);
@@ -652,6 +669,24 @@ internal static class AutomationStalledWorkCommand
             repo,
             Array.Empty<string>(),
             GitHubAutomationReadSurface.StalledWork));
+        // G805: review verdict and label-transition evidence is an explicit
+        // read-only enrichment. A failure to read this optional evidence must
+        // not erase the established stalled-work lanes; it simply suppresses
+        // this new detector and leaves a diagnostic warning.
+        if (openPrs.Count > 0)
+        {
+            try
+            {
+                openPrs = lister.EnrichPullRequestLifecycle(
+                    repo,
+                    openPrs,
+                    GitHubAutomationReadSurface.StalledWork);
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                warnings.Add($"review-verdict evidence could not be read: {exception.Message}");
+            }
+        }
         var mergedPrs = ReadGitHub(() => lister.ListMergedPullRequests(
             repo,
             Array.Empty<string>(),
@@ -731,6 +766,16 @@ internal static class AutomationStalledWorkCommand
         }
 
         CollectPrCreatedNotReviewing(context, domain, candidateDomains, openIssues, openPrs, repo, now, repairSilentMinutes, ciWaitRead.Records, items, excluded);
+        CollectReviewVerdictAheadOfLabel(
+            context,
+            domain,
+            candidateDomains,
+            repo,
+            openPrs,
+            now,
+            reviewVerdictAheadMinutes,
+            items,
+            excluded);
         CollectDraftRepairStalled(context, domain, candidateDomains, openIssues, openPrs, repo, now, repairSilentMinutes, items, excluded);
         CollectMergedNotClosedOut(context, domain, candidateDomains, repo, mergedPrs, now, items, excluded, warnings);
         CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded, warnings);
@@ -803,6 +848,7 @@ internal static class AutomationStalledWorkCommand
             Repo = repo,
             RecordingRole = recordingRole,
             StaleMinutesThreshold = staleMinutes,
+            ReviewVerdictAheadMinutesThreshold = reviewVerdictAheadMinutes,
             BacklogIdleMinutesThreshold = backlogIdleMinutes,
             // G793: the diagnostic count describes genuinely outstanding
             // delegations, so an open store record with independently
@@ -1684,6 +1730,137 @@ internal static class AutomationStalledWorkCommand
         if (match.Success)
         {
             values[key] = match.Groups["value"].Value;
+        }
+    }
+
+    /// <summary>
+    /// G805: reports an open PR when its newest durable approval or
+    /// request-update review is newer than the last <c>intent-pr-*</c> label
+    /// transition by more than the declared quiet period. This collector only
+    /// projects read evidence; the recommended transition is never executed.
+    /// </summary>
+    private static void CollectReviewVerdictAheadOfLabel(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> candidateDomains,
+        string repo,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        DateTimeOffset now,
+        int thresholdMinutes,
+        List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded)
+    {
+        foreach (var pr in openPrs)
+        {
+            if (!IsOpen(pr.State))
+            {
+                continue;
+            }
+
+            var verdict = pr.Reviews
+                .Where(review => string.Equals(review.State, "APPROVED", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(review.State, "CHANGES_REQUESTED", StringComparison.OrdinalIgnoreCase))
+                .Select(review =>
+                {
+                    if (!DateTimeOffset.TryParse(
+                            review.SubmittedAt,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                            out var submittedAt))
+                    {
+                        return (Valid: false, Review: review, SubmittedAt: default(DateTimeOffset));
+                    }
+
+                    return (Valid: true, Review: review, SubmittedAt: submittedAt);
+                })
+                .Where(candidate => candidate.Valid)
+                .OrderByDescending(candidate => candidate.SubmittedAt)
+                .FirstOrDefault();
+            if (!verdict.Valid)
+            {
+                // No review, a COMMENTED review, or an unusable timestamp is
+                // an active/unknown review shape, never a fabricated stall.
+                continue;
+            }
+
+            var lastTransition = pr.IntentPrLabelTransitions
+                .Where(transition => transition.Name.StartsWith("intent-pr-", StringComparison.Ordinal))
+                .Select(transition =>
+                {
+                    if (!DateTimeOffset.TryParse(
+                            transition.OccurredAt,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                            out var occurredAt))
+                    {
+                        return (Valid: false, Transition: transition, OccurredAt: default(DateTimeOffset));
+                    }
+
+                    return (Valid: true, Transition: transition, OccurredAt: occurredAt);
+                })
+                .Where(candidate => candidate.Valid)
+                .OrderByDescending(candidate => candidate.OccurredAt)
+                .FirstOrDefault();
+            if (!lastTransition.Valid || verdict.SubmittedAt <= lastTransition.OccurredAt)
+            {
+                // The label already follows the review, the label transition
+                // is newer than the review, or transition evidence is absent.
+                continue;
+            }
+
+            var lag = verdict.SubmittedAt - lastTransition.OccurredAt;
+            if (lag.TotalMinutes <= thresholdMinutes)
+            {
+                continue;
+            }
+            var lagMinutes = (int)Math.Floor(lag.TotalMinutes);
+
+            var resolution = ResolveExecutionUnit(context, pr.Title);
+            var packetDeclaredDomain = resolution.Corroborated
+                ? ReadPacketDeclaredDomain(context, resolution.ExecutionUnit)
+                : null;
+            if (!TryConfirmDomain(
+                    domain,
+                    resolution,
+                    packetDeclaredDomain,
+                    candidateDomains,
+                    repo,
+                    out var reason,
+                    out var detail))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindReviewVerdictAheadOfLabel,
+                    ExecutionUnit = resolution.ExecutionUnit,
+                    Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                    Reason = reason,
+                    Detail = detail,
+                });
+                continue;
+            }
+
+            var approveEquivalent = string.Equals(
+                verdict.Review.State,
+                "APPROVED",
+                StringComparison.OrdinalIgnoreCase);
+            var verdictKind = approveEquivalent ? "approve-equivalent" : "request-update";
+            var dueTransition = approveEquivalent ? "approved" : "request-update";
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindReviewVerdictAheadOfLabel,
+                ExecutionUnit = resolution.ExecutionUnit,
+                Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                AgeMinutes = Math.Max(0, lagMinutes),
+                IsInformational = true,
+                VerdictKind = verdictKind,
+                VerdictAt = verdict.SubmittedAt,
+                LabelTransitionAt = lastTransition.OccurredAt,
+                DueTransition = dueTransition,
+                RecommendedAction =
+                    $"intent-cli automation pr-transition --repo {repo} --pr {pr.Number} "
+                    + $"--transition {dueTransition} --write --format json; this stalled-work "
+                    + "finding is read-only and never applies the transition automatically.",
+            });
         }
     }
 
@@ -4670,6 +4847,7 @@ internal static class AutomationStalledWorkCommand
         out string? team,
         out string? recordingRole,
         out int staleMinutes,
+        out int reviewVerdictAheadMinutes,
         out int claimedSilentMinutes,
         out int backlogIdleMinutes,
         out int repairSilentMinutes,
@@ -4683,6 +4861,7 @@ internal static class AutomationStalledWorkCommand
         team = null;
         recordingRole = null;
         staleMinutes = 0;
+        reviewVerdictAheadMinutes = DefaultReviewVerdictAheadMinutes;
         claimedSilentMinutes = DefaultClaimedSilentMinutes;
         backlogIdleMinutes = DefaultBacklogIdleMinutes;
         repairSilentMinutes = DefaultRepairSilentMinutes;
@@ -4742,6 +4921,18 @@ internal static class AutomationStalledWorkCommand
                         return false;
                     }
                     staleMinutes = parsedMinutes;
+                    index++;
+                    break;
+                case "--review-verdict-ahead-minutes":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture, out var parsedReviewVerdictAheadMinutes)
+                        || parsedReviewVerdictAheadMinutes < 0)
+                    {
+                        error = "--review-verdict-ahead-minutes requires a non-negative integer.";
+                        return false;
+                    }
+                    reviewVerdictAheadMinutes = parsedReviewVerdictAheadMinutes;
                     index++;
                     break;
                 case "--claimed-silent-minutes":
@@ -4911,6 +5102,22 @@ internal static class AutomationStalledWorkCommand
                 if (item.ClosedIssueNumber is { } closedIssueNumber)
                 {
                     writer.WriteLine($"- closed_issue_number: #{closedIssueNumber}");
+                }
+                if (item.VerdictKind is { } verdictKind)
+                {
+                    writer.WriteLine($"- verdict_kind: {verdictKind}");
+                }
+                if (item.VerdictAt is { } verdictAt)
+                {
+                    writer.WriteLine($"- verdict_at: {verdictAt:O}");
+                }
+                if (item.LabelTransitionAt is { } labelTransitionAt)
+                {
+                    writer.WriteLine($"- label_transition_at: {labelTransitionAt:O}");
+                }
+                if (item.DueTransition is { } dueTransition)
+                {
+                    writer.WriteLine($"- due_transition: {dueTransition}");
                 }
                 if (item.ReleasedVersion is { } releasedVersion)
                 {
@@ -5108,6 +5315,10 @@ internal sealed record AutomationStalledWorkResult
     [JsonPropertyName("stale_minutes_threshold")]
     public required int StaleMinutesThreshold { get; init; }
 
+    /// <summary>G805: declared quiet period for review-verdict lag.</summary>
+    [JsonIgnore]
+    public int ReviewVerdictAheadMinutesThreshold { get; init; } = AutomationStalledWorkCommand.DefaultReviewVerdictAheadMinutes;
+
     /// <summary>G544: the <c>--backlog-idle-minutes</c> threshold used to gate <c>backlog-ready-idle</c>.</summary>
     [JsonPropertyName("backlog_idle_minutes_threshold")]
     public required int BacklogIdleMinutesThreshold { get; init; }
@@ -5257,6 +5468,26 @@ internal sealed record StalledWorkItem
     [JsonPropertyName("closed_issue_number")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? ClosedIssueNumber { get; init; }
+
+    /// <summary>G805: normalized durable review outcome.</summary>
+    [JsonPropertyName("verdict_kind")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? VerdictKind { get; init; }
+
+    /// <summary>G805: timestamp of the newest durable review verdict.</summary>
+    [JsonPropertyName("verdict_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? VerdictAt { get; init; }
+
+    /// <summary>G805: timestamp of the last intent-pr label transition.</summary>
+    [JsonPropertyName("label_transition_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? LabelTransitionAt { get; init; }
+
+    /// <summary>G805: transition owed by the verdict-ahead observation.</summary>
+    [JsonPropertyName("due_transition")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DueTransition { get; init; }
 
     /// <summary>
     /// G725: the release and the two policy values required to clear the

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -1736,8 +1736,9 @@ internal static class AutomationStalledWorkCommand
     /// <summary>
     /// G805: reports an open PR when its newest durable approval or
     /// request-update review is newer than the last <c>intent-pr-*</c> label
-    /// transition by more than the declared quiet period. This collector only
-    /// projects read evidence; the recommended transition is never executed.
+    /// transition and older than the declared quiet period at observation
+    /// time. This collector only projects read evidence; the recommended
+    /// transition is never executed.
     /// </summary>
     private static void CollectReviewVerdictAheadOfLabel(
         CliContext context,
@@ -1808,12 +1809,15 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
-            var lag = verdict.SubmittedAt - lastTransition.OccurredAt;
-            if (lag.TotalMinutes <= thresholdMinutes)
+            // The transition ordering gates the finding, but elapsed age is
+            // measured from the verdict to the observation time. A fast
+            // reviewer must become stale when the label remains parked.
+            var verdictAge = now - verdict.SubmittedAt;
+            if (verdictAge.TotalMinutes <= thresholdMinutes)
             {
                 continue;
             }
-            var lagMinutes = (int)Math.Floor(lag.TotalMinutes);
+            var verdictAgeMinutes = (int)Math.Floor(verdictAge.TotalMinutes);
 
             var resolution = ResolveExecutionUnit(context, pr.Title);
             var packetDeclaredDomain = resolution.Corroborated
@@ -1850,7 +1854,7 @@ internal static class AutomationStalledWorkCommand
                 Kind = KindReviewVerdictAheadOfLabel,
                 ExecutionUnit = resolution.ExecutionUnit,
                 Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
-                AgeMinutes = Math.Max(0, lagMinutes),
+                AgeMinutes = Math.Max(0, verdictAgeMinutes),
                 IsInformational = true,
                 VerdictKind = verdictKind,
                 VerdictAt = verdict.SubmittedAt,

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -27,6 +27,19 @@ internal interface IGitHubAutomationCandidateLister
         GitHubAutomationReadSurface surface)
         => ListPullRequests(repo, requiredLabels);
 
+    /// <summary>
+    /// G805: enrich the open-PR rows with the read-only review verdict and
+    /// intent-pr label-transition evidence needed to detect a verdict that
+    /// has not yet reached the workflow label. Existing fakes keep their
+    /// original behavior; only the gh-backed adapter performs the extra
+    /// GitHub reads.
+    /// </summary>
+    IReadOnlyList<GitHubAutomationPrCandidate> EnrichPullRequestLifecycle(
+        string repo,
+        IReadOnlyList<GitHubAutomationPrCandidate> candidates,
+        GitHubAutomationReadSurface surface)
+        => candidates;
+
     IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
         string repo,
         IReadOnlyCollection<string> requiredLabels);
@@ -163,6 +176,39 @@ internal sealed record GitHubAutomationPrCandidate
     [JsonPropertyName("statusCheckRollup")]
     public IReadOnlyList<GitHubAutomationStatusCheckCandidate> StatusCheckRollup { get; init; }
         = Array.Empty<GitHubAutomationStatusCheckCandidate>();
+
+    /// <summary>G805: durable PR-level review verdicts.</summary>
+    [JsonPropertyName("reviews")]
+    public IReadOnlyList<GitHubAutomationReviewCandidate> Reviews { get; init; }
+        = Array.Empty<GitHubAutomationReviewCandidate>();
+
+    /// <summary>G805: read-only GitHub label timeline observations.</summary>
+    [JsonPropertyName("intentPrLabelTransitions")]
+    public IReadOnlyList<GitHubAutomationLabelTransitionCandidate> IntentPrLabelTransitions { get; init; }
+        = Array.Empty<GitHubAutomationLabelTransitionCandidate>();
+}
+
+/// <summary>G805: review verdict projection used by stalled-work.</summary>
+internal sealed record GitHubAutomationReviewCandidate
+{
+    [JsonPropertyName("state")]
+    public string State { get; init; } = string.Empty;
+
+    [JsonPropertyName("submittedAt")]
+    public string? SubmittedAt { get; init; }
+}
+
+/// <summary>G805: one issue-timeline label event.</summary>
+internal sealed record GitHubAutomationLabelTransitionCandidate
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("action")]
+    public string Action { get; init; } = string.Empty;
+
+    [JsonPropertyName("occurredAt")]
+    public string OccurredAt { get; init; } = string.Empty;
 }
 
 /// <summary>G793: immutable merge SHA nested in GitHub's PR payload.</summary>
@@ -486,6 +532,143 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
             GitHubApiReadDependencies.GraphQlBound,
             GitHubApiReadInventory.UnverifiedFieldsFor(surface));
         return DeserializeList<GitHubAutomationPrCandidate>(stdout, $"`gh pr list` for {repo}");
+    }
+
+    /// <summary>
+    /// G805: read the review verdicts and issue-timeline label transitions
+    /// for the open PRs. This is deliberately a separate enrichment call so
+    /// the established PR-list field set remains unchanged for every other
+    /// automation surface.
+    /// </summary>
+    public IReadOnlyList<GitHubAutomationPrCandidate> EnrichPullRequestLifecycle(
+        string repo,
+        IReadOnlyList<GitHubAutomationPrCandidate> candidates,
+        GitHubAutomationReadSurface surface)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        var enriched = new List<GitHubAutomationPrCandidate>(candidates.Count);
+        foreach (var candidate in candidates)
+        {
+            var reviews = candidate.Reviews.Count > 0
+                ? candidate.Reviews
+                : ReadReviews(repo, candidate.Number);
+            var transitions = candidate.IntentPrLabelTransitions.Count > 0
+                ? candidate.IntentPrLabelTransitions
+                : ReadIntentPrLabelTransitions(repo, candidate.Number);
+            enriched.Add(candidate with
+            {
+                Reviews = reviews,
+                IntentPrLabelTransitions = transitions,
+            });
+        }
+
+        return enriched;
+    }
+
+    internal static IReadOnlyList<string> BuildPrReviewArguments(string repo, int prNumber)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        return
+        [
+            "pr", "view", prNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo", repo, "--json", "reviews",
+        ];
+    }
+
+    internal static IReadOnlyList<string> BuildPrEventsArguments(string repo, int prNumber)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        return
+        [
+            "api", $"repos/{repo}/issues/{prNumber}/events", "--method", "GET",
+            "--paginate", "--slurp",
+        ];
+    }
+
+    private IReadOnlyList<GitHubAutomationReviewCandidate> ReadReviews(string repo, int prNumber)
+    {
+        var stdout = RunGh(
+            BuildPrReviewArguments(repo, prNumber),
+            $"`gh pr view {prNumber} --repo {repo} --json reviews");
+        try
+        {
+            var result = JsonSerializer.Deserialize<GitHubPrCommentsLookupResult>(stdout);
+            return result?.Reviews
+                .Select(review => new GitHubAutomationReviewCandidate
+                {
+                    State = review.State,
+                    SubmittedAt = review.SubmittedAt,
+                })
+                .ToArray() ?? Array.Empty<GitHubAutomationReviewCandidate>();
+        }
+        catch (JsonException exception)
+        {
+            throw new GitHubApiRequestException(
+                GitHubCliJsonBoundary.Classifications.GithubJsonInvalid,
+                $"`gh pr view {prNumber} --repo {repo} --json reviews",
+                $"could not parse review verdict JSON: {exception.Message}",
+                innerException: exception);
+        }
+    }
+
+    private IReadOnlyList<GitHubAutomationLabelTransitionCandidate> ReadIntentPrLabelTransitions(
+        string repo,
+        int prNumber)
+    {
+        var description = $"`gh api repos/{repo}/issues/{prNumber}/events`";
+        var stdout = RunGh(BuildPrEventsArguments(repo, prNumber), description);
+        var extraction = GitHubCliJsonBoundary.ExtractJsonArray(stdout, description);
+        if (!extraction.Succeeded)
+        {
+            throw GitHubApiFailureFactory.JsonInvalid(
+                description,
+                extraction.DiagnosticMessage ?? "gh stdout was not valid JSON");
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(extraction.Json);
+            var transitions = new List<GitHubAutomationLabelTransitionCandidate>();
+            foreach (var pageOrEvent in document.RootElement.EnumerateArray())
+            {
+                var events = pageOrEvent.ValueKind == JsonValueKind.Array
+                    ? pageOrEvent.EnumerateArray()
+                    : new[] { pageOrEvent }.AsEnumerable();
+                foreach (var eventElement in events)
+                {
+                    if (!eventElement.TryGetProperty("event", out var eventName)
+                        || (eventName.GetString() is not ("labeled" or "unlabeled")))
+                    {
+                        continue;
+                    }
+                    if (!eventElement.TryGetProperty("label", out var label)
+                        || !label.TryGetProperty("name", out var labelName)
+                        || !(labelName.GetString() ?? string.Empty).StartsWith("intent-pr-", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                    if (!eventElement.TryGetProperty("created_at", out var createdAt))
+                    {
+                        continue;
+                    }
+                    transitions.Add(new GitHubAutomationLabelTransitionCandidate
+                    {
+                        Name = labelName.GetString() ?? string.Empty,
+                        Action = eventName.GetString() ?? string.Empty,
+                        OccurredAt = createdAt.GetString() ?? string.Empty,
+                    });
+                }
+            }
+            return transitions;
+        }
+        catch (JsonException exception)
+        {
+            throw GitHubApiFailureFactory.JsonInvalid(
+                description,
+                $"could not map label events: {exception.Message}");
+        }
     }
 
     public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkG805Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkG805Tests.cs
@@ -1,0 +1,343 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using Xunit.Abstractions;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class AutomationStalledWorkG805Tests : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 4, 15, 0, 0, TimeSpan.Zero);
+    private readonly ITestOutputHelper output;
+
+    public AutomationStalledWorkG805Tests(ITestOutputHelper output)
+    {
+        this.output = output;
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = () => Now;
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = null;
+        GhCliGitHubAutomationCandidateLister.ProcessRunner = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = null;
+        GhCliGitHubAutomationCandidateLister.ProcessRunner = null;
+    }
+
+    [Fact]
+    public void G805_AC1_AC2_BothVerdictKindsCarryFieldsAndCanonicalActions()
+    {
+        using var workspace = new G805Workspace();
+        var approved = BuildPr(8051, "G805 approved verdict", Now.AddMinutes(-20), "APPROVED", Now.AddMinutes(-30));
+        var requestUpdate = BuildPr(8052, "G805 request update verdict", Now.AddMinutes(-18), "CHANGES_REQUESTED", Now.AddMinutes(-28));
+        var result = Analyze(workspace, [approved, requestUpdate], thresholdMinutes: 5);
+
+        var items = result.Items
+            .Where(item => item.Kind == AutomationStalledWorkCommand.KindReviewVerdictAheadOfLabel)
+            .OrderBy(item => item.Pr!.Number)
+            .ToArray();
+        Assert.Equal(2, items.Length);
+        Assert.Equal("approve-equivalent", items[0].VerdictKind);
+        Assert.Equal("approved", items[0].DueTransition);
+        Assert.Contains("--transition approved", items[0].RecommendedAction, StringComparison.Ordinal);
+        Assert.Equal("request-update", items[1].VerdictKind);
+        Assert.Equal("request-update", items[1].DueTransition);
+        Assert.Contains("--transition request-update", items[1].RecommendedAction, StringComparison.Ordinal);
+        Assert.All(items, item =>
+        {
+            Assert.True(item.Pr!.Number > 0);
+            Assert.True(item.AgeMinutes > 5);
+            Assert.NotNull(item.VerdictAt);
+            Assert.NotNull(item.LabelTransitionAt);
+        });
+        output.WriteLine(JsonSerializer.Serialize(items, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    [Fact]
+    public void G805_AC3_AC4_ReflectedLabelsAndBothQuietShapesStaySilent()
+    {
+        using var workspace = new G805Workspace();
+        var reflectedApproved = BuildPr(8053, "G805 reflected approved", Now.AddMinutes(-20), "APPROVED", Now.AddMinutes(-10), labelName: "intent-pr-approved");
+        var reflectedRequest = BuildPr(8054, "G805 reflected request", Now.AddMinutes(-18), "CHANGES_REQUESTED", Now.AddMinutes(-8), labelName: "intent-pr-request-update");
+        var reviewPredatesLabel = BuildPr(8055, "G805 active review", Now.AddMinutes(-16), "APPROVED", Now.AddMinutes(-10));
+        var noReview = BuildPr(8056, "G805 no review", Now.AddMinutes(-14), state: null, labelMinutesAgo: 9);
+        var result = Analyze(
+            workspace,
+            [reflectedApproved, reflectedRequest, reviewPredatesLabel, noReview],
+            thresholdMinutes: 0);
+
+        Assert.DoesNotContain(result.Items, item => item.Kind == AutomationStalledWorkCommand.KindReviewVerdictAheadOfLabel);
+        output.WriteLine("reflected_and_quiet_verdict_findings=0");
+    }
+
+    [Fact]
+    public void G805_AC5_DefaultAndOperatorThresholdsAreDeclared()
+    {
+        using var workspace = new G805Workspace();
+        var pr = BuildPr(8057, "G805 threshold", Now.AddMinutes(-20), "APPROVED", Now.AddMinutes(-30));
+
+        var defaultResult = Analyze(workspace, [pr]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister([pr]);
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            AutomationStalledWorkCommand.Execute(
+                workspace.Context,
+                [
+                    "--domain", "intent-cli",
+                    "--repo", "J-Tech-Japan/intent-system",
+                    "--review-verdict-ahead-minutes", "15",
+                    "--format", "json",
+                ],
+                writer));
+        using var overriddenDocument = JsonDocument.Parse(writer.ToString());
+
+        Assert.Equal(AutomationStalledWorkCommand.DefaultReviewVerdictAheadMinutes, 5);
+        Assert.Contains(defaultResult.Items, item => item.Kind == AutomationStalledWorkCommand.KindReviewVerdictAheadOfLabel);
+        Assert.DoesNotContain(
+            overriddenDocument.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindReviewVerdictAheadOfLabel);
+        output.WriteLine($"default={AutomationStalledWorkCommand.DefaultReviewVerdictAheadMinutes}; override=15; findings={overriddenDocument.RootElement.GetProperty("items").GetArrayLength()}");
+    }
+
+    [Fact]
+    public void G805_AC6_ReadOnlyScanPreservesDurableBytes()
+    {
+        using var workspace = new G805Workspace();
+        workspace.WriteFile(".intent-cli/runs.jsonl", "before\n");
+        workspace.WriteFile(".intent-cli/queue-state.json", "{\"schema_version\":\"1\"}\n");
+        workspace.WriteFile(".intent-cli/custom-state.json", "durable\n");
+        var before = HashWorkspace(workspace.RootPath);
+
+        var pr = BuildPr(8058, "G805 read-only", Now.AddMinutes(-20), "APPROVED", Now.AddMinutes(-30));
+        var result = Analyze(workspace, [pr]);
+        var after = HashWorkspace(workspace.RootPath);
+
+        Assert.Equal(before, after);
+        Assert.Contains(result.Items, item => item.Kind == AutomationStalledWorkCommand.KindReviewVerdictAheadOfLabel);
+        output.WriteLine($"before_sha256={before}\nafter_sha256={after}\nbytes_unchanged={before == after}");
+    }
+
+    [Fact]
+    public void G805_AC7_FourMeasuredFixturesEachYieldTheFinding()
+    {
+        using var workspace = new G805Workspace();
+        var prs = new[]
+        {
+            BuildPr(1743, "G805 measured approval one", Now.AddMinutes(-25), "APPROVED", Now.AddMinutes(-35)),
+            BuildPr(1747, "G805 measured request update", Now.AddMinutes(-32), "CHANGES_REQUESTED", Now.AddMinutes(-42)),
+            BuildPr(1748, "G805 measured approval two", Now.AddMinutes(-9), "APPROVED", Now.AddMinutes(-16)),
+            BuildPr(1746, "G805 measured approval three", Now.AddHours(-2), "APPROVED", Now.AddHours(-3)),
+        };
+        var result = Analyze(workspace, prs, thresholdMinutes: 5);
+
+        var findings = result.Items
+            .Where(item => item.Kind == AutomationStalledWorkCommand.KindReviewVerdictAheadOfLabel)
+            .OrderBy(item => item.Pr!.Number)
+            .ToArray();
+        Assert.Equal(4, findings.Length);
+        Assert.Equal([1743, 1746, 1747, 1748], findings.Select(item => item.Pr!.Number).ToArray());
+        Assert.All(findings, item => Assert.True(item.AgeMinutes > 5));
+        output.WriteLine(JsonSerializer.Serialize(
+            findings.Select(item => new
+            {
+                pr = item.Pr!.Number,
+                item.VerdictKind,
+                item.AgeMinutes,
+                item.DueTransition,
+            }).ToArray(),
+            new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    [Fact]
+    public void G805_AC1_ReadOnlyGitHubEnrichmentReadsReviewsAndLabelEvents()
+    {
+        var calls = new List<IReadOnlyList<string>>();
+        GhCliGitHubAutomationCandidateLister.ProcessRunner = args =>
+        {
+            calls.Add(args);
+            if (args[0] == "pr")
+            {
+                return new GhCliProcessResult(
+                    0,
+                    """{"reviews":[{"state":"APPROVED","submittedAt":"2026-09-04T14:40:00Z"}]}""",
+                    string.Empty);
+            }
+
+            return new GhCliProcessResult(
+                0,
+                """[[{"event":"labeled","label":{"name":"intent-pr-rereview-ready"},"created_at":"2026-09-04T14:30:00Z"}]]""",
+                string.Empty);
+        };
+
+        var candidate = BuildPr(
+            8059,
+            "G805 enrichment",
+            Now.AddMinutes(-20),
+            state: null,
+            labelTransitionAt: Now.AddMinutes(-30)) with
+        {
+            IntentPrLabelTransitions = Array.Empty<GitHubAutomationLabelTransitionCandidate>(),
+        };
+        var enriched = Assert.Single(
+            new GhCliGitHubAutomationCandidateLister().EnrichPullRequestLifecycle(
+                "J-Tech-Japan/intent-system",
+                [candidate],
+                GitHubAutomationReadSurface.StalledWork));
+
+        Assert.Equal("APPROVED", Assert.Single(enriched.Reviews).State);
+        Assert.Equal("intent-pr-rereview-ready", Assert.Single(enriched.IntentPrLabelTransitions).Name);
+        Assert.Equal(2, calls.Count);
+        Assert.Contains(calls, args => args.SequenceEqual(
+            GhCliGitHubAutomationCandidateLister.BuildPrReviewArguments(
+                "J-Tech-Japan/intent-system",
+                8059)));
+        Assert.Contains(calls, args => args.SequenceEqual(
+            GhCliGitHubAutomationCandidateLister.BuildPrEventsArguments(
+                "J-Tech-Japan/intent-system",
+                8059)));
+        Assert.All(calls, args => Assert.DoesNotContain("--write", args, StringComparer.Ordinal));
+        output.WriteLine(JsonSerializer.Serialize(new
+        {
+            reviews = enriched.Reviews.Count,
+            label_transitions = enriched.IntentPrLabelTransitions.Count,
+            read_only = calls.All(args => !args.Contains("--write", StringComparer.Ordinal)),
+        }));
+    }
+
+    private static AutomationStalledWorkResult Analyze(
+        G805Workspace workspace,
+        IReadOnlyList<GitHubAutomationPrCandidate> prs,
+        int thresholdMinutes = AutomationStalledWorkCommand.DefaultReviewVerdictAheadMinutes)
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(prs);
+        return AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 0,
+            reviewVerdictAheadMinutes: thresholdMinutes);
+    }
+
+    private static GitHubAutomationPrCandidate BuildPr(
+        int number,
+        string title,
+        DateTimeOffset reviewAt,
+        string? state,
+        DateTimeOffset labelTransitionAt = default,
+        int? labelMinutesAgo = null,
+        string labelName = "intent-pr-rereview-ready")
+    {
+        var transitionAt = labelMinutesAgo is int minutes
+            ? Now.AddMinutes(-minutes)
+            : labelTransitionAt;
+        var labels = state switch
+        {
+            "APPROVED" => ["intent-pr-approved"],
+            "CHANGES_REQUESTED" => ["intent-pr-request-update"],
+            _ => Array.Empty<string>(),
+        };
+        return new GitHubAutomationPrCandidate
+        {
+            Number = number,
+            Title = title,
+            Url = $"https://github.com/J-Tech-Japan/intent-system/pull/{number}",
+            State = "OPEN",
+            CreatedAt = Now.AddHours(-4).ToString("O"),
+            UpdatedAt = Now.AddMinutes(-1).ToString("O"),
+            Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+            Reviews = state is null
+                ? Array.Empty<GitHubAutomationReviewCandidate>()
+                : [new GitHubAutomationReviewCandidate
+                {
+                    State = state,
+                    SubmittedAt = reviewAt.ToString("O"),
+                }],
+            IntentPrLabelTransitions =
+            [
+                new GitHubAutomationLabelTransitionCandidate
+                {
+                    Name = labelName,
+                    Action = "labeled",
+                    OccurredAt = transitionAt.ToString("O"),
+                },
+            ],
+        };
+    }
+
+    private static string HashWorkspace(string root)
+    {
+        using var hash = SHA256.Create();
+        var bytes = Directory
+            .GetFiles(root, "*", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .SelectMany(path => Encoding.UTF8.GetBytes(
+                $"{Path.GetRelativePath(root, path)}\0{Convert.ToHexString(File.ReadAllBytes(path))}\n"))
+            .ToArray();
+        return Convert.ToHexString(hash.ComputeHash(bytes));
+    }
+
+    private sealed class FakeLister(IReadOnlyList<GitHubAutomationPrCandidate> prs) : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) => prs;
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) => Array.Empty<GitHubAutomationIssueCandidate>();
+    }
+
+    private sealed class G805Workspace : IDisposable
+    {
+        public G805Workspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("g805-stalled-work-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+            WritePacket("G805");
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public void WriteFile(string relativePath, string content)
+        {
+            var path = Path.Combine(RootPath, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content);
+        }
+
+        private void WritePacket(string executionUnit) =>
+            WriteFile($".intent-cli/issues/{executionUnit}/packet.yaml", $"domain: intent-cli\nsource_execution_unit: {executionUnit}\n");
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkG805Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkG805Tests.cs
@@ -11,7 +11,9 @@ namespace IntentSystem.Cli.Tests;
 [Collection(AutomationStalledWorkSharedStateCollection.Name)]
 public sealed class AutomationStalledWorkG805Tests : IDisposable
 {
-    private static readonly DateTimeOffset Now = new(2026, 9, 4, 15, 0, 0, TimeSpan.Zero);
+    // G805 F2: all measured fixtures use this declared observation instant.
+    private static readonly DateTimeOffset DeclaredObservationTime = new(2026, 9, 4, 15, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Now = DeclaredObservationTime;
     private readonly ITestOutputHelper output;
 
     public AutomationStalledWorkG805Tests(ITestOutputHelper output)
@@ -81,7 +83,7 @@ public sealed class AutomationStalledWorkG805Tests : IDisposable
     public void G805_AC5_DefaultAndOperatorThresholdsAreDeclared()
     {
         using var workspace = new G805Workspace();
-        var pr = BuildPr(8057, "G805 threshold", Now.AddMinutes(-20), "APPROVED", Now.AddMinutes(-30));
+        var pr = BuildPr(8057, "G805 threshold", Now.AddMinutes(-10), "APPROVED", Now.AddMinutes(-30));
 
         var defaultResult = Analyze(workspace, [pr]);
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister([pr]);
@@ -108,6 +110,35 @@ public sealed class AutomationStalledWorkG805Tests : IDisposable
     }
 
     [Fact]
+    public void G805_F1_StaleVerdictFiresFreshVerdictStaysSilent()
+    {
+        using var workspace = new G805Workspace();
+        var stale = BuildPr(
+            8060,
+            "G805 stale verdict",
+            DeclaredObservationTime.AddMinutes(-25),
+            "APPROVED",
+            DeclaredObservationTime.AddMinutes(-35));
+        var fresh = BuildPr(
+            8061,
+            "G805 fresh verdict",
+            DeclaredObservationTime.AddMinutes(-4),
+            "APPROVED",
+            DeclaredObservationTime.AddMinutes(-10));
+
+        var result = Analyze(workspace, [stale, fresh], thresholdMinutes: 5);
+        var findings = result.Items
+            .Where(item => item.Kind == AutomationStalledWorkCommand.KindReviewVerdictAheadOfLabel)
+            .ToArray();
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(8060, finding.Pr!.Number);
+        Assert.Equal(25, finding.AgeMinutes);
+        output.WriteLine(
+            $"observation_time={DeclaredObservationTime:O}; stale_pr=8060 age_minutes={finding.AgeMinutes}; fresh_pr=8061 findings=0");
+    }
+
+    [Fact]
     public void G805_AC6_ReadOnlyScanPreservesDurableBytes()
     {
         using var workspace = new G805Workspace();
@@ -131,10 +162,10 @@ public sealed class AutomationStalledWorkG805Tests : IDisposable
         using var workspace = new G805Workspace();
         var prs = new[]
         {
-            BuildPr(1743, "G805 measured approval one", Now.AddMinutes(-25), "APPROVED", Now.AddMinutes(-35)),
-            BuildPr(1747, "G805 measured request update", Now.AddMinutes(-32), "CHANGES_REQUESTED", Now.AddMinutes(-42)),
-            BuildPr(1748, "G805 measured approval two", Now.AddMinutes(-9), "APPROVED", Now.AddMinutes(-16)),
-            BuildPr(1746, "G805 measured approval three", Now.AddHours(-2), "APPROVED", Now.AddHours(-3)),
+            BuildPr(1743, "G805 measured approval", DeclaredObservationTime.AddMinutes(-25), "APPROVED", DeclaredObservationTime.AddMinutes(-35)),
+            BuildPr(1747, "G805 measured request update", DeclaredObservationTime.AddMinutes(-32), "CHANGES_REQUESTED", DeclaredObservationTime.AddMinutes(-42)),
+            BuildPr(1747, "G805 measured approval", DeclaredObservationTime.AddMinutes(-9), "APPROVED", DeclaredObservationTime.AddMinutes(-15)),
+            BuildPr(1746, "G805 measured approval", DeclaredObservationTime.AddMinutes(-10), "APPROVED", DeclaredObservationTime.AddMinutes(-16)),
         };
         var result = Analyze(workspace, prs, thresholdMinutes: 5);
 
@@ -143,8 +174,12 @@ public sealed class AutomationStalledWorkG805Tests : IDisposable
             .OrderBy(item => item.Pr!.Number)
             .ToArray();
         Assert.Equal(4, findings.Length);
-        Assert.Equal([1743, 1746, 1747, 1748], findings.Select(item => item.Pr!.Number).ToArray());
+        Assert.Equal([1743, 1746, 1747, 1747], findings.Select(item => item.Pr!.Number).ToArray());
+        Assert.Equal(
+            [25, 10, 32, 9],
+            findings.Select(item => item.AgeMinutes).ToArray());
         Assert.All(findings, item => Assert.True(item.AgeMinutes > 5));
+        output.WriteLine($"observation_time={DeclaredObservationTime:O}");
         output.WriteLine(JsonSerializer.Serialize(
             findings.Select(item => new
             {

--- a/tests/IntentSystem.Cli.Tests/SharedStaticSeamSerializationMetaTests.cs
+++ b/tests/IntentSystem.Cli.Tests/SharedStaticSeamSerializationMetaTests.cs
@@ -33,7 +33,7 @@ public sealed class SharedStaticSeamSerializationMetaTests
     }
 
     [Fact]
-    public void FiveSplitCollectionCases_AreExplicitlyProtectedByXunitDisableParallelization_G580()
+    public void SixSplitCollectionCases_AreExplicitlyProtectedByXunitDisableParallelization_G580()
     {
         var analysis = StaticSeamAnalysis.Discover();
         var splitCases = analysis.DiscoverSplitCollectionCases();
@@ -59,17 +59,21 @@ public sealed class SharedStaticSeamSerializationMetaTests
                 "IntentSystem.Cli.Commands.ClarifyOpenCommand.TimestampFactory",
                 typeof(AutomationStalledWorkCommandTests),
                 typeof(CommandRouterTests)),
+            new SplitCollectionCase(
+                "IntentSystem.Cli.Commands.GhCliGitHubAutomationCandidateLister.ProcessRunner",
+                typeof(AutomationStalledWorkG805Tests),
+                typeof(GitHubApiReadG674Tests)),
         };
 
         // xUnit 2.9.3 documents CollectionDefinitionAttribute.DisableParallelization
         // as determining whether a collection runs in parallel with ANY other
-        // collection. This explicit record of the five existing cross-collection
-        // class pairs is safe only while every collection involved keeps that
-        // setting. Discovery remains independent of this accepted-case inventory.
+        // collection. This explicit record of the six cross-collection class
+        // pairs is safe only while every collection involved keeps that setting.
+        // Discovery remains independent of this accepted-case inventory.
         Assert.True(
             splitCases.SequenceEqual(expectedSplitCases)
             && splitCases.All(split => analysis.AreSerializedTogether([split.LeftClass, split.RightClass])),
-            "expected the five recorded shared-static assigning-class pairs split across distinct explicitly "
+            "expected the six recorded shared-static assigning-class pairs split across distinct explicitly "
             + "non-parallel xUnit collections, with no additions or substitutions. Every involved CollectionDefinition must keep "
             + $"DisableParallelization = true. Discovered {splitCases.Count}:\n"
             + string.Join("\n", splitCases.Select(analysis.Describe)));


### PR DESCRIPTION
Closes #1757

## G805 implementation

Head: `5142d60b7210ad59971f5530d85584a54b247920`

`automation stalled-work` now has the read-only `review-verdict-ahead-of-label` finding. The GitHub adapter reads durable PR review summaries and issue-timeline `labeled`/`unlabeled` events, and the analyzer compares the newest APPROVED/CHANGES_REQUESTED verdict with the latest `intent-pr-*` transition. It carries the PR, verdict kind, elapsed minutes, and due transition and only recommends the canonical transition command; it never performs a write.

### AC1 / AC2 — both verdicts, fields, and canonical actions

Actual focused-test output (`G805_AC1_AC2_BothVerdictKindsCarryFieldsAndCanonicalActions`):

```json
[
  {
    "kind": "review-verdict-ahead-of-label",
    "execution_unit": "G805",
    "pr": { "number": 8051, "url": "https://github.com/J-Tech-Japan/intent-system/pull/8051" },
    "age_minutes": 20,
    "is_informational": true,
    "recommended_action": "intent-cli automation pr-transition --repo J-Tech-Japan/intent-system --pr 8051 --transition approved --write --format json; this stalled-work finding is read-only and never applies the transition automatically.",
    "verdict_kind": "approve-equivalent",
    "verdict_at": "2026-09-04T14:40:00+00:00",
    "label_transition_at": "2026-09-04T14:30:00+00:00",
    "due_transition": "approved"
  },
  {
    "kind": "review-verdict-ahead-of-label",
    "execution_unit": "G805",
    "pr": { "number": 8052, "url": "https://github.com/J-Tech-Japan/intent-system/pull/8052" },
    "age_minutes": 18,
    "is_informational": true,
    "recommended_action": "intent-cli automation pr-transition --repo J-Tech-Japan/intent-system --pr 8052 --transition request-update --write --format json; this stalled-work finding is read-only and never applies the transition automatically.",
    "verdict_kind": "request-update",
    "verdict_at": "2026-09-04T14:42:00+00:00",
    "label_transition_at": "2026-09-04T14:32:00+00:00",
    "due_transition": "request-update"
  }
]
```

### F1 — elapsed verdict age, stale-fires and fresh-silent

Actual focused-test output (`G805_F1_StaleVerdictFiresFreshVerdictStaysSilent`):

```text
observation_time=2026-09-04T15:00:00.0000000+00:00; stale_pr=8060 age_minutes=25; fresh_pr=8061 findings=0
```

The production path first requires `verdict_at > last_intent_pr_transition`, then computes `age_minutes = floor(observation_time - verdict_at)` and applies the declared threshold to that value.

### AC3 / AC4 — reflected labels and active-review quiet shapes

Actual output (`G805_AC3_AC4_ReflectedLabelsAndBothQuietShapesStaySilent`):

```text
reflected_and_quiet_verdict_findings=0
```

The fixtures cover both matching label transitions, a newest verdict that predates the label, and no review.

### AC5 — declared default and operator override

Actual output (`G805_AC5_DefaultAndOperatorThresholdsAreDeclared`):

```text
default=5; override=15; findings=0
```

The default is `DefaultReviewVerdictAheadMinutes = 5`; `--review-verdict-ahead-minutes 15` is parsed and suppresses a ten-minute lag. The threshold is retained as a non-serialized result property so the existing JSON contract stays byte-identical.

### AC6 — read-only durable state

Actual output (`G805_AC6_ReadOnlyScanPreservesDurableBytes`):

```text
before_sha256=0DE52429135732EA02AD3C059EAE593B1F558F68E7F9BAE24195C03708D128B8
after_sha256=0DE52429135732EA02AD3C059EAE593B1F558F68E7F9BAE24195C03708D128B8
bytes_unchanged=True
```

The adapter regression also captured the exact read-only vectors:

```json
{"reviews":1,"label_transitions":1,"read_only":true}
```

The vectors were `gh pr view 8059 --repo J-Tech-Japan/intent-system --json reviews` and `gh api repos/J-Tech-Japan/intent-system/issues/8059/events --method GET --paginate --slurp`; neither contains `--write`.

### AC7 — four measured fixtures

Actual output (`G805_AC7_FourMeasuredFixturesEachYieldTheFinding`):

```json
[
    { "pr": 1743, "VerdictKind": "approve-equivalent", "AgeMinutes": 25, "DueTransition": "approved" },
    { "pr": 1746, "VerdictKind": "approve-equivalent", "AgeMinutes": 10, "DueTransition": "approved" },
    { "pr": 1747, "VerdictKind": "request-update", "AgeMinutes": 32, "DueTransition": "request-update" },
    { "pr": 1747, "VerdictKind": "approve-equivalent", "AgeMinutes": 9, "DueTransition": "approved" }
]
```

Declared observation time for all four measured fixtures: `2026-09-04T15:00:00Z`; no synthetic PR number or 60-minute substitute is used.

### Parent absence / failure proof

The new test and detector were absent at parent `d4645e2f02aea6a7969804a156df176cc2122a4a`:

```text
$ git cat-file -e d4645e2f02aea6a7969804a156df176cc2122a4a:tests/IntentSystem.Cli.Tests/AutomationStalledWorkG805Tests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/AutomationStalledWorkG805Tests.cs' exists on disk, but not in 'd4645e2f02aea6a7969804a156df176cc2122a4a'
RC:128
$ git grep -n 'review-verdict-ahead-of-label' d4645e2f02aea6a7969804a156df176cc2122a4a -- src/IntentSystem.Cli tests/IntentSystem.Cli.Tests
RC:1
$ git grep -n 'EnrichPullRequestLifecycle' d4645e2f02aea6a7969804a156df176cc2122a4a -- src/IntentSystem.Cli tests/IntentSystem.Cli.Tests
RC:1
```

### Validation and scope

- Focused G805 + shared-static guard TRX: 11 total, 11 executed, 11 passed, 0 failed, 0 skipped (RC 0).
- Full Release TRX: 5772 total, 5771 executed, 5771 passed, 0 failed, 1 expected skip (RC 0).
- `git diff --check`: passed.
- Only `AutomationStalledWorkCommand.cs`, `IGitHubAutomationCandidateLister.cs`, `AutomationStalledWorkG805Tests.cs`, and the required shared-static collection inventory update are committed. No auto-label, merge, queue-state, or other durable write was added; `stalled-work` remains read-only.

## Canonical collected-output blocks

### Criterion 1 — verdict-ahead finding fields

```text
G805_F1_StaleVerdictFiresFreshVerdictStaysSilent: observation_time=2026-09-04T15:00:00.0000000+00:00; stale_pr=8060 age_minutes=25; fresh_pr=8061 findings=0
G805_AC1_AC2_BothVerdictKindsCarryFieldsAndCanonicalActions: 2 findings; PRs 8051/8052; verdict kinds approve-equivalent/request-update; verdict ages 20/18 minutes; due transitions approved/request-update.
```

### Criterion 2 — canonical due-transition commands

```text
G805_AC1_AC2_BothVerdictKindsCarryFieldsAndCanonicalActions: approved command = intent-cli automation pr-transition --repo J-Tech-Japan/intent-system --pr 8051 --transition approved --write --format json; request-update command = intent-cli automation pr-transition --repo J-Tech-Japan/intent-system --pr 8052 --transition request-update --write --format json.
```

### Criterion 3 — reflected verdicts stay quiet

```text
G805_AC3_AC4_ReflectedLabelsAndBothQuietShapesStaySilent: reflected_and_quiet_verdict_findings=0
```

### Criterion 4 — active-review quiet shapes

```text
G805_AC3_AC4_ReflectedLabelsAndBothQuietShapesStaySilent: reflected_and_quiet_verdict_findings=0; covered newest-review-before-label and no-review fixtures.
```

### Criterion 5 — declared default and operator override

```text
G805_AC5_DefaultAndOperatorThresholdsAreDeclared: default=5; override=15; findings=0
```

### Criterion 6 — durable bytes unchanged

```text
G805_AC6_ReadOnlyScanPreservesDurableBytes: before_sha256=0DE52429135732EA02AD3C059EAE593B1F558F68E7F9BAE24195C03708D128B8; after_sha256=0DE52429135732EA02AD3C059EAE593B1F558F68E7F9BAE24195C03708D128B8; bytes_unchanged=True
```

### Criterion 7 — four measured fixtures

```text
G805_AC7_FourMeasuredFixturesEachYieldTheFinding: observation_time=2026-09-04T15:00:00.0000000+00:00; findings=[1743 approve-equivalent 25 approved, 1746 approve-equivalent 10 approved, 1747 request-update 32 request-update, 1747 approve-equivalent 9 approved]
```

### Criterion 8 — parent absence/failure

```text
parent=d4645e2f02aea6a7969804a156df176cc2122a4a
git cat-file -e parent:tests/IntentSystem.Cli.Tests/AutomationStalledWorkG805Tests.cs -> fatal: path exists on disk, but not in parent (RC:128)
git grep -n review-verdict-ahead-of-label parent -- src/IntentSystem.Cli tests/IntentSystem.Cli.Tests -> no matches (RC:1)
git grep -n EnrichPullRequestLifecycle parent -- src/IntentSystem.Cli tests/IntentSystem.Cli.Tests -> no matches (RC:1)
```

### Criterion 9 — full Release count

```text
full Release TRX: total=5772 executed=5771 passed=5771 failed=0 skipped=1; process RC:0
focused G805/static guard TRX: total=11 executed=11 passed=11 failed=0 skipped=0; process RC:0
```
