### PR TITLE
G806: distinguish published intake from runtime dispatch

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -23,11 +23,14 @@ namespace IntentSystem.Cli.Commands;
 /// deliberately names a human edit), and <see
 /// cref="StalledWorkItem.IsInformational"/> is <see langword="false"/>:
 /// <list type="bullet">
-/// <item><c>published-not-delegated</c> — an OPEN issue carries
-///   <c>intent-target</c>, has no claim label
-///   (<c>intent-issue-in-progress</c> / <c>intent-pr-created</c>), and no
-///   open PR in this repo closes it (checked independently of label state,
-///   since a label can drift out of sync with an already-created PR).</item>
+/// <item><c>published-without-intake</c> — an OPEN issue carries
+///   <c>intent-target</c>, has no claim label, and no delivered intake
+///   delegation names the orchestrator. The row names the originating seat
+///   and the canonical notify-delegate action.</item>
+/// <item><c>published-intake-awaiting-dispatch</c> — the orchestrator has a
+///   delivered intake delegation, but the queue item has not entered a
+///   runtime-dispatched state. The row carries task, delivering role,
+///   delivery timestamp, elapsed minutes, and the read-only dispatch command.</item>
 /// <item><c>pr-created-not-reviewing</c> — the source issue carries
 ///   <c>intent-pr-created</c> and its closing PR has not had the
 ///   <c>review-start</c> transition applied (no <c>intent-pr-reviewing</c> /
@@ -184,7 +187,15 @@ internal static class AutomationStalledWorkCommand
     private const string FormatJson = "json";
     private const string FormatMarkdown = "markdown";
 
-    public const string KindPublishedNotDelegated = "published-not-delegated";
+    /// <summary>G806: a published issue has no delivered intake delegation.</summary>
+    public const string KindPublishedWithoutIntake = "published-without-intake";
+
+    /// <summary>G806: orchestrator intake was delivered, but runtime dispatch has not happened.</summary>
+    public const string KindPublishedIntakeAwaitingDispatch = "published-intake-awaiting-dispatch";
+
+    // Keep the compatibility constant for existing consumers and fixtures;
+    // the published-unit surface now emits the two explicit G806 kinds.
+    public const string KindPublishedNotDelegated = KindPublishedWithoutIntake;
     public const string KindPrCreatedNotReviewing = "pr-created-not-reviewing";
     public const string KindCiPending = "ci-pending";
     public const string KindCiAllGreenNotTransitioned = "ci-all-green-not-transitioned";
@@ -727,8 +738,21 @@ internal static class AutomationStalledWorkCommand
         // result-level partial marker is applied below without losing them.
         CollectStaleClaims(context, now, staleMinutes, items, warnings);
 
-        CollectPublishedNotDelegated(context, domain, candidateDomains, openIssues, openPrs, repo, now, capabilityMatrix, items, excluded);
         var branchLaneQueueState = TryLoadQueueStateForBranchLaneRouting(context, domain, repo, warnings);
+        CollectPublishedNotDelegated(
+            context,
+            domain,
+            candidateDomains,
+            openIssues,
+            openPrs,
+            repo,
+            now,
+            capabilityMatrix,
+            openPendingDelegations,
+            branchLaneQueueState,
+            team,
+            items,
+            excluded);
         var closedPrs = branchLaneQueueState?.Items.Any(item => item.RoutingSnapshot is not null) == true
             ? ReadGitHub(() => lister.ListClosedPullRequests(
                 repo,
@@ -2078,6 +2102,9 @@ internal static class AutomationStalledWorkCommand
         string repo,
         DateTimeOffset now,
         TeamModeCapabilityMatrix capabilityMatrix,
+        IReadOnlyList<NotifyPendingDelegation> openPendingDelegations,
+        QueueState? queueState,
+        string? team,
         List<StalledWorkItem> items,
         List<StalledWorkExcluded> excluded)
     {
@@ -2153,19 +2180,190 @@ internal static class AutomationStalledWorkCommand
                 }
             }
 
+            // G806: a published unit has two materially different states. A
+            // delivered intake to the orchestrator is waiting for the
+            // runtime queue transition; absence of such delivery means the
+            // originating seat still owes the intake delegation. Neither
+            // path writes queue state: only the orchestrator's normal
+            // dispatch transition can flip the marker.
+            var queueItem = FindPublishedQueueItem(queueState, repo, issue.Number, resolution.ExecutionUnit);
+            if (queueItem is { State: QueueItemState.Active or QueueItemState.Review or QueueItemState.Fixing })
+            {
+                continue;
+            }
+
+            var intake = FindDeliveredOrchestratorIntake(
+                context,
+                resolution.ExecutionUnit,
+                openPendingDelegations,
+                out var intakeReadError);
+            if (intakeReadError is not null)
+            {
+                // A malformed optional carrier must not be promoted to an
+                // intake finding. The no-intake state remains the honest
+                // observable result while the read error is retained in the
+                // exclusion diagnostics for operators.
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindPublishedWithoutIntake,
+                    ExecutionUnit = resolution.ExecutionUnit,
+                    Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
+                    Pr = null,
+                    Reason = "published-intake-evidence-unreadable",
+                    Detail = intakeReadError,
+                });
+            }
+
+            if (intake is { Delivery: { } delivery, Record: { } intakeRecord })
+            {
+                var deliveredAt = delivery.DeliveredAt.ToUniversalTime();
+                items.Add(new StalledWorkItem
+                {
+                    Kind = KindPublishedIntakeAwaitingDispatch,
+                    ExecutionUnit = resolution.ExecutionUnit,
+                    Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
+                    Pr = null,
+                    AgeMinutes = ComputeAgeMinutesFromInstant(ClampToNow(deliveredAt, now), now),
+                    IsInformational = false,
+                    RecommendedAction =
+                        $"orchestrator must dispatch {resolution.ExecutionUnit}; run `intent-cli queue transition {resolution.ExecutionUnit} active --write --format json`",
+                    IntakeTaskId = intakeRecord.TaskId,
+                    IntakeDeliveringRole = intakeRecord.DelegatingRole ?? "<unknown>",
+                    IntakeDeliveredAt = deliveredAt,
+                    IntakeMinutesElapsed = ComputeAgeMinutesFromInstant(ClampToNow(deliveredAt, now), now),
+                });
+                continue;
+            }
+
+            var originatingRole = ResolvePublishedOriginatingRole(context, domain, team);
+
             items.Add(new StalledWorkItem
             {
-                Kind = KindPublishedNotDelegated,
+                Kind = KindPublishedWithoutIntake,
                 ExecutionUnit = resolution.ExecutionUnit,
                 Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
                 Pr = null,
                 AgeMinutes = ComputeAgeMinutes(issue.CreatedAt, now),
                 IsInformational = false,
                 RecommendedAction =
-                    $"intent-cli worker claim --repo {repo} --kind issue --number {issue.Number} --github-only --write",
+                    $"{originatingRole} owes intake delegation to orchestrator; worker claim is not the dispatch path; run `intent-cli notify delegate --domain {domain} --from {originatingRole} --to orchestrator --report-to {originatingRole} --task-id {resolution.ExecutionUnit}-intake --objective \"deliver issue #{issue.Number} to orchestrator\" --input {issue.Url} --expected-artifact {issue.Url} --result-nonce {resolution.ExecutionUnit}-intake --write --format json`; only after delivery may `intent-cli worker claim --repo {repo} --kind issue --number {issue.Number} --github-only --write` be considered",
+                OriginatingRole = originatingRole,
             });
         }
     }
+
+    private static QueueItem? FindPublishedQueueItem(
+        QueueState? queueState,
+        string repo,
+        int issueNumber,
+        string executionUnit)
+    {
+        return queueState?.Items
+            .Where(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.OrdinalIgnoreCase))
+            .Where(item => item.LinkedIssue is null
+                || (item.LinkedIssue.Number == issueNumber
+                    && string.Equals(item.LinkedIssue.Repo, repo, StringComparison.OrdinalIgnoreCase)))
+            .OrderByDescending(item => item.State is QueueItemState.Active or QueueItemState.Review or QueueItemState.Fixing)
+            .FirstOrDefault();
+    }
+
+    private static DeliveredOrchestratorIntake? FindDeliveredOrchestratorIntake(
+        CliContext context,
+        string executionUnit,
+        IReadOnlyList<NotifyPendingDelegation> openPendingDelegations,
+        out string? readError)
+    {
+        readError = null;
+        DeliveredOrchestratorIntake? best = null;
+        foreach (var record in openPendingDelegations)
+        {
+            if (!string.Equals(
+                    GuideRoleContractGuidance.Normalize(record.RecipientRole),
+                    LogicalRoleNormalizer.Orchestrator,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!NotifyDelegationExecutionEvidence.TryExtractExecutionUnitToken(
+                    context.RepoRoot,
+                    record,
+                    out var token,
+                    out var tokenError))
+            {
+                readError ??= tokenError;
+                continue;
+            }
+
+            if (!string.Equals(token, executionUnit, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var delivery = NotifyDelegationDeliveryStore.Find(
+                context.RepoRoot,
+                record.Domain,
+                record.Team,
+                record.TaskId,
+                record.ResultNonce);
+            if (!delivery.Resolved)
+            {
+                readError ??= delivery.Error;
+                continue;
+            }
+
+            if (delivery.Evidence is not { DeliverySucceeded: true } evidence)
+            {
+                continue;
+            }
+
+            var candidate = new DeliveredOrchestratorIntake(record, evidence);
+            if (best is null || candidate.Delivery.DeliveredAt > best.Delivery.DeliveredAt)
+            {
+                best = candidate;
+            }
+        }
+
+        return best;
+    }
+
+    private static string ResolvePublishedOriginatingRole(
+        CliContext context,
+        string domain,
+        string? team)
+    {
+        // Topology is optional evidence for this read-only diagnostic. When
+        // it is readable, preserve a recorded legacy design key; otherwise
+        // teach the canonical five-role name rather than inventing a runtime.
+        var topologyTeam = team ?? "intent-cli-dev";
+        var topology = NotifyRoleTopologyStore.Resolve(context.RepoRoot, domain, topologyTeam);
+        if (topology.Topology is { Roles: { } roles })
+        {
+            if (roles.Keys.Any(key => string.Equals(key, LogicalRoleNormalizer.Architect, StringComparison.OrdinalIgnoreCase)))
+            {
+                return LogicalRoleNormalizer.Architect;
+            }
+
+            if (roles.Keys.Any(key => string.Equals(key, "design", StringComparison.OrdinalIgnoreCase)))
+            {
+                return "design";
+            }
+
+            if (roles.Keys.Any(key => string.Equals(
+                    GuideRoleContractGuidance.Normalize(key),
+                    LogicalRoleNormalizer.Architect,
+                    StringComparison.Ordinal)))
+            {
+                return LogicalRoleNormalizer.Architect;
+            }
+        }
+
+        return LogicalRoleNormalizer.Architect;
+    }
+
+    private sealed record DeliveredOrchestratorIntake(
+        NotifyPendingDelegation Record,
+        NotifyDelegationDeliveryEvidence Delivery);
 
     private static void CollectPrCreatedNotReviewing(
         CliContext context,
@@ -5107,6 +5305,26 @@ internal static class AutomationStalledWorkCommand
                 {
                     writer.WriteLine($"- closed_issue_number: #{closedIssueNumber}");
                 }
+                if (item.OriginatingRole is { } originatingRole)
+                {
+                    writer.WriteLine($"- originating_role: {originatingRole}");
+                }
+                if (item.IntakeTaskId is { } intakeTaskId)
+                {
+                    writer.WriteLine($"- intake_task_id: {intakeTaskId}");
+                }
+                if (item.IntakeDeliveringRole is { } intakeDeliveringRole)
+                {
+                    writer.WriteLine($"- intake_delivering_role: {intakeDeliveringRole}");
+                }
+                if (item.IntakeDeliveredAt is { } intakeDeliveredAt)
+                {
+                    writer.WriteLine($"- intake_delivered_at: {intakeDeliveredAt:O}");
+                }
+                if (item.IntakeMinutesElapsed is { } intakeMinutesElapsed)
+                {
+                    writer.WriteLine($"- intake_minutes_elapsed: {intakeMinutesElapsed}");
+                }
                 if (item.VerdictKind is { } verdictKind)
                 {
                     writer.WriteLine($"- verdict_kind: {verdictKind}");
@@ -5472,6 +5690,28 @@ internal sealed record StalledWorkItem
     [JsonPropertyName("closed_issue_number")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? ClosedIssueNumber { get; init; }
+
+    /// <summary>G806: recorded originating seat for a published unit with no intake.</summary>
+    [JsonPropertyName("originating_role")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? OriginatingRole { get; init; }
+
+    /// <summary>G806: delivered intake task awaiting the orchestrator's runtime dispatch.</summary>
+    [JsonPropertyName("intake_task_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IntakeTaskId { get; init; }
+
+    [JsonPropertyName("intake_delivering_role")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IntakeDeliveringRole { get; init; }
+
+    [JsonPropertyName("intake_delivered_at")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? IntakeDeliveredAt { get; init; }
+
+    [JsonPropertyName("intake_minutes_elapsed")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? IntakeMinutesElapsed { get; init; }
 
     /// <summary>G805: normalized durable review outcome.</summary>
     [JsonPropertyName("verdict_kind")]

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -27,10 +27,12 @@ namespace IntentSystem.Cli.Commands;
 ///   <c>intent-target</c>, has no claim label, and no delivered intake
 ///   delegation names the orchestrator. The row names the originating seat
 ///   and the canonical notify-delegate action.</item>
-/// <item><c>published-intake-awaiting-dispatch</c> — the orchestrator has a
-///   delivered intake delegation, but the queue item has not entered a
-///   runtime-dispatched state. The row carries task, delivering role,
-///   delivery timestamp, elapsed minutes, and the read-only dispatch command.</item>
+/// <item><c>published-intake-awaiting-dispatch</c> — an existing intake
+///   delegation (normally delivered to the orchestrator) has not yet led to
+///   a runtime-dispatched queue item. The row carries task, delivering role,
+///   actual recipient, delivery state, timestamp, elapsed minutes, and a
+///   read-only action; a misrouted existing intake is never replaced with a
+///   fresh delegation recommendation.</item>
 /// <item><c>pr-created-not-reviewing</c> — the source issue carries
 ///   <c>intent-pr-created</c> and its closing PR has not had the
 ///   <c>review-start</c> transition applied (no <c>intent-pr-reviewing</c> /
@@ -2192,7 +2194,7 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
-            var intake = FindDeliveredOrchestratorIntake(
+            var intake = FindExistingIntakeDelegation(
                 context,
                 resolution.ExecutionUnit,
                 openPendingDelegations,
@@ -2214,23 +2216,37 @@ internal static class AutomationStalledWorkCommand
                 });
             }
 
-            if (intake is { Delivery: { } delivery, Record: { } intakeRecord })
+            if (intake is { Record: { } intakeRecord })
             {
-                var deliveredAt = delivery.DeliveredAt.ToUniversalTime();
+                var delivery = intake.Delivery;
+                var deliveredAt = delivery?.DeliveredAt.ToUniversalTime();
+                var recipientRole = intakeRecord.RecipientRole;
+                var isOrchestratorRecipient = string.Equals(
+                    GuideRoleContractGuidance.Normalize(recipientRole),
+                    LogicalRoleNormalizer.Orchestrator,
+                    StringComparison.Ordinal);
+                var action = isOrchestratorRecipient && delivery is not null
+                    ? $"orchestrator must dispatch {resolution.ExecutionUnit}; run `intent-cli queue transition {resolution.ExecutionUnit} active --write --format json`"
+                    : $"existing intake {intakeRecord.TaskId} from {intakeRecord.DelegatingRole ?? "<unknown>"} to {recipientRole} has delivery state {intake.DeliveryState}; do not create a fresh intake; resolve this recorded delegation before orchestrator dispatch";
                 items.Add(new StalledWorkItem
                 {
                     Kind = KindPublishedIntakeAwaitingDispatch,
                     ExecutionUnit = resolution.ExecutionUnit,
                     Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
                     Pr = null,
-                    AgeMinutes = ComputeAgeMinutesFromInstant(ClampToNow(deliveredAt, now), now),
+                    AgeMinutes = deliveredAt is { } deliveryInstant
+                        ? ComputeAgeMinutesFromInstant(ClampToNow(deliveryInstant, now), now)
+                        : ComputeAgeMinutesFromInstant(ClampToNow(intakeRecord.DispatchedAt, now), now),
                     IsInformational = false,
-                    RecommendedAction =
-                        $"orchestrator must dispatch {resolution.ExecutionUnit}; run `intent-cli queue transition {resolution.ExecutionUnit} active --write --format json`",
+                    RecommendedAction = action,
                     IntakeTaskId = intakeRecord.TaskId,
                     IntakeDeliveringRole = intakeRecord.DelegatingRole ?? "<unknown>",
+                    IntakeRecipientRole = recipientRole,
+                    IntakeDeliveryState = intake.DeliveryState,
                     IntakeDeliveredAt = deliveredAt,
-                    IntakeMinutesElapsed = ComputeAgeMinutesFromInstant(ClampToNow(deliveredAt, now), now),
+                    IntakeMinutesElapsed = deliveredAt is { } deliveredInstant
+                        ? ComputeAgeMinutesFromInstant(ClampToNow(deliveredInstant, now), now)
+                        : null,
                 });
                 continue;
             }
@@ -2267,27 +2283,19 @@ internal static class AutomationStalledWorkCommand
             .FirstOrDefault();
     }
 
-    private static DeliveredOrchestratorIntake? FindDeliveredOrchestratorIntake(
+    private static ExistingIntakeDelegation? FindExistingIntakeDelegation(
         CliContext context,
         string executionUnit,
         IReadOnlyList<NotifyPendingDelegation> openPendingDelegations,
         out string? readError)
     {
         readError = null;
-        DeliveredOrchestratorIntake? best = null;
+        ExistingIntakeDelegation? best = null;
         foreach (var record in openPendingDelegations)
         {
-            if (!string.Equals(
-                    GuideRoleContractGuidance.Normalize(record.RecipientRole),
-                    LogicalRoleNormalizer.Orchestrator,
-                    StringComparison.Ordinal))
-            {
-                continue;
-            }
-
             if (!NotifyDelegationExecutionEvidence.TryExtractExecutionUnitToken(
-                    context.RepoRoot,
-                    record,
+                context.RepoRoot,
+                record,
                     out var token,
                     out var tokenError))
             {
@@ -2309,16 +2317,20 @@ internal static class AutomationStalledWorkCommand
             if (!delivery.Resolved)
             {
                 readError ??= delivery.Error;
-                continue;
             }
 
-            if (delivery.Evidence is not { DeliverySucceeded: true } evidence)
-            {
-                continue;
-            }
-
-            var candidate = new DeliveredOrchestratorIntake(record, evidence);
-            if (best is null || candidate.Delivery.DeliveredAt > best.Delivery.DeliveredAt)
+            var evidence = delivery.Evidence is { DeliverySucceeded: true } delivered
+                ? delivered
+                : null;
+            var deliveryState = !delivery.Resolved
+                ? "unreadable"
+                : evidence is not null
+                    ? "delivered"
+                    : "pending";
+            var candidate = new ExistingIntakeDelegation(record, evidence, deliveryState);
+            var candidateTime = evidence?.DeliveredAt ?? record.DispatchedAt;
+            var bestTime = best?.Delivery?.DeliveredAt ?? best?.Record.DispatchedAt;
+            if (best is null || bestTime is null || candidateTime > bestTime.Value)
             {
                 best = candidate;
             }
@@ -2361,9 +2373,10 @@ internal static class AutomationStalledWorkCommand
         return LogicalRoleNormalizer.Architect;
     }
 
-    private sealed record DeliveredOrchestratorIntake(
+    private sealed record ExistingIntakeDelegation(
         NotifyPendingDelegation Record,
-        NotifyDelegationDeliveryEvidence Delivery);
+        NotifyDelegationDeliveryEvidence? Delivery,
+        string DeliveryState);
 
     private static void CollectPrCreatedNotReviewing(
         CliContext context,
@@ -5317,6 +5330,14 @@ internal static class AutomationStalledWorkCommand
                 {
                     writer.WriteLine($"- intake_delivering_role: {intakeDeliveringRole}");
                 }
+                if (item.IntakeRecipientRole is { } intakeRecipientRole)
+                {
+                    writer.WriteLine($"- intake_recipient_role: {intakeRecipientRole}");
+                }
+                if (item.IntakeDeliveryState is { } intakeDeliveryState)
+                {
+                    writer.WriteLine($"- intake_delivery_state: {intakeDeliveryState}");
+                }
                 if (item.IntakeDeliveredAt is { } intakeDeliveredAt)
                 {
                     writer.WriteLine($"- intake_delivered_at: {intakeDeliveredAt:O}");
@@ -5704,6 +5725,14 @@ internal sealed record StalledWorkItem
     [JsonPropertyName("intake_delivering_role")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? IntakeDeliveringRole { get; init; }
+
+    [JsonPropertyName("intake_recipient_role")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IntakeRecipientRole { get; init; }
+
+    [JsonPropertyName("intake_delivery_state")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? IntakeDeliveryState { get; init; }
 
     [JsonPropertyName("intake_delivered_at")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
@@ -432,6 +432,33 @@ internal sealed record NotifyDelegationExecutionEvidence
     }
 
     /// <summary>
+    /// G806: apply the same configured, ordered G788 recognizer to a pending
+    /// delegation record.  Consumers that only need the carrier identity do
+    /// not have to reimplement token parsing or manufacture a second pattern.
+    /// </summary>
+    internal static bool TryExtractExecutionUnitToken(
+        string routingRoot,
+        NotifyPendingDelegation record,
+        out string? executionUnitToken,
+        out string? error)
+    {
+        var pattern = ResolveUnitPattern(routingRoot, record.Domain, out error);
+        if (pattern is null)
+        {
+            executionUnitToken = null;
+            return false;
+        }
+
+        executionUnitToken = ExtractExecutionUnitToken(
+            record.TaskId,
+            record.Objective,
+            record.Inputs,
+            pattern);
+        error = null;
+        return true;
+    }
+
+    /// <summary>
     /// Resolves a Steward's downstream reference against the same measured
     /// evidence set used by G788.  A reference is accepted only when it is
     /// present in a token-carrying pending ledger, report outbox, or

--- a/src/IntentSystem.Cli/Commands/TeamModeCapabilityMatrix.cs
+++ b/src/IntentSystem.Cli/Commands/TeamModeCapabilityMatrix.cs
@@ -71,7 +71,8 @@ internal sealed record TeamModeCapabilityMatrix
     /// </summary>
     public bool IsStalledKindApplicable(string kind)
     {
-        if (string.Equals(kind, AutomationStalledWorkCommand.KindPublishedNotDelegated, StringComparison.Ordinal))
+        if (kind is AutomationStalledWorkCommand.KindPublishedWithoutIntake
+            or AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch)
         {
             return true;
         }
@@ -117,7 +118,8 @@ internal sealed record TeamModeCapabilityMatrix
             or AutomationStalledWorkCommand.KindRereviewPending
             or AutomationStalledWorkCommand.KindRepairStalled
             => TeamModeCapabilityClasses.Review,
-        AutomationStalledWorkCommand.KindPublishedNotDelegated
+        AutomationStalledWorkCommand.KindPublishedWithoutIntake
+            or AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch
             => TeamModeCapabilityClasses.Delegation,
         _ => TeamModeCapabilityClasses.ContractReadiness,
     };

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkG806Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkG806Tests.cs
@@ -102,7 +102,7 @@ public sealed class AutomationStalledWorkG806Tests : IDisposable
     }
 
     [Fact]
-    public void G806_AC4_AC6_NonOrchestratorIntakeAndStalledScanPreserveBytes()
+    public void G806_AC4_AC6_MisroutedIntakeAndStalledScanPreserveBytes()
     {
         workspace.WritePacket("G806");
         var issue = BuildIssue(1805, "G806: read-only", Now.AddMinutes(-90));
@@ -113,11 +113,17 @@ public sealed class AutomationStalledWorkG806Tests : IDisposable
         var beforeFiles = SnapshotFiles(workspace.Root);
         var before = Digest(beforeFiles);
 
-        // A non-orchestrator delivery is not intake for this finding. It is
-        // still observable, but it cannot flip the queue marker.
+        // A non-orchestrator delivery is an existing intake, but it cannot
+        // flip the queue marker or trigger a second intake recommendation.
         var result = Analyze(issue, "G806");
-        Assert.DoesNotContain(result.Items, item => item.Kind == AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch);
-        Assert.Contains(result.Items, item => item.Kind == AutomationStalledWorkCommand.KindPublishedWithoutIntake);
+        var finding = Assert.Single(result.Items, item => item.ExecutionUnit == "G806");
+        Assert.Equal(AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch, finding.Kind);
+        Assert.Equal("G806-read-only-intake", finding.IntakeTaskId);
+        Assert.Equal("steward", finding.IntakeDeliveringRole);
+        Assert.Equal("builder", finding.IntakeRecipientRole);
+        Assert.Equal("delivered", finding.IntakeDeliveryState);
+        Assert.DoesNotContain("notify delegate", finding.RecommendedAction, StringComparison.Ordinal);
+        Assert.Contains("G806-read-only-intake", finding.RecommendedAction, StringComparison.Ordinal);
         var afterFiles = SnapshotFiles(workspace.Root);
         var after = Digest(afterFiles);
         if (before != after)
@@ -131,7 +137,12 @@ public sealed class AutomationStalledWorkG806Tests : IDisposable
             }
         }
         Assert.Equal(before, after);
-        output.WriteLine($"queue_state_unchanged={before == after}; non_orchestrator_intake=not-counted; bytes={before}");
+        output.WriteLine(JsonSerializer.Serialize(new
+        {
+            misrouted_intake = finding,
+            queue_state_unchanged = before == after,
+            bytes = before,
+        }, new JsonSerializerOptions { WriteIndented = true }));
     }
 
     [Theory]
@@ -163,16 +174,25 @@ public sealed class AutomationStalledWorkG806Tests : IDisposable
     public void G806_AC7_G799PublishedFixtureUsesAwaitingDispatchAndCorrectElapsed()
     {
         workspace.WritePacket("G799");
-        var issue = BuildIssue(1744, "G799: published implementation", Now.AddMinutes(-120));
-        var pending = BuildPending("G799-implementation-v1", "G799", "orchestration", Now.AddMinutes(-90));
+        var intakeDispatchedAt = new DateTimeOffset(2026, 9, 4, 10, 29, 56, TimeSpan.Zero);
+        var runtimeObservedAt = new DateTimeOffset(2026, 9, 5, 2, 3, 16, TimeSpan.Zero);
+        AutomationStalledWorkCommand.UtcNowFactory = () => runtimeObservedAt;
+        var issue = BuildIssue(1744, "G799: published implementation", intakeDispatchedAt.AddMinutes(-10));
+        var pending = BuildPending(
+            "G799-intake-and-repair-priority-v1",
+            "G799",
+            "design",
+            intakeDispatchedAt);
         Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.Root, pending).Written);
-        Assert.True(NotifyDelegationDeliveryStore.Write(workspace.Root, pending, Now.AddMinutes(-25)).Written);
+        Assert.True(NotifyDelegationDeliveryStore.Write(workspace.Root, pending, intakeDispatchedAt).Written);
         var result = Analyze(issue, "G799");
         var finding = Assert.Single(result.Items, item => item.ExecutionUnit == "G799");
         Assert.Equal(AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch, finding.Kind);
-        Assert.Equal("G799-implementation-v1", finding.IntakeTaskId);
-        Assert.Equal("orchestration", finding.IntakeDeliveringRole);
-        Assert.Equal(25, finding.IntakeMinutesElapsed);
+        Assert.Equal("G799-intake-and-repair-priority-v1", finding.IntakeTaskId);
+        Assert.Equal("design", finding.IntakeDeliveringRole);
+        Assert.Equal("orchestrator", finding.IntakeRecipientRole);
+        Assert.Equal("delivered", finding.IntakeDeliveryState);
+        Assert.InRange(finding.IntakeMinutesElapsed!.Value, 930, 935);
         output.WriteLine(JsonSerializer.Serialize(finding, new JsonSerializerOptions { WriteIndented = true }));
     }
 

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkG806Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkG806Tests.cs
@@ -1,0 +1,357 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+using Xunit.Abstractions;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G806: published issue findings distinguish missing intake from an intake
+/// delivered to orchestrator but not yet dispatched into the runtime queue.
+/// The analyzer is read-only; the only state transition remains the ordinary
+/// orchestrator queue transition command.
+/// </summary>
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class AutomationStalledWorkG806Tests : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 5, 12, 0, 0, TimeSpan.Zero);
+    private readonly G806Workspace workspace = new();
+    private readonly ITestOutputHelper output;
+
+    public AutomationStalledWorkG806Tests(ITestOutputHelper output)
+    {
+        this.output = output;
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = () => Now;
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = null;
+        workspace.Dispose();
+    }
+
+    [Fact]
+    public void G806_AC1_AC2_NoIntakeAndDeliveredIntakeAreDistinctWithOwnerEvidence()
+    {
+        workspace.WritePacket("G806");
+        var noIntakeIssue = BuildIssue(1801, "G806: no intake", Now.AddMinutes(-80));
+        var noIntake = Analyze(noIntakeIssue, "G806");
+        var noIntakeFinding = Assert.Single(noIntake.Items, item => item.ExecutionUnit == "G806");
+        Assert.Equal(AutomationStalledWorkCommand.KindPublishedWithoutIntake, noIntakeFinding.Kind);
+        Assert.Equal("architect", noIntakeFinding.OriginatingRole);
+        Assert.Contains("notify delegate", noIntakeFinding.RecommendedAction, StringComparison.Ordinal);
+
+        var deliveredIssue = BuildIssue(1802, "G806: delivered intake", Now.AddMinutes(-70));
+        var pending = BuildPending(
+            "G806-intake",
+            "G806-delivered",
+            delegatingRole: "architect",
+            dispatchedAt: Now.AddMinutes(-55));
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.Root, pending).Written);
+        Assert.True(NotifyDelegationDeliveryStore.Write(workspace.Root, pending, Now.AddMinutes(-42)).Written);
+        var delivered = Analyze(deliveredIssue, "G806");
+        var awaiting = Assert.Single(delivered.Items, item => item.ExecutionUnit == "G806");
+        Assert.Equal(AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch, awaiting.Kind);
+        Assert.Equal("G806-intake", awaiting.IntakeTaskId);
+        Assert.Equal("architect", awaiting.IntakeDeliveringRole);
+        Assert.Equal(42, awaiting.IntakeMinutesElapsed);
+        Assert.Equal(Now.AddMinutes(-42), awaiting.IntakeDeliveredAt);
+        Assert.Contains("queue transition G806 active", awaiting.RecommendedAction, StringComparison.Ordinal);
+
+        output.WriteLine(JsonSerializer.Serialize(new { no_intake = noIntakeFinding, awaiting_dispatch = awaiting }, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    [Fact]
+    public void G806_AC3_RecordedLegacyDesignOriginIsNamedWithoutRuntimeRolePairing()
+    {
+        workspace.WritePacket("G806");
+        workspace.WriteTopology("design");
+        var issue = BuildIssue(1803, "G806 legacy design origin", Now.AddMinutes(-75));
+        var result = Analyze(issue, "G806");
+        var finding = Assert.Single(result.Items, item => item.ExecutionUnit == "G806");
+        Assert.Equal(AutomationStalledWorkCommand.KindPublishedWithoutIntake, finding.Kind);
+        Assert.Equal("design", finding.OriginatingRole);
+        Assert.Contains("design owes intake delegation", finding.RecommendedAction, StringComparison.Ordinal);
+        output.WriteLine(JsonSerializer.Serialize(finding, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    [Fact]
+    public void G806_AC5_AwaitingDispatchDisappearsAfterRuntimeQueueTransition()
+    {
+        workspace.WritePacket("G806");
+        var issue = BuildIssue(1804, "G806: dispatch transition", Now.AddMinutes(-60));
+        var pending = BuildPending("G806-dispatch-intake", "G806", "architect", Now.AddMinutes(-45));
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.Root, pending).Written);
+        Assert.True(NotifyDelegationDeliveryStore.Write(workspace.Root, pending, Now.AddMinutes(-35)).Written);
+        var awaiting = Analyze(issue, "G806");
+        Assert.Contains(awaiting.Items, item => item.Kind == AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch);
+
+        workspace.WriteQueueState(BuildQueueState("G806", QueueItemState.Active, issue.Number));
+        var dispatched = Analyze(issue, "G806");
+        Assert.DoesNotContain(dispatched.Items, item => item.ExecutionUnit == "G806");
+        output.WriteLine("before=published-intake-awaiting-dispatch\nafter=runtime-dispatched; findings=0");
+    }
+
+    [Fact]
+    public void G806_AC4_AC6_NonOrchestratorIntakeAndStalledScanPreserveBytes()
+    {
+        workspace.WritePacket("G806");
+        var issue = BuildIssue(1805, "G806: read-only", Now.AddMinutes(-90));
+        var pending = BuildPending("G806-read-only-intake", "G806", "steward", Now.AddMinutes(-75), recipientRole: "builder");
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.Root, pending).Written);
+        Assert.True(NotifyDelegationDeliveryStore.Write(workspace.Root, pending, Now.AddMinutes(-65)).Written);
+        workspace.WriteQueueState(BuildQueueState("G806", QueueItemState.Queued, issue.Number));
+        var beforeFiles = SnapshotFiles(workspace.Root);
+        var before = Digest(beforeFiles);
+
+        // A non-orchestrator delivery is not intake for this finding. It is
+        // still observable, but it cannot flip the queue marker.
+        var result = Analyze(issue, "G806");
+        Assert.DoesNotContain(result.Items, item => item.Kind == AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch);
+        Assert.Contains(result.Items, item => item.Kind == AutomationStalledWorkCommand.KindPublishedWithoutIntake);
+        var afterFiles = SnapshotFiles(workspace.Root);
+        var after = Digest(afterFiles);
+        if (before != after)
+        {
+            output.WriteLine($"before={before}\nafter={after}");
+            foreach (var path in beforeFiles.Keys.Union(afterFiles.Keys).OrderBy(path => path, StringComparer.Ordinal))
+            {
+                beforeFiles.TryGetValue(path, out var oldHash);
+                afterFiles.TryGetValue(path, out var newHash);
+                output.WriteLine($"file={path} before={oldHash} after={newHash}");
+            }
+        }
+        Assert.Equal(before, after);
+        output.WriteLine($"queue_state_unchanged={before == after}; non_orchestrator_intake=not-counted; bytes={before}");
+    }
+
+    [Theory]
+    [InlineData("architect")]
+    [InlineData("design")]
+    [InlineData("steward")]
+    public void G806_AC4_NotifyDelegateFromNonOrchestratorLeavesQueueBytesUnchanged(string fromRole)
+    {
+        workspace.WriteNotifyTopology();
+        workspace.WriteQueueState(BuildQueueState("G806", QueueItemState.Queued, 1806));
+        var before = File.ReadAllBytes(workspace.Context.GetQueueStatePath());
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteDelegate(
+            workspace.Context,
+            [
+                "--domain", "intent-cli", "--team", "intent-cli-dev", "--from", fromRole,
+                "--to", "builder", "--report-to", "architect", "--task-id", $"G806-{fromRole}-intake",
+                "--objective", "deliver G806 to orchestrator", "--input", "issue=1806",
+                "--expected-artifact", "published issue intake", "--result-nonce", $"G806-{fromRole}-nonce",
+                "--event-kind", "completion", "--write", "--format", "json",
+            ],
+            writer);
+        Assert.True(exitCode == 0, writer.ToString());
+        Assert.Equal(before, File.ReadAllBytes(workspace.Context.GetQueueStatePath()));
+        output.WriteLine($"from={fromRole}; exit={exitCode}; queue_bytes_unchanged=true; queue_transition=none; output={writer}");
+    }
+
+    [Fact]
+    public void G806_AC7_G799PublishedFixtureUsesAwaitingDispatchAndCorrectElapsed()
+    {
+        workspace.WritePacket("G799");
+        var issue = BuildIssue(1744, "G799: published implementation", Now.AddMinutes(-120));
+        var pending = BuildPending("G799-implementation-v1", "G799", "orchestration", Now.AddMinutes(-90));
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.Root, pending).Written);
+        Assert.True(NotifyDelegationDeliveryStore.Write(workspace.Root, pending, Now.AddMinutes(-25)).Written);
+        var result = Analyze(issue, "G799");
+        var finding = Assert.Single(result.Items, item => item.ExecutionUnit == "G799");
+        Assert.Equal(AutomationStalledWorkCommand.KindPublishedIntakeAwaitingDispatch, finding.Kind);
+        Assert.Equal("G799-implementation-v1", finding.IntakeTaskId);
+        Assert.Equal("orchestration", finding.IntakeDeliveringRole);
+        Assert.Equal(25, finding.IntakeMinutesElapsed);
+        output.WriteLine(JsonSerializer.Serialize(finding, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private AutomationStalledWorkResult Analyze(
+        GitHubAutomationIssueCandidate issue,
+        string? executionUnit = null)
+    {
+        var unit = executionUnit ?? "G806";
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister([issue]);
+        return AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 0,
+            team: "intent-cli-dev");
+    }
+
+    private static GitHubAutomationIssueCandidate BuildIssue(int number, string title, DateTimeOffset createdAt) => new()
+    {
+        Number = number,
+        Title = title,
+        Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
+        CreatedAt = createdAt.ToString("O"),
+        UpdatedAt = createdAt.ToString("O"),
+        State = "OPEN",
+        Labels = [new GitHubAutomationLabel { Name = "intent-target" }],
+    };
+
+    private static NotifyPendingDelegation BuildPending(
+        string taskId,
+        string unit,
+        string delegatingRole,
+        DateTimeOffset dispatchedAt,
+        string recipientRole = "orchestrator") => new()
+    {
+        Domain = "intent-cli",
+        Team = "intent-cli-dev",
+        TaskId = taskId,
+        DelegatingRole = delegatingRole,
+        RecipientRole = recipientRole,
+        RecipientIdentity = "orchestrator-seat",
+        ExpectedArtifact = $"https://github.com/J-Tech-Japan/intent-system/issues/{unit}",
+        ExpectedArtifacts = [$"https://github.com/J-Tech-Japan/intent-system/issues/{unit}"],
+        Objective = $"Deliver {unit} intake to orchestrator.",
+        Inputs = [$"https://github.com/J-Tech-Japan/intent-system/issues/{unit}"],
+        ResultNonce = $"{taskId}-nonce",
+        DispatchedAt = dispatchedAt,
+    };
+
+    private static string BuildQueueState(string unit, QueueItemState state, int issueNumber) =>
+        QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = Now,
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = unit,
+                    Title = unit + " title",
+                    State = state,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = string.Empty,
+                    PacketPaths = new PacketPaths { Yaml = "a", Implementation = "b", ReviewContext = "c" },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = issueNumber,
+                        Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{issueNumber}",
+                    },
+                    LinkedPr = null,
+                    WorkerRole = "builder",
+                    ReviewRole = "reviewer",
+                    Priority = "normal",
+                },
+            ],
+        });
+
+    private static Dictionary<string, string> SnapshotFiles(string root)
+    {
+        return Directory.GetFiles(root, "*", SearchOption.AllDirectories)
+            .Where(path => !path.Contains("/bin/", StringComparison.Ordinal) && !path.Contains("/obj/", StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToDictionary(
+                path => path[(root.Length + 1)..],
+                path => Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path))),
+                StringComparer.Ordinal);
+    }
+
+    private static string Digest(IReadOnlyDictionary<string, string> files) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(string.Join("\n", files.Select(pair => pair.Key + "=" + pair.Value)))));
+
+    private sealed class FakeLister(IReadOnlyList<GitHubAutomationIssueCandidate> issues) : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => [];
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => issues;
+    }
+
+    private sealed class G806Workspace : IDisposable
+    {
+        public G806Workspace()
+        {
+            Root = Directory.CreateTempSubdirectory("stalled-work-g806-").FullName;
+            Directory.CreateDirectory(Path.Combine(Root, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = Root,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli", WorktreeRoot = ".intent-cli/worktrees" },
+                },
+            };
+        }
+
+        public string Root { get; }
+        public CliContext Context { get; }
+
+        public void WritePacket(string unit) => WriteFile(
+            $".intent-cli/issues/{unit}/packet.yaml",
+            "implementation_issue_packet:\n  domain: intent-cli\n");
+
+        public void WriteQueueState(string content) => File.WriteAllText(Context.GetQueueStatePath(), content);
+
+        public void WriteTopology(string role)
+        {
+            WriteFile(
+                ".intent-cli/topology/intent-cli/intent-cli-dev.json",
+                $$"""
+                {
+                  "domain": "intent-cli",
+                  "team": "intent-cli-dev",
+                  "workspace_id": "g806",
+                  "roles": {
+                    "{{role}}": { "resident": "external", "reader": "codex" }
+                  }
+                }
+                """);
+        }
+
+        public void WriteNotifyTopology()
+        {
+            WriteFile(
+                ".intent-cli/topology/intent-cli/intent-cli-dev.json",
+                """
+                {
+                  "domain": "intent-cli",
+                  "team": "intent-cli-dev",
+                  "workspace_id": "g806",
+                  "roles": {
+                    "architect": { "resident": "external", "reader": "codex" },
+                    "orchestrator": { "resident": "external", "reader": "codex" },
+                    "builder": { "resident": "external", "reader": "codex" },
+                    "reviewer": { "resident": "external", "reader": "codex" },
+                    "steward": { "resident": "external", "reader": "codex" },
+                    "design": { "resident": "external", "reader": "codex" }
+                  }
+                }
+            """);
+            using var writer = new StringWriter();
+            Assert.Equal(0, SessionLayerCommand.ExecuteSet(
+                Context,
+                ["--domain", "intent-cli", "--team", "intent-cli-dev", "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+                writer));
+        }
+
+        public void WriteFile(string relativePath, string content)
+        {
+            var path = Path.Combine(Root, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1758

## G806 implementation

This PR separates the read-only `stalled-work` result for a published issue with no intake from an existing intake that has not yet reached a runtime queue transition. It reuses the existing G788 execution-unit recognizer, records owner/action evidence only, and does not write queue state. The repair also preserves the one-intake constraint for misrouted or pending records: an existing delegation is named and never replaced with a fresh intake recommendation.

## Criteria 1–2 — distinct findings and delivered-intake fields

Actual focused Release test output (`G806_AC1_AC2_NoIntakeAndDeliveredIntakeAreDistinctWithOwnerEvidence`):

### Criterion 1

```json
{
  "no_intake": {
    "kind": "published-without-intake",
    "execution_unit": "G806",
    "issue": { "number": 1801, "url": "https://github.com/J-Tech-Japan/intent-system/issues/1801" },
    "age_minutes": 80,
    "is_informational": false,
    "recommended_action": "architect owes intake delegation to orchestrator; worker claim is not the dispatch path; run `intent-cli notify delegate --domain intent-cli --from architect --to orchestrator --report-to architect --task-id G806-intake --objective \"deliver issue #1801 to orchestrator\" --input https://github.com/J-Tech-Japan/intent-system/issues/1801 --expected-artifact https://github.com/J-Tech-Japan/intent-system/issues/1801 --result-nonce G806-intake --write --format json`; only after delivery may `intent-cli worker claim --repo J-Tech-Japan/intent-system --kind issue --number 1801 --github-only --write` be considered",
    "originating_role": "architect"
  },
  "awaiting_dispatch": {
    "kind": "published-intake-awaiting-dispatch",
    "execution_unit": "G806",
    "issue": { "number": 1802, "url": "https://github.com/J-Tech-Japan/intent-system/issues/1802" },
    "age_minutes": 42,
    "is_informational": false,
    "recommended_action": "orchestrator must dispatch G806; run `intent-cli queue transition G806 active --write --format json`",
    "intake_task_id": "G806-intake",
    "intake_delivering_role": "architect",
    "intake_delivered_at": "2026-09-05T11:18:00+00:00",
    "intake_minutes_elapsed": 42
  },
  "misrouted_intake": {
    "kind": "published-intake-awaiting-dispatch",
    "execution_unit": "G806",
    "issue": { "number": 1805, "url": "https://github.com/J-Tech-Japan/intent-system/issues/1805" },
    "age_minutes": 65,
    "is_informational": false,
    "recommended_action": "existing intake G806-read-only-intake from steward to builder has delivery state delivered; do not create a fresh intake; resolve this recorded delegation before orchestrator dispatch",
    "intake_task_id": "G806-read-only-intake",
    "intake_delivering_role": "steward",
    "intake_recipient_role": "builder",
    "intake_delivery_state": "delivered",
    "intake_delivered_at": "2026-09-05T10:55:00+00:00",
    "intake_minutes_elapsed": 65
  }
}
```

### Criterion 2

```json
{
  "kind": "published-intake-awaiting-dispatch",
  "execution_unit": "G806",
  "issue": { "number": 1802, "url": "https://github.com/J-Tech-Japan/intent-system/issues/1802" },
  "age_minutes": 42,
  "is_informational": false,
  "recommended_action": "orchestrator must dispatch G806; run `intent-cli queue transition G806 active --write --format json`",
  "intake_task_id": "G806-intake",
  "intake_delivering_role": "architect",
  "intake_recipient_role": "orchestrator",
  "intake_delivery_state": "delivered",
  "intake_delivered_at": "2026-09-05T11:18:00+00:00",
  "intake_minutes_elapsed": 42
}
```

## Criterion 3 — topology names the originating seat

Actual focused Release test output (`G806_AC3_RecordedLegacyDesignOriginIsNamedWithoutRuntimeRolePairing`):

### Criterion 3

```json
{
  "kind": "published-without-intake",
  "execution_unit": "G806",
  "issue": { "number": 1803, "url": "https://github.com/J-Tech-Japan/intent-system/issues/1803" },
  "age_minutes": 75,
  "is_informational": false,
  "recommended_action": "design owes intake delegation to orchestrator; worker claim is not the dispatch path; run `intent-cli notify delegate --domain intent-cli --from design --to orchestrator --report-to design --task-id G806-intake --objective \"deliver issue #1803 to orchestrator\" --input https://github.com/J-Tech-Japan/intent-system/issues/1803 --expected-artifact https://github.com/J-Tech-Japan/intent-system/issues/1803 --result-nonce G806-intake --write --format json`; only after delivery may `intent-cli worker claim --repo J-Tech-Japan/intent-system --kind issue --number 1803 --github-only --write` be considered",
  "originating_role": "design"
}
```

## Criterion 4 — non-orchestrator delegates do not move the queue marker

Actual `notify delegate --write` fixture output for every required sender:

### Criterion 4

```text
from=architect; exit=0; queue_bytes_unchanged=true; queue_transition=none; command_mode=write; delivered=true; event_appended=true
from=design; exit=0; queue_bytes_unchanged=true; queue_transition=none; command_mode=write; delivered=true; event_appended=true
from=steward; exit=0; queue_bytes_unchanged=true; queue_transition=none; command_mode=write; delivered=true; event_appended=true
```

The corresponding emitted JSON in each raw test record has `"command_mode": "write"`, `"delivered": true`, and `"event_appended": true`; the queue assertion is byte-for-byte unchanged for all three cases.

## Criterion 5 — runtime dispatch clears awaiting state

Actual focused Release test output (`G806_AC5_AwaitingDispatchDisappearsAfterRuntimeQueueTransition`):

### Criterion 5

```text
before=published-intake-awaiting-dispatch
after=runtime-dispatched; findings=0
```

## Criterion 6 — stalled-work is read-only

Actual focused Release test output (`G806_AC4_AC6_MisroutedIntakeAndStalledScanPreserveBytes`):

### Criterion 6

```text
{
  "misrouted_intake": {
    "kind": "published-intake-awaiting-dispatch",
    "execution_unit": "G806",
    "issue": {
      "number": 1805,
      "url": "https://github.com/J-Tech-Japan/intent-system/issues/1805"
    },
    "pr": null,
    "age_minutes": 65,
    "is_informational": false,
    "recommended_action": "existing intake G806-read-only-intake from steward to builder has delivery state delivered; do not create a fresh intake; resolve this recorded delegation before orchestrator dispatch",
    "intake_task_id": "G806-read-only-intake",
    "intake_delivering_role": "steward",
    "intake_recipient_role": "builder",
    "intake_delivery_state": "delivered",
    "intake_delivered_at": "2026-09-05T10:55:00+00:00",
    "intake_minutes_elapsed": 65,
    "declared_write_back_targets": null
  },
  "queue_state_unchanged": true,
  "bytes": "5FBC65275FB556245C914DC6D0C96EBD9618E6E628E239372E6FACE65DEBD945"
}
```

## Criterion 7 — G799 reproduction

Actual focused Release test output (`G806_AC7_G799PublishedFixtureUsesAwaitingDispatchAndCorrectElapsed`):

### Criterion 7

```json
{
  "kind": "published-intake-awaiting-dispatch",
  "execution_unit": "G799",
  "issue": { "number": 1744, "url": "https://github.com/J-Tech-Japan/intent-system/issues/1744" },
  "age_minutes": 933,
  "is_informational": false,
  "recommended_action": "orchestrator must dispatch G799; run `intent-cli queue transition G799 active --write --format json`",
  "intake_task_id": "G799-intake-and-repair-priority-v1",
  "intake_delivering_role": "design",
  "intake_recipient_role": "orchestrator",
  "intake_delivery_state": "delivered",
  "intake_delivered_at": "2026-09-04T10:29:56+00:00",
  "intake_minutes_elapsed": 933
}
```

## Criterion 8 — parent absence proof

All new G806 fixtures are in `tests/IntentSystem.Cli.Tests/AutomationStalledWorkG806Tests.cs`. The exact parent probe was:

### Criterion 8

```text
$ git show origin/main:tests/IntentSystem.Cli.Tests/AutomationStalledWorkG806Tests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/AutomationStalledWorkG806Tests.cs' exists on disk, but not in 'origin/main'
RC:128
```

## Criterion 9 — validation

Focused Release:

### Criterion 9

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-restore --filter 'FullyQualifiedName~AutomationStalledWorkG806Tests|FullyQualifiedName~AutomationStalledWorkCommandTests|FullyQualifiedName~NotifySupervisionG788Tests|FullyQualifiedName~NotifyRoutingG796Tests'
Total: 200; Passed: 200; Failed: 0; Skipped: 0; RC:0
```

Full Release (TRX-authoritative; clean rerun after the unrelated timing-flaky isolated test):

```text
Total: 5780; Executed: 5779; Passed: 5779; Failed: 0; Skipped: 1; RC:0
```

`git diff --check` passed. The implementation is limited to the stalled-work classifier, the shared G788 token extraction entry point, the capability mapping, and the named G806 tests; no queue-state write was added to `stalled-work`.
