### PR TITLE
G809: preserve explicit notify delegate assignees

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -183,6 +183,7 @@ internal static class GuideDesignThreadCommand
                 ReviewSeatSelection = reviewSeatSelection,
             },
             ResearchDelegation = ResearchDelegationContract.CreateGuidance(),
+            NotifyDelegateAssignment = NotifyDelegateAssignmentGuidance.Create(domainArg, teamArg),
             Monitoring = new DesignThreadMonitoring
             {
                 Separation = "Supervision runs outside the design conversation and is consulted at most once per design wake.",
@@ -348,6 +349,14 @@ internal static class GuideDesignThreadCommand
         writer.WriteLine($"- size rule: {result.ResearchDelegation.NoSizeRule}");
         foreach (var example in result.ResearchDelegation.Examples) writer.WriteLine($"  - example: {example}");
         writer.WriteLine();
+        writer.WriteLine("## 6b. Explicit notify delegate assignment (G809)");
+        writer.WriteLine($"- precedence: {result.NotifyDelegateAssignment.Precedence}");
+        writer.WriteLine($"- validation: {result.NotifyDelegateAssignment.Validation}");
+        writer.WriteLine($"- dry-run: {result.NotifyDelegateAssignment.DryRun}");
+        writer.WriteLine($"- authority: {result.NotifyDelegateAssignment.Authority}");
+        writer.WriteLine($"- historical records: {result.NotifyDelegateAssignment.HistoricalRecords}");
+        foreach (var example in result.NotifyDelegateAssignment.Examples) writer.WriteLine($"  - example: {example}");
+        writer.WriteLine();
         writer.WriteLine("## 7. Outcome-shaped reporting");
         writer.WriteLine($"- {result.Reporting.Rule}");
         writer.WriteLine($"- {result.Reporting.HumanActionRule}");
@@ -454,6 +463,9 @@ internal sealed record DesignThreadGuideResult
     public required DesignThreadTeamAndDutySplit TeamAndDutySplit { get; init; }
     [JsonPropertyName("research_delegation")]
     public required ResearchDelegationGuidance ResearchDelegation { get; init; }
+    [JsonPropertyName("notify_delegate_assignment")]
+    [JsonIgnore]
+    public NotifyDelegateAssignmentGuidance NotifyDelegateAssignment { get; init; } = null!;
     public required DesignThreadMonitoring Monitoring { get; init; }
     public required DesignThreadReporting Reporting { get; init; }
     public required IReadOnlyList<string> NegativeInvariants { get; init; }

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -876,6 +876,7 @@ internal static class GuideOrchestratorThreadCommand
         {
             HostStateDiscovery = hostStateDiscovery,
             SeatPreflight = seatPreflightGuidance,
+            NotifyDelegateAssignment = NotifyDelegateAssignmentGuidance.Create(domain, values["<team>"]),
             SessionLayerSwitchChecklist = SessionLayerSwitchChecklist.Create(),
             SetupIntake = BuildSetupIntake(values, herdrOnly),
             // G696/G645: the orchestrator surface names the review seat's
@@ -1826,7 +1827,8 @@ internal static class GuideOrchestratorThreadCommand
                     "Prerequisites travel with the delegation, not with the receiver's privileges. Before delegating, "
                     + "the orchestrator identifies every workspace prerequisite the task needs, prepares it under the "
                     + "orchestrator's authority, and verifies it. A bounded receiver is never assumed able to create "
-                    + "worktrees, checkout state, or directories outside its recorded write envelope.",
+                    + "worktrees, checkout state, or directories outside its recorded write envelope. "
+                    + NotifyDelegateAssignmentGuidance.HelpText,
                 RequiredSequence = new[]
                 {
                     "Identify the task's required worktrees, checkouts, checkout state, and directories before choosing the receiver.",
@@ -4495,6 +4497,19 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine("- authority is recorded only by the explicit role+envelope declaration; resident, kind, external placement, and co-location do not authorize host-state work.");
         writer.WriteLine();
 
+        writer.WriteLine("## Explicit notify delegate assignment (G809)");
+        writer.WriteLine();
+        writer.WriteLine($"- **precedence:** {guide.NotifyDelegateAssignment.Precedence}");
+        writer.WriteLine($"- **validation:** {guide.NotifyDelegateAssignment.Validation}");
+        writer.WriteLine($"- **dry-run:** {guide.NotifyDelegateAssignment.DryRun}");
+        writer.WriteLine($"- **authority:** {guide.NotifyDelegateAssignment.Authority}");
+        writer.WriteLine($"- **historical records:** {guide.NotifyDelegateAssignment.HistoricalRecords}");
+        foreach (var example in guide.NotifyDelegateAssignment.Examples)
+        {
+            writer.WriteLine($"- example: {example}");
+        }
+        writer.WriteLine();
+
         WriteCloseoutRunsContract(writer, guide.CloseoutRunsContract);
 
         // G701: the registry and dialog rule are mode-independent guide
@@ -5518,6 +5533,10 @@ internal sealed record OrchestratorThreadGuide
     /// </summary>
     [JsonPropertyName("host_state_discovery")]
     public required OrchestratorHostStateDiscovery HostStateDiscovery { get; init; }
+
+    [JsonPropertyName("notify_delegate_assignment")]
+    [JsonIgnore]
+    public NotifyDelegateAssignmentGuidance NotifyDelegateAssignment { get; init; } = null!;
 
     [JsonPropertyName("seat_preflight")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -32,14 +32,15 @@ internal static class NotifyCommand
 
     private const string MissingRecipientWorkRootPlaceholder = "<role-work-root>";
 
-    private const string DelegateUsage =
+    private static readonly string DelegateUsage =
         "Usage: intent-cli notify delegate --domain <d> [--team <t>] --from <role> --to <role> --report-to <role> "
         + "--task-id <id> --objective <text> [--input <value>]... --expected-artifact <value> "
         + "[--expected-artifact <value>]... --result-nonce <nonce> [--routing-root <host-root>] "
         + "[--event-kind completion|transition|acknowledgement|escalation|question|blocked] "
         + "[--ruling-payload <text> --ruling-origin <role> [--ruling-digest <sha256>] "
         + "[--ruling-envelope-field <key=value>]... --downstream-delegation-reference <id>] "
-        + "[--task-kind research --question <text>] [--dry-run|--write] [--format markdown|json]";
+        + "[--task-kind research --question <text>] [--dry-run|--write] [--format markdown|json]\n"
+        + NotifyDelegateAssignmentGuidance.HelpText;
 
     private const string ReportUsage =
         "Usage: intent-cli notify report --domain <d> --team <t> --from <role> --to <role> --task-id <id> "
@@ -196,9 +197,25 @@ internal static class NotifyCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        if (args.Contains("--help", StringComparer.Ordinal))
         {
-            writer.WriteLine(Usage(operation));
+            var wantsJson = args.Any(argument => string.Equals(argument, "json", StringComparison.OrdinalIgnoreCase))
+                && args.Any(argument => string.Equals(argument, "--format", StringComparison.Ordinal));
+            if (wantsJson)
+            {
+                writer.WriteLine(JsonSerializer.Serialize(new
+                {
+                    operation,
+                    usage = Usage(operation),
+                    assignment = operation == OperationDelegate
+                        ? NotifyDelegateAssignmentGuidance.HelpText
+                        : null,
+                }, JsonOptions));
+            }
+            else
+            {
+                writer.WriteLine(Usage(operation));
+            }
             return 0;
         }
 
@@ -342,14 +359,22 @@ internal static class NotifyCommand
             var fallbackTarget = string.Equals(operation, OperationEscalate, StringComparison.Ordinal)
                 ? "design"
                 : null;
-            options = options with
-            {
-                ToRole = NotifyEventKindRouting.ResolveTarget(
+            // G809: an explicitly addressed delegate keeps its validated
+            // assignee.  Event-kind routing remains authoritative for report
+            // and escalation, but it must not substitute a Steward/Architect
+            // default for a delegate's explicit --to.  Canonicalize accepted
+            // aliases before the topology preflight so every emitted role
+            // field describes the same logical assignee; leave an unknown
+            // value untouched so preflight refuses it rather than routing it
+            // to a different seat.
+            var routedTarget = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+                ? NormalizeExplicitDelegateTarget(options.ToRole)
+                : NotifyEventKindRouting.ResolveTarget(
                     eventKind,
                     options.ToRole,
                     stewardRecorded,
-                    fallbackTarget),
-            };
+                    fallbackTarget);
+            options = options with { ToRole = routedTarget };
 
             var isStewardJudgement = LogicalRoleNormalizer.TryNormalize(
                     options.FromRole,
@@ -671,6 +696,24 @@ internal static class NotifyCommand
     private static bool IsAdvisoryPreflightFinding(SessionLayerPreflightFinding finding) =>
         string.Equals(finding.Cause, "marker-not-generated", StringComparison.Ordinal)
         || string.Equals(finding.Cause, SessionLayerMigration.ResidueCause, StringComparison.Ordinal);
+
+    private static string? NormalizeExplicitDelegateTarget(string? requestedTarget)
+    {
+        if (!LogicalRoleNormalizer.TryNormalize(requestedTarget, out var canonical, out _)
+            || canonical is null)
+        {
+            return requestedTarget;
+        }
+
+        // G795 accepts historical spellings at the boundary. Preserve an
+        // accepted alias in serialized notification envelopes so legacy
+        // consumers keep their established fields; canonical inputs remain
+        // canonical. The normalized value is still what makes the explicit
+        // assignee/topology comparison, never event-kind inference.
+        return string.Equals(requestedTarget, canonical, StringComparison.Ordinal)
+            ? canonical
+            : requestedTarget;
+    }
 
     private static int ExecuteCollect(
         TextWriter writer,

--- a/src/IntentSystem.Cli/Commands/NotifyDelegateAssignmentGuidance.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyDelegateAssignmentGuidance.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G809: the notify delegate assignment contract is shared by the design and
+/// orchestrator guides so neither surface can teach the old event-kind
+/// destination substitution.
+/// </summary>
+internal sealed record NotifyDelegateAssignmentGuidance
+{
+    public const string HelpText =
+        "G809 assignment contract: notify delegate preserves the explicit --to assignee after canonical role normalization and topology validation; event-kind inference never substitutes a destination. --report-to remains the reporting contract. Use --routing-root <host-root> and run the same command with --dry-run --format json to verify the recipient without a receiver call or durable write before --write. Report/escalate routing and Steward authority guards remain unchanged; historical misroutes are not replayed.";
+
+    [JsonPropertyName("precedence")]
+    public required string Precedence { get; init; }
+
+    [JsonPropertyName("validation")]
+    public required string Validation { get; init; }
+
+    [JsonPropertyName("dry_run")]
+    public required string DryRun { get; init; }
+
+    [JsonPropertyName("authority")]
+    public required string Authority { get; init; }
+
+    [JsonPropertyName("historical_records")]
+    public required string HistoricalRecords { get; init; }
+
+    [JsonPropertyName("examples")]
+    public required IReadOnlyList<string> Examples { get; init; }
+
+    public static NotifyDelegateAssignmentGuidance Create(string domain, string team) => new()
+    {
+        Precedence = "For `notify delegate`, the explicit `--to` assignee wins after LogicalRoleNormalizer canonicalization. Event-kind inference remains task context and an authority-check input; it never substitutes Architect, Steward, or another default destination. `--report-to` remains the caller-declared reporting contract.",
+        Validation = $"Resolve the canonical assignee against the recorded team topology before delivery. Use the explicit `--routing-root <host-root>` and `--domain {domain} --team {team}` so the same validated role appears in the result `to_role`, TASK role, pending recipient, and generated report command.",
+        DryRun = "Run the identical command with `--dry-run --format json` to verify the recipient before sending: it performs topology/role resolution but invokes no receiver and changes no durable bytes. The subsequent `--write` sends exactly once to that recorded assignee.",
+        Authority = "The existing Steward boundary remains binding: explicit destination does not grant judgement authority. Report/escalate retain their G796 event-kind routing, ruling and downstream-evidence guards, and no authority is manufactured from `--to`.",
+        HistoricalRecords = "This correction is forward-only. It does not replay, retarget, resend, rewrite, settle, or delete historical misrouted dispatch/delivery records.",
+        Examples =
+        [
+            $"`intent-cli notify delegate --domain {domain} --team {team} --from architect --to orchestrator --report-to architect --task-id <task-id> --objective <objective> --expected-artifact <artifact> --result-nonce <nonce> --routing-root <host-root> --dry-run --format json`",
+            $"`intent-cli notify delegate --domain {domain} --team {team} --from orchestrator --to builder --report-to orchestrator --task-id <task-id> --objective <objective> --expected-artifact <artifact> --result-nonce <nonce> --routing-root <host-root> --write --format json`",
+        ],
+    };
+}

--- a/src/IntentSystem.Cli/Commands/ResearchDelegationContract.cs
+++ b/src/IntentSystem.Cli/Commands/ResearchDelegationContract.cs
@@ -204,9 +204,12 @@ internal static class ResearchDelegationContract
         TaskKind = TaskKind,
         SenderRoles = [LogicalRoleNormalizer.Architect, LogicalRoleNormalizer.Reviewer],
         RecipientRoles = [LogicalRoleNormalizer.Orchestrator, LogicalRoleNormalizer.Steward],
-        WhatGoesDown = "The research question, the expected artifact, and the requested context go down as a task-kind research delegation.",
+        WhatGoesDown = "The research question, the expected artifact, and the requested context go down as a task-kind research delegation. "
+            + "For notify delegate, the explicit --to assignee wins after canonical role normalization; event-kind inference never substitutes a destination. "
+            + "Use --dry-run --format json to verify the recipient without a receiver call or durable write before --write.",
         WhoReceives = "An Architect or Reviewer may send it to the Orchestrator or Steward; all four sender/recipient pairs are routable.",
-        WhatStays = "The judgement seat keeps the ruling responsibility; the recipient returns findings, each paired with its source.",
+        WhatStays = "The judgement seat keeps the ruling responsibility; the recipient returns findings, each paired with its source. "
+            + "Report/escalate routing and Steward authority guards remain unchanged, and historical misroutes are not replayed.",
         SourcedFindingRule = "Every finding names a source such as a file and symbol, a command and output, or a URL.",
         NoRulingBoundary = "A research report carrying the ruling payload is refused and names the Architect or Reviewer that must rule.",
         DirectResearchRule = "Direct Architect and Reviewer research remains an ordinary, successful path; it is never refused or turned into a failure warning.",

--- a/src/IntentSystem.Cli/Commands/SessionLayerSections.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerSections.cs
@@ -136,6 +136,7 @@ internal static class SessionLayerSections
         new(SessionLayerSwitchChecklist.Heading, SessionLayerSwitchChecklist.JsonProperty, Applicability.ModeIndependent),
         new("## Host-state topology discovery (G736)", null, Applicability.ModeIndependent),
         new("(json) host-state topology discovery", "host_state_discovery", Applicability.ModeIndependent),
+        new("## Explicit notify delegate assignment (G809)", null, Applicability.ModeIndependent),
         new("## Guide reachability (G645/G696)", "guide_reachability", Applicability.ModeIndependent),
         new("(json) seat preflight (G808)", "seat_preflight", Applicability.ModeIndependent),
         new("## Topology workspace move reachability (G697)", "topology_workspace_move", Applicability.ModeIndependent),

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadCommandTests.cs
@@ -92,7 +92,7 @@ public sealed class GuideDesignThreadCommandTests
                     writer));
 
             var hash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(writer.ToString())));
-            Assert.Equal("f4684097ad587b5f849aa869a0c24d65be82d67d1731491231c7ca2cce0928ca", hash);
+            Assert.Equal("9cb6691f1a11e22966ea5d218d4c0b7ac13db7a4dc600109d19b1386cc9f0a5a", hash);
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -15,9 +15,9 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     // G655/G673/G683 extend the shared guide; keep the deterministic baseline aligned
     // with the rendered guidance while preserving the hash guard.
     // G684 extends shared orchestrator guidance with envelope-only recipe drift.
-    // G685/G686/G690/G699/G707/G708/G719/G776/G781/G797 intentionally extend the shared guide while preserving
+    // G685/G686/G690/G699/G707/G708/G719/G776/G781/G797/G809 intentionally extend the shared guide while preserving
     // the G594 preflight contract. G696/G697/G700 add structured role-facing routes.
-    private const string G594AgmsgBaselineSha256 = "f4684097ad587b5f849aa869a0c24d65be82d67d1731491231c7ca2cce0928ca";
+    private const string G594AgmsgBaselineSha256 = "9cb6691f1a11e22966ea5d218d4c0b7ac13db7a4dc600109d19b1386cc9f0a5a";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -9,11 +9,11 @@ namespace IntentSystem.Cli.Tests;
 
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
-    // G685/G686/G690/G698/G699/G700/G707/G708/G719/G776/G781/G797 extend the shared orchestrator guidance; keep the snapshot
+    // G685/G686/G690/G698/G699/G700/G707/G708/G719/G776/G781/G797/G809 extend the shared orchestrator guidance; keep the snapshot
     // assertion explicit so a future wake-source or route change remains
     // intentional.
     private const string G594AgmsgGuideSha256 =
-        "CC7D1DAE48D08C67170648488A25C194605320E37221C7780D45DFFFB7EAE973";
+        "581E802D835FB9BD1997ED9F9628E10EB45257F0BF8087C9CD305C828FF0C2E0";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/NotifyRoutingG809Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyRoutingG809Tests.cs
@@ -1,0 +1,509 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using Xunit.Abstractions;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifyRoutingG809Tests : IDisposable
+{
+    private readonly ITestOutputHelper output;
+    private readonly G809Workspace workspace = new();
+
+    public NotifyRoutingG809Tests(ITestOutputHelper output)
+    {
+        this.output = output;
+        NotifyCommand.HerdrExecutableFactory = () => "fake-herdr";
+        NotifyCommand.UtcNowFactory = () => new DateTimeOffset(2026, 9, 5, 12, 0, 0, TimeSpan.Zero);
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.AgmsgScriptsDirectoryFactory = null;
+        NotifyCommand.HerdrExecutableFactory = null;
+        NotifyCommand.UtcNowFactory = null;
+        workspace.Dispose();
+    }
+
+    public static IEnumerable<object?[]> ExplicitAssignments()
+    {
+        var pairs = new[]
+        {
+            (From: "architect", To: "orchestrator"),
+            (From: "orchestrator", To: "builder"),
+            (From: "orchestrator", To: "reviewer"),
+            (From: "architect", To: "reviewer"),
+            (From: "architect", To: "steward"),
+            (From: "reviewer", To: "orchestrator"),
+            (From: "reviewer", To: "steward"),
+        };
+        var kinds = new string?[]
+        {
+            null,
+            NotifyEventKindRouting.Completion,
+            NotifyEventKindRouting.Transition,
+            NotifyEventKindRouting.Acknowledgement,
+            NotifyEventKindRouting.Escalation,
+            NotifyEventKindRouting.Question,
+            NotifyEventKindRouting.Blocked,
+        };
+
+        foreach (var pair in pairs)
+        {
+            foreach (var kind in kinds)
+            {
+                yield return [pair.From, pair.To, kind];
+            }
+        }
+    }
+
+    public static IEnumerable<object?[]> ResearchAssignments()
+    {
+        var pairs = new[]
+        {
+            (From: "architect", To: "orchestrator"),
+            (From: "architect", To: "steward"),
+            (From: "reviewer", To: "orchestrator"),
+            (From: "reviewer", To: "steward"),
+        };
+        var kinds = new string?[]
+        {
+            null,
+            NotifyEventKindRouting.Completion,
+            NotifyEventKindRouting.Transition,
+            NotifyEventKindRouting.Acknowledgement,
+            NotifyEventKindRouting.Escalation,
+            NotifyEventKindRouting.Question,
+            NotifyEventKindRouting.Blocked,
+        };
+
+        foreach (var pair in pairs)
+        {
+            foreach (var kind in kinds)
+            {
+                yield return [pair.From, pair.To, kind];
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ExplicitAssignments))]
+    public void ExplicitDelegateAssigneeWinsAcrossEventKinds_G809(
+        string from,
+        string to,
+        string? eventKind)
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var taskId = $"G809-{from}-{to}-{eventKind ?? "omitted"}";
+        var args = workspace.DelegateArgs(from, to, taskId, eventKind, write: false);
+        var (exitCode, result) = workspace.Run(args);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(to, result.GetProperty("to_role").GetString());
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.Contains("would deliver notification", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"]));
+        output.WriteLine(
+            $"G809 AC1 explicit-assignment from={from}; requested_to={to}; event_kind={eventKind ?? "<omitted>"}; resolved_to={result.GetProperty("to_role").GetString()}; dry_run=true; receiver_calls=0; accepted=true");
+    }
+
+    [Theory]
+    [MemberData(nameof(ResearchAssignments))]
+    public void ResearchDelegateKeepsAllFourExplicitDestinationsAcrossEventKinds_G809(
+        string from,
+        string to,
+        string? eventKind)
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var taskId = $"G809-research-{from}-{to}-{eventKind ?? "omitted"}";
+        var (dryExitCode, dryResult) = workspace.Run(
+            workspace.DelegateArgs(from, to, taskId, eventKind, write: false, research: true));
+
+        Assert.Equal(0, dryExitCode);
+        Assert.Equal(to, dryResult.GetProperty("to_role").GetString());
+        Assert.Equal("research", dryResult.GetProperty("task_kind").GetString());
+        Assert.Contains("task-kind: research", dryResult.GetProperty("payload").GetString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+
+        runner.Calls.Clear();
+        var (writeExitCode, writeResult) = workspace.Run(
+            workspace.DelegateArgs(from, to, taskId, eventKind, write: true, research: true));
+        Assert.Equal(0, writeExitCode);
+        Assert.True(writeResult.GetProperty("delivered").GetBoolean());
+        Assert.Equal(to, writeResult.GetProperty("to_role").GetString());
+        var prompt = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        var wait = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"]));
+        Assert.Equal($"wG809:p-{to}", prompt.Arguments[2]);
+        Assert.Equal($"wG809:p-{to}", wait.Arguments[2]);
+        output.WriteLine(
+            $"G809 AC1/AC2 research-pair={from}->{to}; event_kind={eventKind ?? "<omitted>"}; dry_resolved_to={dryResult.GetProperty("to_role").GetString()}; write_resolved_to={writeResult.GetProperty("to_role").GetString()}; task_kind=research; dry_receiver_calls=0; write_prompt_calls=1; write_wait_calls=1; accepted=true");
+    }
+
+    [Fact]
+    public void WriteDelegateUsesOnlyTheExplicitRecipientAndAgreesAcrossEvidence_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var taskId = "G809-builder-fixture";
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("architect", "builder", taskId, NotifyEventKindRouting.Question, write: true));
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.Equal("builder", result.GetProperty("to_role").GetString());
+        var payload = result.GetProperty("payload").GetString()!;
+        Assert.Contains("role: builder", payload, StringComparison.Ordinal);
+        Assert.Contains("--from builder --to architect", result.GetProperty("report_command").GetString(), StringComparison.Ordinal);
+
+        var pending = NotifyPendingDelegationStore.Find(
+            workspace.RootPath,
+            G809Workspace.Domain,
+            G809Workspace.Team,
+            taskId);
+        Assert.True(pending.Resolved, pending.Error);
+        Assert.NotNull(pending.Record);
+        Assert.Equal("builder", pending.Record!.RecipientRole);
+        Assert.Contains("workspace=wG809;pane=wG809:p-builder", pending.Record.RecipientIdentity, StringComparison.Ordinal);
+
+        var prompt = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        var wait = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"]));
+        Assert.Equal("wG809:p-builder", prompt.Arguments[2]);
+        Assert.Equal("wG809:p-builder", wait.Arguments[2]);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Count > 2 && call.Arguments[2] is "wG809:p-architect" or "wG809:p-orchestrator");
+
+        output.WriteLine(
+            $"G809 AC2/AC9 write_case=architect->builder; result_to={result.GetProperty("to_role").GetString()}; task_role={payload.Split('\n').Single(line => line.StartsWith("role:", StringComparison.Ordinal))}; pending_recipient={pending.Record.RecipientRole}; pending_identity={pending.Record.RecipientIdentity}; report_from=builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true");
+    }
+
+    [Fact]
+    public void AgmsgWriteUsesExplicitRecipientWithoutEventKindSubstitution_G809()
+    {
+        workspace.SetMode(SessionLayerMode.Agmsg);
+        var scripts = Path.Combine(workspace.RootPath, "agmsg-scripts");
+        Directory.CreateDirectory(scripts);
+        File.WriteAllText(Path.Combine(scripts, "team.sh"), "fixture");
+        File.WriteAllText(Path.Combine(scripts, "send.sh"), "fixture");
+        var runner = workspace.NewRunner(agmsg: true);
+        NotifyCommand.AgmsgScriptsDirectoryFactory = () => scripts;
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("architect", "orchestrator", "G809-agmsg", NotifyEventKindRouting.Blocked, write: true));
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.Equal("orchestrator", result.GetProperty("to_role").GetString());
+        var send = Assert.Single(runner.Calls, call => call.Arguments.Any(argument => argument.EndsWith("send.sh", StringComparison.Ordinal)));
+        Assert.Equal("orchestrator", send.Arguments[3]);
+        output.WriteLine("G809 AC2 transport=agmsg; requested_to=orchestrator; send_to=orchestrator; competing_destination_calls=0; delivered=true");
+    }
+
+    [Fact]
+    public void UnknownExplicitAssigneeFailsClosedInsteadOfReceivingEventKindDefault_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("architect", "not-recorded", "G809-unknown", NotifyEventKindRouting.Question, write: false));
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("unknown-role", result.GetProperty("cause").GetString());
+        Assert.Equal("not-recorded", result.GetProperty("to_role").GetString());
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        output.WriteLine($"G809 AC5 unknown_assignee=not-recorded; event_kind=question; exit={exitCode}; cause={result.GetProperty("cause").GetString()}; receiver_calls=0; substitute_default=false");
+    }
+
+    [Fact]
+    public void StewardJudgementStillRequiresRecordedUpstreamEvidence_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var pendingPath = NotifyPendingDelegationStore.ResolvePath(workspace.RootPath, G809Workspace.Domain, G809Workspace.Team);
+        var before = File.Exists(pendingPath) ? File.ReadAllBytes(pendingPath) : [];
+
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("steward", "orchestrator", "G809-steward-no-upstream", NotifyEventKindRouting.Question, write: true));
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("steward-boundary-refused", result.GetProperty("cause").GetString());
+        Assert.Contains("no recorded upstream Architect ruling/delegation", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        var after = File.Exists(pendingPath) ? File.ReadAllBytes(pendingPath) : [];
+        Assert.Equal(before, after);
+        output.WriteLine($"G809 AC3 authority_guard=steward-question; upstream=missing; exit={exitCode}; cause={result.GetProperty("cause").GetString()}; receiver_calls=0; pending_bytes_unchanged={before.SequenceEqual(after)}");
+    }
+
+    [Fact]
+    public void DryRunDoesNotReplayOrRewriteHistoricalPendingBytes_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var historical = new NotifyPendingDelegation
+        {
+            Domain = G809Workspace.Domain,
+            Team = G809Workspace.Team,
+            TaskId = "synthetic-G805",
+            DelegatingRole = "architect",
+            RecipientRole = "architect",
+            RecipientIdentity = "role=architect;workspace=wG809;pane=wG809:p-architect",
+            ExpectedArtifact = "old-result",
+            ExpectedArtifacts = ["old-result"],
+            Objective = "historical misroute",
+            Inputs = ["legacy"],
+            ResultNonce = "synthetic-G805-v1",
+            DispatchedAt = new DateTimeOffset(2026, 9, 5, 11, 0, 0, TimeSpan.Zero),
+            TransportMode = SessionLayerMode.HerdrOnly,
+            Resident = NotifyRecordedRole.HerdrResident,
+            WorkspaceId = "wG809",
+            PaneId = "wG809:p-architect",
+        };
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.RootPath, historical).Written);
+        var path = NotifyPendingDelegationStore.ResolvePath(workspace.RootPath, G809Workspace.Domain, G809Workspace.Team);
+        var before = File.ReadAllBytes(path);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("architect", "orchestrator", "G809-forward-only", null, write: false));
+
+        Assert.Equal(0, exitCode);
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.Equal(before, File.ReadAllBytes(path));
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        output.WriteLine($"G809 AC6 historical_task=synthetic-G805; new_task=G809-forward-only; dry_run=true; exit={exitCode}; historical_bytes_unchanged={before.SequenceEqual(File.ReadAllBytes(path))}; replayed=false");
+    }
+
+    [Fact]
+    public void GuidesAndDelegateHelpDocumentExplicitAssignmentAndNoReplay_G809()
+    {
+        using var designWriter = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(
+            workspace.Context,
+            ["--domain", G809Workspace.Domain, "--team", G809Workspace.Team, "--format", "markdown"],
+            designWriter));
+        Assert.Contains("Explicit notify delegate assignment (G809)", designWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("explicit `--to` assignee wins", designWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("historical misrouted", designWriter.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        using var designJsonWriter = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(
+            workspace.Context,
+            ["--domain", G809Workspace.Domain, "--team", G809Workspace.Team, "--format", "json"],
+            designJsonWriter));
+        using var designJson = JsonDocument.Parse(designJsonWriter.ToString());
+        var designResearch = designJson.RootElement.GetProperty("research_delegation");
+        Assert.Contains("explicit --to assignee wins", designResearch.GetProperty("what_goes_down").GetString(), StringComparison.Ordinal);
+        Assert.Contains("historical misroutes are not replayed", designResearch.GetProperty("what_stays").GetString(), StringComparison.Ordinal);
+
+        using var orchestratorWriter = new StringWriter();
+        Assert.Equal(0, GuideOrchestratorThreadCommand.Execute(
+            workspace.Context,
+            ["--domain", G809Workspace.Domain, "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex", "--team", G809Workspace.Team, "--format", "markdown"],
+            orchestratorWriter));
+        Assert.Contains("Explicit notify delegate assignment (G809)", orchestratorWriter.ToString(), StringComparison.Ordinal);
+
+        using var orchestratorJsonWriter = new StringWriter();
+        Assert.Equal(0, GuideOrchestratorThreadCommand.Execute(
+            workspace.Context,
+            ["--domain", G809Workspace.Domain, "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex", "--team", G809Workspace.Team, "--format", "json"],
+            orchestratorJsonWriter));
+        using var orchestratorJson = JsonDocument.Parse(orchestratorJsonWriter.ToString());
+        var orchestratorPrerequisites = orchestratorJson.RootElement.GetProperty("pre_delegation_prerequisites");
+        Assert.Contains("event-kind inference", orchestratorPrerequisites.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("historical misroutes are not replayed", orchestratorPrerequisites.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+
+        using var helpWriter = new StringWriter();
+        Assert.Equal(0, NotifyCommand.ExecuteDelegate(workspace.Context, ["--help"], helpWriter));
+        var help = helpWriter.ToString();
+        Assert.Contains("G809 assignment contract", help, StringComparison.Ordinal);
+        Assert.Contains("--routing-root <host-root>", help, StringComparison.Ordinal);
+        Assert.Contains("historical misroutes are not replayed", help, StringComparison.Ordinal);
+        using var helpJsonWriter = new StringWriter();
+        Assert.Equal(0, NotifyCommand.ExecuteDelegate(workspace.Context, ["--help", "--format", "json"], helpJsonWriter));
+        using var helpJson = JsonDocument.Parse(helpJsonWriter.ToString());
+        Assert.Contains("G809 assignment contract", helpJson.RootElement.GetProperty("assignment").GetString(), StringComparison.Ordinal);
+        output.WriteLine("G809 AC7 guides=design-thread markdown+json, orchestrator-thread markdown+json, notify delegate help; explicit-assignment-precedence=true; dry-run-recipient-verification=true; Steward-guards-retained=true; report/escalate-routing-unchanged=true; historical-replay=false");
+    }
+
+    private sealed class G809Workspace : IDisposable
+    {
+        public const string Domain = "intent-cli";
+        public const string Team = "intent-cli-dev";
+
+        public G809Workspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("notify-g809-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            WriteTopology();
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig { Domain = Domain, ArtifactRoot = ".intent-cli" },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public void SetMode(string mode)
+        {
+            var topologyPath = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
+            if (string.Equals(mode, SessionLayerMode.Agmsg, StringComparison.Ordinal))
+            {
+                File.Delete(topologyPath);
+            }
+            else
+            {
+                WriteTopology();
+            }
+
+            using var writer = new StringWriter();
+            var exitCode = SessionLayerCommand.ExecuteSet(
+                Context,
+                ["--domain", Domain, "--team", Team, "--mode", mode, "--write", "--format", "json"],
+                writer);
+            Assert.Equal(0, exitCode);
+        }
+
+        public (int ExitCode, JsonElement Result) Run(string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, Context, writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        public string[] DelegateArgs(string from, string to, string taskId, string? eventKind, bool write, bool research = false)
+        {
+            var args = new List<string>
+            {
+                "notify", "delegate", "--domain", Domain, "--team", Team,
+                "--from", from, "--to", to, "--report-to", "architect",
+                "--task-id", taskId, "--objective", "route this explicit assignment",
+                "--input", "issue #1763", "--expected-artifact", "routing evidence",
+                "--result-nonce", taskId + "-nonce", "--routing-root", RootPath,
+                write ? "--write" : "--dry-run", "--format", "json",
+            };
+            if (research)
+            {
+                args.Insert(args.IndexOf(write ? "--write" : "--dry-run"), "--question");
+                args.Insert(args.IndexOf(write ? "--write" : "--dry-run"), "measure the assigned surface");
+                args.Insert(args.IndexOf(write ? "--write" : "--dry-run"), "--task-kind");
+                args.Insert(args.IndexOf(write ? "--write" : "--dry-run"), "research");
+            }
+            if (eventKind is not null)
+            {
+                args.Insert(args.IndexOf(write ? "--write" : "--dry-run"), "--event-kind");
+                args.Insert(args.IndexOf(write ? "--write" : "--dry-run"), eventKind);
+            }
+
+            return args.ToArray();
+        }
+
+        public FakeRunner NewRunner(bool agmsg = false) => new(agmsg ? AgmsgRoster : HerdrRoster);
+
+        private void WriteTopology()
+        {
+            var topology = new
+            {
+                domain = Domain,
+                team = Team,
+                workspace_id = "wG809",
+                roles = new Dictionary<string, object>
+                {
+                    ["architect"] = Pane("wG809:p-architect"),
+                    ["orchestrator"] = Pane("wG809:p-orchestrator"),
+                    ["builder"] = Pane("wG809:p-builder"),
+                    ["reviewer"] = Pane("wG809:p-reviewer"),
+                    ["steward"] = Pane("wG809:p-steward"),
+                },
+            };
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, JsonSerializer.Serialize(topology));
+        }
+
+        private static object Pane(string pane) => new
+        {
+            resident = "herdr",
+            workspace_id = "wG809",
+            pane_id = pane,
+        };
+
+        private static string HerdrRoster => JsonSerializer.Serialize(new
+        {
+            result = new
+            {
+                agents = new[]
+                {
+                    Agent("wG809:p-architect"), Agent("wG809:p-orchestrator"), Agent("wG809:p-builder"),
+                    Agent("wG809:p-reviewer"), Agent("wG809:p-steward"),
+                },
+            },
+        });
+
+        private static string AgmsgRoster =>
+            "Team: intent-cli-dev\n"
+            + "  architect (codex) — /work/architect\n"
+            + "  orchestrator (codex) — /work/orchestrator\n"
+            + "  builder (codex) — /work/builder\n"
+            + "  reviewer (codex) — /work/reviewer\n"
+            + "  steward (codex) — /work/steward\n";
+
+        private static object Agent(string pane) => new
+        {
+            name = pane[("wG809:".Length)..],
+            workspace_id = "wG809",
+            pane_id = pane,
+            agent = "codex",
+            agent_session = new { id = pane },
+            agent_status = "idle",
+            interactive_ready = true,
+        };
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+
+    private sealed class FakeRunner(string roster) : INotifyProcessRunner
+    {
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            if (arguments.SequenceEqual(["agent", "list"]))
+            {
+                return new NotifyProcessResult(0, roster, string.Empty);
+            }
+
+            if (arguments.Count > 0 && arguments[0].EndsWith("team.sh", StringComparison.Ordinal))
+            {
+                return new NotifyProcessResult(0, roster, string.Empty);
+            }
+
+            return new NotifyProcessResult(0, string.Empty, string.Empty);
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/NotifyRoutingG809Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyRoutingG809Tests.cs
@@ -28,6 +28,23 @@ public sealed class NotifyRoutingG809Tests : IDisposable
         workspace.Dispose();
     }
 
+    private static string[] RemoveOption(IReadOnlyList<string> args, string option)
+    {
+        var result = new List<string>(args.Count);
+        for (var index = 0; index < args.Count; index++)
+        {
+            if (string.Equals(args[index], option, StringComparison.Ordinal))
+            {
+                index++;
+                continue;
+            }
+
+            result.Add(args[index]);
+        }
+
+        return result.ToArray();
+    }
+
     public static IEnumerable<object?[]> ExplicitAssignments()
     {
         var pairs = new[]
@@ -133,6 +150,8 @@ public sealed class NotifyRoutingG809Tests : IDisposable
         Assert.Equal(to, dryResult.GetProperty("to_role").GetString());
         Assert.Equal("research", dryResult.GetProperty("task_kind").GetString());
         Assert.Contains("task-kind: research", dryResult.GetProperty("payload").GetString(), StringComparison.Ordinal);
+        Assert.Contains($"role: {to}", dryResult.GetProperty("payload").GetString(), StringComparison.Ordinal);
+        Assert.Contains($"--from {to} --to architect", dryResult.GetProperty("report_command").GetString(), StringComparison.Ordinal);
         Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
 
         runner.Calls.Clear();
@@ -141,12 +160,22 @@ public sealed class NotifyRoutingG809Tests : IDisposable
         Assert.Equal(0, writeExitCode);
         Assert.True(writeResult.GetProperty("delivered").GetBoolean());
         Assert.Equal(to, writeResult.GetProperty("to_role").GetString());
+        Assert.Contains($"role: {to}", writeResult.GetProperty("payload").GetString(), StringComparison.Ordinal);
+        Assert.Contains($"--from {to} --to architect", writeResult.GetProperty("report_command").GetString(), StringComparison.Ordinal);
+        var pending = NotifyPendingDelegationStore.Find(
+            workspace.RootPath,
+            G809Workspace.Domain,
+            G809Workspace.Team,
+            taskId);
+        Assert.True(pending.Resolved, pending.Error);
+        Assert.Equal(to, pending.Record?.RecipientRole);
+        Assert.Contains($"pane=wG809:p-{to}", pending.Record?.RecipientIdentity, StringComparison.Ordinal);
         var prompt = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
         var wait = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"]));
         Assert.Equal($"wG809:p-{to}", prompt.Arguments[2]);
         Assert.Equal($"wG809:p-{to}", wait.Arguments[2]);
         output.WriteLine(
-            $"G809 AC1/AC2 research-pair={from}->{to}; event_kind={eventKind ?? "<omitted>"}; dry_resolved_to={dryResult.GetProperty("to_role").GetString()}; write_resolved_to={writeResult.GetProperty("to_role").GetString()}; task_kind=research; dry_receiver_calls=0; write_prompt_calls=1; write_wait_calls=1; accepted=true");
+            $"G809 AC2 research-pair={from}->{to}; event_kind={eventKind ?? "<omitted>"}; dry_task_role={to}; dry_pending_bytes_unchanged=true; dry_report_from={to}; write_task_role={to}; pending_recipient={pending.Record?.RecipientRole}; pending_identity={pending.Record?.RecipientIdentity}; write_report_from={to}; steward_case={string.Equals(to, "steward", StringComparison.Ordinal)}; dry_receiver_calls=0; write_prompt_calls=1; write_wait_calls=1; accepted=true");
     }
 
     [Fact]
@@ -185,6 +214,171 @@ public sealed class NotifyRoutingG809Tests : IDisposable
 
         output.WriteLine(
             $"G809 AC2/AC9 write_case=architect->builder; result_to={result.GetProperty("to_role").GetString()}; task_role={payload.Split('\n').Single(line => line.StartsWith("role:", StringComparison.Ordinal))}; pending_recipient={pending.Record.RecipientRole}; pending_identity={pending.Record.RecipientIdentity}; report_from=builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true");
+    }
+
+    public static IEnumerable<object?[]> ArchitectBuilderEventKinds()
+    {
+        yield return [null];
+        yield return [NotifyEventKindRouting.Completion];
+        yield return [NotifyEventKindRouting.Transition];
+        yield return [NotifyEventKindRouting.Acknowledgement];
+        yield return [NotifyEventKindRouting.Escalation];
+        yield return [NotifyEventKindRouting.Question];
+        yield return [NotifyEventKindRouting.Blocked];
+    }
+
+    public static IEnumerable<object?[]> WriteExplicitAssignments()
+    {
+        var pairs = new[]
+        {
+            (From: "orchestrator", To: "builder"),
+            (From: "orchestrator", To: "reviewer"),
+            (From: "architect", To: "reviewer"),
+        };
+        foreach (var pair in pairs)
+        {
+            yield return [pair.From, pair.To, null];
+            yield return [pair.From, pair.To, NotifyEventKindRouting.Completion];
+            yield return [pair.From, pair.To, NotifyEventKindRouting.Transition];
+            yield return [pair.From, pair.To, NotifyEventKindRouting.Acknowledgement];
+            yield return [pair.From, pair.To, NotifyEventKindRouting.Escalation];
+            yield return [pair.From, pair.To, NotifyEventKindRouting.Question];
+            yield return [pair.From, pair.To, NotifyEventKindRouting.Blocked];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(WriteExplicitAssignments))]
+    public void WriteExplicitAssignmentsUseExactlyOneRequestedTransport_G809(
+        string from,
+        string to,
+        string? eventKind)
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var taskId = $"G809-AC1-write-{from}-{to}-{eventKind ?? "omitted"}";
+
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs(from, to, taskId, eventKind, write: true));
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.Equal(to, result.GetProperty("to_role").GetString());
+        var pending = NotifyPendingDelegationStore.Find(
+            workspace.RootPath,
+            G809Workspace.Domain,
+            G809Workspace.Team,
+            taskId);
+        Assert.True(pending.Resolved, pending.Error);
+        Assert.Equal(to, pending.Record?.RecipientRole);
+        Assert.Contains($"pane=wG809:p-{to}", pending.Record?.RecipientIdentity, StringComparison.Ordinal);
+        var prompts = runner.Calls.Where(call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"])).ToArray();
+        var waits = runner.Calls.Where(call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"])).ToArray();
+        Assert.Single(prompts);
+        Assert.Single(waits);
+        Assert.Equal($"wG809:p-{to}", prompts[0].Arguments[2]);
+        Assert.Equal($"wG809:p-{to}", waits[0].Arguments[2]);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Count > 2
+            && (call.Arguments[2] is "wG809:p-architect" or "wG809:p-orchestrator" or "wG809:p-builder" or "wG809:p-reviewer" or "wG809:p-steward")
+            && !string.Equals(call.Arguments[2], $"wG809:p-{to}", StringComparison.Ordinal));
+        output.WriteLine(
+            $"G809 AC1 write-transport from={from}; to={to}; event_kind={eventKind ?? "<omitted>"}; result_to={result.GetProperty("to_role").GetString()}; pending_recipient={pending.Record?.RecipientRole}; pending_identity={pending.Record?.RecipientIdentity}; prompt_calls={prompts.Length}; wait_calls={waits.Length}; unintended_recipient_calls=0; delivered=true");
+    }
+
+    [Theory]
+    [MemberData(nameof(ArchitectBuilderEventKinds))]
+    public void ArchitectBuilderFullEventKindMatrixUsesOneExactTransportTarget_G809(string? eventKind)
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var taskId = $"G809-AC9-builder-{eventKind ?? "omitted"}";
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("architect", "builder", taskId, eventKind, write: true));
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.Equal("builder", result.GetProperty("to_role").GetString());
+        Assert.Contains("--from builder --to architect", result.GetProperty("report_command").GetString(), StringComparison.Ordinal);
+        Assert.Contains("role: builder", result.GetProperty("payload").GetString(), StringComparison.Ordinal);
+
+        var pending = NotifyPendingDelegationStore.Find(
+            workspace.RootPath,
+            G809Workspace.Domain,
+            G809Workspace.Team,
+            taskId);
+        Assert.True(pending.Resolved, pending.Error);
+        Assert.Equal("builder", pending.Record?.RecipientRole);
+        Assert.Contains("pane=wG809:p-builder", pending.Record?.RecipientIdentity, StringComparison.Ordinal);
+
+        var prompt = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        var wait = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"]));
+        Assert.Equal("wG809:p-builder", prompt.Arguments[2]);
+        Assert.Equal("wG809:p-builder", wait.Arguments[2]);
+        Assert.DoesNotContain(
+            runner.Calls,
+            call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"])
+                && !string.Equals(call.Arguments[2], "wG809:p-builder", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            runner.Calls,
+            call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"])
+                && !string.Equals(call.Arguments[2], "wG809:p-builder", StringComparison.Ordinal));
+
+        output.WriteLine(
+            $"G809 AC9 architect->builder; event_kind={eventKind ?? "<omitted>"}; result_to=builder; task_role=builder; pending_recipient=builder; pending_identity=wG809:p-builder; report_from=builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true");
+    }
+
+    [Theory]
+    [InlineData("G805-architect-intake-20260905")]
+    [InlineData("G806-architect-intake-20260905")]
+    [InlineData("G807-architect-intake-20260905")]
+    public void SavedArchitectIntakeShapesAgreeInDryRunAndWrite_G809(string savedTaskId)
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var pendingPath = NotifyPendingDelegationStore.ResolvePath(
+            workspace.RootPath,
+            G809Workspace.Domain,
+            G809Workspace.Team);
+        var before = File.Exists(pendingPath) ? File.ReadAllBytes(pendingPath) : [];
+
+        var (dryExitCode, dryResult) = workspace.Run(
+            workspace.DelegateArgs("architect", "orchestrator", savedTaskId, null, write: false));
+        Assert.Equal(0, dryExitCode);
+        Assert.False(dryResult.GetProperty("delivered").GetBoolean());
+        Assert.Equal("orchestrator", dryResult.GetProperty("to_role").GetString());
+        Assert.Contains("role: orchestrator", dryResult.GetProperty("payload").GetString(), StringComparison.Ordinal);
+        Assert.Contains("--from orchestrator --to architect", dryResult.GetProperty("report_command").GetString(), StringComparison.Ordinal);
+        Assert.Equal(before, File.Exists(pendingPath) ? File.ReadAllBytes(pendingPath) : []);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+
+        runner.Calls.Clear();
+        var (writeExitCode, writeResult) = workspace.Run(
+            workspace.DelegateArgs("architect", "orchestrator", savedTaskId, null, write: true));
+        Assert.Equal(0, writeExitCode);
+        Assert.True(writeResult.GetProperty("delivered").GetBoolean());
+        Assert.Equal("orchestrator", writeResult.GetProperty("to_role").GetString());
+        Assert.Contains("role: orchestrator", writeResult.GetProperty("payload").GetString(), StringComparison.Ordinal);
+        Assert.Contains("--from orchestrator --to architect", writeResult.GetProperty("report_command").GetString(), StringComparison.Ordinal);
+
+        var pending = NotifyPendingDelegationStore.Find(
+            workspace.RootPath,
+            G809Workspace.Domain,
+            G809Workspace.Team,
+            savedTaskId);
+        Assert.True(pending.Resolved, pending.Error);
+        Assert.Equal("orchestrator", pending.Record?.RecipientRole);
+        Assert.Contains("pane=wG809:p-orchestrator", pending.Record?.RecipientIdentity, StringComparison.Ordinal);
+        var prompt = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        var wait = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"]));
+        Assert.Equal("wG809:p-orchestrator", prompt.Arguments[2]);
+        Assert.Equal("wG809:p-orchestrator", wait.Arguments[2]);
+
+        output.WriteLine(
+            $"G809 AC2 saved_shape={savedTaskId}; dry_to=orchestrator; dry_role=orchestrator; dry_pending_unchanged=true; dry_receiver_calls=0; write_to=orchestrator; write_role=orchestrator; pending_recipient=orchestrator; pending_identity=wG809:p-orchestrator; report_from=orchestrator; write_prompt_calls=1; write_wait_calls=1; accepted=true");
     }
 
     [Fact]
@@ -228,6 +422,89 @@ public sealed class NotifyRoutingG809Tests : IDisposable
     }
 
     [Fact]
+    public void AlternateAuthoringCwdUsesTheExplicitRoutingRoot_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var authoringRoot = Directory.CreateTempSubdirectory("g809-authoring-");
+        try
+        {
+            var (exitCode, result) = workspace.Run(
+                workspace.CreateContext(authoringRoot.FullName),
+                workspace.DelegateArgs("architect", "orchestrator", "G809-alternate-cwd", null, write: false));
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("orchestrator", result.GetProperty("to_role").GetString());
+            Assert.False(result.GetProperty("delivered").GetBoolean());
+            Assert.Equal(Path.GetFullPath(workspace.RootPath), result.GetProperty("routing_root").GetString());
+            Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+            output.WriteLine("G809 AC5 alternate_authoring_cwd=true; explicit_routing_root=fixture-host; resolved_to=orchestrator; delivered=false; receiver_calls=0; accepted=true");
+        }
+        finally
+        {
+            authoringRoot.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MissingKnownAndMalformedAssignmentsFailClosedWithoutTransport_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var missingTo = RemoveOption(
+            workspace.DelegateArgs("architect", "orchestrator", "G809-missing-to", NotifyEventKindRouting.Question, write: false),
+            "--to");
+        var (missingExitCode, missingText) = workspace.RunText(missingTo);
+        Assert.Equal(1, missingExitCode);
+        Assert.Contains("invalid-notification", missingText, StringComparison.Ordinal);
+        Assert.Empty(runner.Calls);
+
+        workspace.WriteTopologyWithout("builder");
+        var (unrecordedExitCode, unrecordedResult) = workspace.Run(
+            workspace.DelegateArgs("architect", "builder", "G809-known-unrecorded", NotifyEventKindRouting.Question, write: false));
+        Assert.Equal(1, unrecordedExitCode);
+        Assert.Equal("builder", unrecordedResult.GetProperty("to_role").GetString());
+        Assert.False(unrecordedResult.GetProperty("delivered").GetBoolean());
+        Assert.False(string.IsNullOrWhiteSpace(unrecordedResult.GetProperty("cause").GetString()));
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+
+        workspace.WriteMalformedTopology();
+        var (malformedExitCode, malformedResult) = workspace.Run(
+            workspace.DelegateArgs("architect", "orchestrator", "G809-malformed-topology", NotifyEventKindRouting.Question, write: false));
+        Assert.Equal(1, malformedExitCode);
+        Assert.Equal("orchestrator", malformedResult.GetProperty("to_role").GetString());
+        Assert.False(malformedResult.GetProperty("delivered").GetBoolean());
+        Assert.False(string.IsNullOrWhiteSpace(malformedResult.GetProperty("cause").GetString()));
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+
+        output.WriteLine(
+            $"G809 AC5 missing_to=invalid-notification; known_unrecorded_exit={unrecordedExitCode}; known_unrecorded_to={unrecordedResult.GetProperty("to_role").GetString()}; malformed_exit={malformedExitCode}; malformed_to={malformedResult.GetProperty("to_role").GetString()}; receiver_calls=0");
+    }
+
+    [Fact]
+    public void UnavailableReceiverFailsClosedWithoutSubstitution_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner(rosterOverride: "{\"result\":{\"agents\":[]}}");
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("architect", "orchestrator", "G809-unavailable-receiver", NotifyEventKindRouting.Question, write: false));
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("orchestrator", result.GetProperty("to_role").GetString());
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.False(string.IsNullOrWhiteSpace(result.GetProperty("cause").GetString()));
+        Assert.Contains("available", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        output.WriteLine(
+            $"G809 AC5 unavailable_receiver=orchestrator; exit={exitCode}; cause={result.GetProperty("cause").GetString()}; delivered=false; substitute_default=false; receiver_prompt_calls=0");
+    }
+
+    [Fact]
     public void StewardJudgementStillRequiresRecordedUpstreamEvidence_G809()
     {
         workspace.SetMode(SessionLayerMode.HerdrOnly);
@@ -246,6 +523,137 @@ public sealed class NotifyRoutingG809Tests : IDisposable
         var after = File.Exists(pendingPath) ? File.ReadAllBytes(pendingPath) : [];
         Assert.Equal(before, after);
         output.WriteLine($"G809 AC3 authority_guard=steward-question; upstream=missing; exit={exitCode}; cause={result.GetProperty("cause").GetString()}; receiver_calls=0; pending_bytes_unchanged={before.SequenceEqual(after)}");
+    }
+
+    [Theory]
+    [InlineData(NotifyEventKindRouting.Question)]
+    [InlineData(NotifyEventKindRouting.Escalation)]
+    [InlineData(NotifyEventKindRouting.Blocked)]
+    public void StewardJudgementWithoutUpstreamRefusesEveryJudgementKind_G809(string eventKind)
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var pendingPath = NotifyPendingDelegationStore.ResolvePath(workspace.RootPath, G809Workspace.Domain, G809Workspace.Team);
+        var before = File.Exists(pendingPath) ? File.ReadAllBytes(pendingPath) : [];
+
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("steward", "architect", $"G809-no-upstream-{eventKind}", eventKind, write: true));
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("steward-boundary-refused", result.GetProperty("cause").GetString());
+        Assert.Contains("no recorded upstream Architect ruling/delegation", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        var after = File.Exists(pendingPath) ? File.ReadAllBytes(pendingPath) : [];
+        Assert.Equal(before, after);
+        output.WriteLine(
+            $"G809 AC3 refusal event_kind={eventKind}; upstream=missing; exit={exitCode}; cause={result.GetProperty("cause").GetString()}; receiver_calls=0; pending_bytes_unchanged={before.SequenceEqual(after)}");
+    }
+
+    [Theory]
+    [InlineData(NotifyEventKindRouting.Question)]
+    [InlineData(NotifyEventKindRouting.Escalation)]
+    [InlineData(NotifyEventKindRouting.Blocked)]
+    public void StewardJudgementWithRecordedRelayReachesExplicitAssignee_G809(string eventKind)
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        const string payload = "G809 opaque architect ruling";
+        Assert.True(NotifyRuling.TryCreate(payload, "architect", null, out var ruling, out var rulingError), rulingError);
+        Assert.NotNull(ruling);
+
+        var parent = WriteG809UpstreamParent(workspace.RootPath, ruling!, eventKind);
+        var child = parent with
+        {
+            TaskId = $"{parent.TaskId}-downstream",
+            DelegatingRole = "steward",
+            RecipientRole = "architect",
+            RecipientIdentity = "role=architect;workspace=wG809;pane=wG809:p-architect",
+            Ruling = null,
+            DispatchedAt = parent.DispatchedAt.AddSeconds(1),
+        };
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.RootPath, child).Written);
+
+        var delegateArgs = workspace.DelegateArgs("steward", "architect", parent.TaskId, eventKind, write: true);
+        delegateArgs = [..delegateArgs, "--downstream-delegation-reference", child.TaskId];
+        var (exitCode, result) = workspace.Run(delegateArgs);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.Equal("architect", result.GetProperty("to_role").GetString());
+        var relayed = result.GetProperty("ruling");
+        Assert.Equal(payload, relayed.GetProperty("payload").GetString());
+        Assert.Equal(ruling!.Digest, relayed.GetProperty("digest").GetString());
+        Assert.Equal("architect", relayed.GetProperty("origin").GetString());
+        var prompt = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        var wait = Assert.Single(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "wait"]));
+        Assert.Equal("wG809:p-architect", prompt.Arguments[2]);
+        Assert.Equal("wG809:p-architect", wait.Arguments[2]);
+        output.WriteLine(
+            $"G809 AC3 positive_relay event_kind={eventKind}; upstream={parent.TaskId}; downstream={child.TaskId}; target=architect; payload_bytes_preserved=true; digest_preserved=true; origin=architect; prompt_calls=1; wait_calls=1; delivered=true");
+    }
+
+    [Fact]
+    public void StewardJudgementWithMissingDownstreamEvidenceRefusesWithoutTransport_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        Assert.True(NotifyRuling.TryCreate(
+            "G809 upstream ruling for missing downstream evidence",
+            "architect",
+            null,
+            out var ruling,
+            out var rulingError), rulingError);
+        var parent = WriteG809UpstreamParent(workspace.RootPath, ruling!, NotifyEventKindRouting.Question);
+        var pendingPath = NotifyPendingDelegationStore.ResolvePath(
+            workspace.RootPath,
+            G809Workspace.Domain,
+            G809Workspace.Team);
+        var before = File.ReadAllBytes(pendingPath);
+
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("steward", "architect", parent.TaskId, NotifyEventKindRouting.Question, write: true));
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("steward-boundary-refused", result.GetProperty("cause").GetString());
+        Assert.Contains("required", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        Assert.Equal(before, File.ReadAllBytes(pendingPath));
+        output.WriteLine(
+            $"G809 AC3 refusal=missing-downstream-evidence; upstream={parent.TaskId}; reference=<omitted>; exit={exitCode}; cause={result.GetProperty("cause").GetString()}; receiver_calls=0; pending_bytes_unchanged=true");
+    }
+
+    [Fact]
+    public void StewardRelayRejectsPayloadMutationAndForgedOriginButAllowsEnvelopeAddition_G809()
+    {
+        Assert.True(NotifyRuling.TryCreate("G809 opaque ruling bytes", "architect", null, out var source, out var createError), createError);
+        Assert.NotNull(source);
+        Assert.True(NotifyRulingRelay.TryRelay(
+            source!,
+            source!.Payload,
+            new Dictionary<string, string> { ["relay_id"] = "G809-envelope" },
+            out var accepted), accepted.Summary);
+        Assert.Equal(source.Payload, accepted.Ruling?.Payload);
+        Assert.Equal(source.Digest, accepted.Ruling?.Digest);
+        Assert.Equal(source.Origin, accepted.Ruling?.Origin);
+        Assert.False(NotifyRulingRelay.TryRelay(
+            source,
+            source.Payload + "!",
+            new Dictionary<string, string> { ["relay_id"] = "G809-envelope" },
+            out var mutated));
+        Assert.Equal("ruling-digest-mismatch", mutated.Cause);
+        var forged = source with { Origin = "reviewer" };
+        Assert.False(NotifyRulingRelay.TryRelay(
+            source,
+            forged,
+            new Dictionary<string, string> { ["relay_id"] = "G809-envelope" },
+            out var forgedResult));
+        Assert.Equal("ruling-origin-mismatch", forgedResult.Cause);
+        output.WriteLine(
+            $"G809 AC3 relay=accepted; envelope_addition=true; payload_bytes_preserved={source.PayloadBytes.SequenceEqual(accepted.Ruling?.PayloadBytes ?? [])}; digest_preserved={string.Equals(source.Digest, accepted.Ruling?.Digest, StringComparison.Ordinal)}; origin_preserved={string.Equals(source.Origin, accepted.Ruling?.Origin, StringComparison.Ordinal)}; mutation_refused={mutated.Cause}; forged_origin_refused={forgedResult.Cause}");
     }
 
     [Fact]
@@ -285,6 +693,131 @@ public sealed class NotifyRoutingG809Tests : IDisposable
         Assert.Equal(before, File.ReadAllBytes(path));
         Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
         output.WriteLine($"G809 AC6 historical_task=synthetic-G805; new_task=G809-forward-only; dry_run=true; exit={exitCode}; historical_bytes_unchanged={before.SequenceEqual(File.ReadAllBytes(path))}; replayed=false");
+    }
+
+    [Fact]
+    public void HistoricalDispatchDeliveryAndHostStateRemainByteEquivalent_G809()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var historicTasks = new[]
+        {
+            (TaskId: "G805-architect-intake-20260905", Recipient: "orchestrator"),
+            (TaskId: "G806-architect-intake-20260905", Recipient: "orchestrator"),
+            (TaskId: "G807-architect-intake-20260905", Recipient: "orchestrator"),
+        };
+        foreach (var (taskId, recipient) in historicTasks)
+        {
+            var dispatch = new NotifyPendingDelegation
+            {
+                Domain = G809Workspace.Domain,
+                Team = G809Workspace.Team,
+                TaskId = taskId,
+                DelegatingRole = "architect",
+                RecipientRole = recipient,
+                ReportToRole = "architect",
+                RecipientIdentity = $"role={recipient};workspace=wG809;pane=wG809:p-{recipient}",
+                ExpectedArtifact = "historical-result.txt",
+                ExpectedArtifacts = ["historical-result.txt"],
+                Objective = "historical architect intake",
+                Inputs = ["saved G805/G806/G807 shape"],
+                ResultNonce = taskId + "-nonce",
+                DispatchedAt = new DateTimeOffset(2026, 9, 5, 11, 0, 0, TimeSpan.Zero),
+                TransportMode = SessionLayerMode.HerdrOnly,
+                Resident = NotifyRecordedRole.HerdrResident,
+                WorkspaceId = "wG809",
+                PaneId = $"wG809:p-{recipient}",
+            };
+            Assert.True(NotifyPendingDelegationStore.WriteDispatch(workspace.RootPath, dispatch).Written);
+            Assert.True(NotifyPendingDelegationStore.WriteReport(
+                workspace.RootPath,
+                dispatch,
+                "completed",
+                "historical-result.txt",
+                "historical delivery",
+                dispatch.DispatchedAt.AddSeconds(2)).Written);
+            var outbox = new NotifyReportOutboxEntry
+            {
+                Domain = dispatch.Domain,
+                Team = dispatch.Team,
+                TaskId = dispatch.TaskId,
+                EntryId = dispatch.TaskId + "-outbox",
+                ResultNonce = dispatch.ResultNonce,
+                FromRole = "orchestrator",
+                ToRole = "architect",
+                Status = "completed",
+                Artifact = dispatch.ExpectedArtifact,
+                Summary = "historical delivery",
+                CreatedAt = dispatch.DispatchedAt.AddSeconds(1),
+                DeliveryState = "prepared",
+            };
+            Assert.True(NotifyReportOutboxStore.WriteNew(workspace.RootPath, outbox).Written);
+            Assert.True(NotifyReportOutboxStore.MarkDelivered(workspace.RootPath, outbox).Written);
+            Assert.True(NotifyEventWriter.TryResolveWritePath(
+                workspace.RootPath,
+                dispatch.Domain,
+                dispatch.Team,
+                out var eventPath,
+                out var eventError), eventError);
+            NotifyEventWriter.Append(eventPath, new NotifyDesignEvent
+            {
+                Timestamp = dispatch.DispatchedAt.AddSeconds(3),
+                Team = dispatch.Team,
+                Kind = "completed",
+                Unit = dispatch.TaskId,
+                Summary = "historical delivery event",
+                Artifact = dispatch.ExpectedArtifact,
+            });
+        }
+
+        foreach (var relative in new[]
+        {
+            ".intent-cli/queue-state.json",
+            ".intent-cli/runs.jsonl",
+            ".intent-cli/claims/G809.json",
+            ".intent-cli/host-state.json",
+            ".intent-cli/labels.json",
+        })
+        {
+            var path = Path.Combine(workspace.RootPath, relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, $"protected {relative}");
+        }
+
+        var before = SnapshotFiles(workspace.RootPath);
+        var runner = workspace.NewRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var (exitCode, result) = workspace.Run(
+            workspace.DelegateArgs("architect", "orchestrator", "G809-historical-read-only", null, write: false));
+        Assert.Equal(0, exitCode);
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+
+        var status = workspace.RunText(
+            ["notify", "status", "--domain", G809Workspace.Domain, "--team", G809Workspace.Team,
+                "--task-id", historicTasks[0].TaskId, "--routing-root", workspace.RootPath, "--format", "json"]);
+        Assert.NotNull(status.Text);
+        var collect = workspace.RunText(
+            ["notify", "collect", "--domain", G809Workspace.Domain, "--team", G809Workspace.Team,
+                "--role", "orchestrator", "--routing-root", workspace.RootPath, "--dry-run", "--format", "json"]);
+        Assert.NotNull(collect.Text);
+
+        var after = SnapshotFiles(workspace.RootPath);
+        AssertSnapshotsEqual(before, after);
+        foreach (var (taskId, _) in historicTasks)
+        {
+            var pending = NotifyPendingDelegationStore.Find(
+                workspace.RootPath,
+                G809Workspace.Domain,
+                G809Workspace.Team,
+                taskId);
+            Assert.True(pending.Resolved, pending.Error);
+            Assert.True(pending.Record?.ReportArrived);
+            Assert.Equal(NotifyRecordedRole.HerdrResident, pending.Record?.Resident);
+            Assert.DoesNotContain("runtime-delegated", pending.Record?.TransportMode, StringComparison.OrdinalIgnoreCase);
+        }
+
+        output.WriteLine(
+            $"G809 AC6 historic_dispatch_rows=3; historic_delivery_rows=3; dry_run_exit={exitCode}; status_exit={status.ExitCode}; collect_exit={collect.ExitCode}; pending_reports_preserved=true; queue_labels_runs_claims_topology_host_state_unchanged=true; runtime_delegated=false; startup_status_collect_repair=false; bytes_unchanged=true");
     }
 
     [Fact]
@@ -339,6 +872,61 @@ public sealed class NotifyRoutingG809Tests : IDisposable
         output.WriteLine("G809 AC7 guides=design-thread markdown+json, orchestrator-thread markdown+json, notify delegate help; explicit-assignment-precedence=true; dry-run-recipient-verification=true; Steward-guards-retained=true; report/escalate-routing-unchanged=true; historical-replay=false");
     }
 
+    private static Dictionary<string, byte[]> SnapshotFiles(string root)
+    {
+        return Directory.Exists(root)
+            ? Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories)
+                .ToDictionary(path => Path.GetRelativePath(root, path), File.ReadAllBytes, StringComparer.Ordinal)
+            : new Dictionary<string, byte[]>(StringComparer.Ordinal);
+    }
+
+    private static void AssertSnapshotsEqual(
+        IReadOnlyDictionary<string, byte[]> expected,
+        IReadOnlyDictionary<string, byte[]> actual)
+    {
+        Assert.Equal(expected.Keys.Order(StringComparer.Ordinal), actual.Keys.Order(StringComparer.Ordinal));
+        foreach (var key in expected.Keys)
+        {
+            Assert.True(expected[key].SequenceEqual(actual[key]), $"File changed: {key}");
+        }
+    }
+
+    private static NotifyPendingDelegation WriteG809UpstreamParent(
+        string root,
+        NotifyRuling ruling,
+        string eventKind)
+    {
+        var parent = new NotifyPendingDelegation
+        {
+            Domain = G809Workspace.Domain,
+            Team = G809Workspace.Team,
+            TaskId = $"G809-upstream-{eventKind}",
+            TaskKind = null,
+            DelegatingRole = "architect",
+            RecipientRole = "steward",
+            ReportToRole = "architect",
+            RecipientIdentity = "role=steward;workspace=wG809;pane=wG809:p-steward",
+            ExpectedArtifact = "ruling.txt",
+            ExpectedArtifacts = ["ruling.txt"],
+            Objective = "relay an attributed ruling",
+            Inputs = ["G809 relay fixture"],
+            ResultNonce = $"G809-upstream-{eventKind}-nonce",
+            DispatchedAt = new DateTimeOffset(2026, 9, 5, 11, 0, 0, TimeSpan.Zero),
+            TransportMode = SessionLayerMode.HerdrOnly,
+            Resident = NotifyRecordedRole.HerdrResident,
+            WorkspaceId = "wG809",
+            PaneId = "wG809:p-steward",
+            Ruling = ruling,
+        };
+        var write = NotifyPendingDelegationStore.WriteDispatch(root, parent);
+        if (!write.Written)
+        {
+            throw new InvalidOperationException(write.Error);
+        }
+
+        return parent;
+    }
+
     private sealed class G809Workspace : IDisposable
     {
         public const string Domain = "intent-cli";
@@ -382,11 +970,29 @@ public sealed class NotifyRoutingG809Tests : IDisposable
             Assert.Equal(0, exitCode);
         }
 
-        public (int ExitCode, JsonElement Result) Run(string[] args)
+        public CliContext CreateContext(string repoRoot) => new()
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig { Domain = Domain, ArtifactRoot = ".intent-cli" },
+            },
+        };
+
+        public (int ExitCode, JsonElement Result) Run(string[] args) => Run(Context, args);
+
+        public (int ExitCode, JsonElement Result) Run(CliContext context, string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, context, writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        public (int ExitCode, string Text) RunText(string[] args)
         {
             using var writer = new StringWriter();
             var exitCode = CommandRouter.Execute(args, Context, writer);
-            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+            return (exitCode, writer.ToString());
         }
 
         public string[] DelegateArgs(string from, string to, string taskId, string? eventKind, bool write, bool research = false)
@@ -416,23 +1022,37 @@ public sealed class NotifyRoutingG809Tests : IDisposable
             return args.ToArray();
         }
 
-        public FakeRunner NewRunner(bool agmsg = false) => new(agmsg ? AgmsgRoster : HerdrRoster);
+        public FakeRunner NewRunner(bool agmsg = false, string? rosterOverride = null) => new(agmsg ? AgmsgRoster : rosterOverride ?? HerdrRoster);
 
-        private void WriteTopology()
+        public void WriteTopologyWithout(string role) => WriteTopology(role);
+
+        public void WriteMalformedTopology()
         {
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
+            File.WriteAllText(path, "{ not valid topology");
+        }
+
+        private void WriteTopology(string? excludedRole = null)
+        {
+            var roles = new Dictionary<string, object>
+            {
+                ["architect"] = Pane("wG809:p-architect"),
+                ["orchestrator"] = Pane("wG809:p-orchestrator"),
+                ["builder"] = Pane("wG809:p-builder"),
+                ["reviewer"] = Pane("wG809:p-reviewer"),
+                ["steward"] = Pane("wG809:p-steward"),
+            };
+            if (excludedRole is not null)
+            {
+                roles.Remove(excludedRole);
+            }
+
             var topology = new
             {
                 domain = Domain,
                 team = Team,
                 workspace_id = "wG809",
-                roles = new Dictionary<string, object>
-                {
-                    ["architect"] = Pane("wG809:p-architect"),
-                    ["orchestrator"] = Pane("wG809:p-orchestrator"),
-                    ["builder"] = Pane("wG809:p-builder"),
-                    ["reviewer"] = Pane("wG809:p-reviewer"),
-                    ["steward"] = Pane("wG809:p-steward"),
-                },
+                roles,
             };
             var path = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);


### PR DESCRIPTION
# G809: preserve explicit `notify delegate --to` assignment

Closes #1763

Repair head: `5fbbaf3a75b52674ac3ec2278ab1d4dba20e1cf3`

This repair closes the review evidence gaps without changing the accepted production routing scope. The repair commit adds command-path regressions only; the production implementation remains the exact-recipient delegate path from the reviewed head. Report/escalate event-kind routing, Steward authority, role aliases, and historical forward-only behavior remain unchanged.

## AC 1 — write-mode exact transport across multiple pairs

`WriteExplicitAssignmentsUseExactlyOneRequestedTransport_G809` runs the actual write-mode `notify delegate` command for orchestrator->builder, orchestrator->reviewer, and architect->reviewer across omitted event kind plus completion, transition, acknowledgement, escalation, question, and blocked. Every row below is collected xUnit output: the result, pending recipient/identity, one prompt, one wait, and zero unintended recipient calls agree.

```text
G809 AC1 write-transport from=architect; to=reviewer; event_kind=escalation; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=reviewer; event_kind=completion; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=architect; to=reviewer; event_kind=completion; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=builder; event_kind=completion; result_to=builder; pending_recipient=builder; pending_identity=role=builder;workspace=wG809;pane=wG809:p-builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=architect; to=reviewer; event_kind=acknowledgement; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=reviewer; event_kind=escalation; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=builder; event_kind=<omitted>; result_to=builder; pending_recipient=builder; pending_identity=role=builder;workspace=wG809;pane=wG809:p-builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=reviewer; event_kind=<omitted>; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=reviewer; event_kind=blocked; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=builder; event_kind=blocked; result_to=builder; pending_recipient=builder; pending_identity=role=builder;workspace=wG809;pane=wG809:p-builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=reviewer; event_kind=transition; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=builder; event_kind=transition; result_to=builder; pending_recipient=builder; pending_identity=role=builder;workspace=wG809;pane=wG809:p-builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=architect; to=reviewer; event_kind=transition; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=builder; event_kind=question; result_to=builder; pending_recipient=builder; pending_identity=role=builder;workspace=wG809;pane=wG809:p-builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=reviewer; event_kind=acknowledgement; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=architect; to=reviewer; event_kind=<omitted>; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=builder; event_kind=acknowledgement; result_to=builder; pending_recipient=builder; pending_identity=role=builder;workspace=wG809;pane=wG809:p-builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=builder; event_kind=escalation; result_to=builder; pending_recipient=builder; pending_identity=role=builder;workspace=wG809;pane=wG809:p-builder; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=orchestrator; to=reviewer; event_kind=question; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=architect; to=reviewer; event_kind=question; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
G809 AC1 write-transport from=architect; to=reviewer; event_kind=blocked; result_to=reviewer; pending_recipient=reviewer; pending_identity=role=reviewer;workspace=wG809;pane=wG809:p-reviewer; prompt_calls=1; wait_calls=1; unintended_recipient_calls=0; delivered=true
```

## AC 2 — saved G805/G806/G807 shapes and research TASK/pending/report

The saved architect-intake shapes are replayed in both dry-run and write. Dry-run leaves pending bytes unchanged and calls no receiver; write persists the requested recipient, identity, rendered TASK role, and report `--from`, then delivers once. The research matrix covers all four architect/reviewer to orchestrator/steward pairs, including the steward cases, with the same TASK/pending/report assertions.

```text
G809 AC2 saved_shape=G805-architect-intake-20260905; dry_to=orchestrator; dry_role=orchestrator; dry_pending_unchanged=true; dry_receiver_calls=0; write_to=orchestrator; write_role=orchestrator; pending_recipient=orchestrator; pending_identity=wG809:p-orchestrator; report_from=orchestrator; write_prompt_calls=1; write_wait_calls=1; accepted=true
G809 AC2 saved_shape=G806-architect-intake-20260905; dry_to=orchestrator; dry_role=orchestrator; dry_pending_unchanged=true; dry_receiver_calls=0; write_to=orchestrator; write_role=orchestrator; pending_recipient=orchestrator; pending_identity=wG809:p-orchestrator; report_from=orchestrator; write_prompt_calls=1; write_wait_calls=1; accepted=true
G809 AC2 saved_shape=G807-architect-intake-20260905; dry_to=orchestrator; dry_role=orchestrator; dry_pending_unchanged=true; dry_receiver_calls=0; write_to=orchestrator; write_role=orchestrator; pending_recipient=orchestrator; pending_identity=wG809:p-orchestrator; report_from=orchestrator; write_prompt_calls=1; write_wait_calls=1; accepted=true
G809 AC2 research-pair=architect->orchestrator; event_kind=<omitted>; dry_task_role=orchestrator; dry_pending_bytes_unchanged=true; dry_report_from=orchestrator; write_task_role=orchestrator; pending_recipient=orchestrator; pending_identity=role=orchestrator;workspace=wG809;pane=wG809:p-orchestrator; write_report_from=orchestrator; steward_case=False; dry_receiver_calls=0; write_prompt_calls=1; write_wait_calls=1; accepted=true
G809 AC2 research-pair=architect->steward; event_kind=<omitted>; dry_task_role=steward; dry_pending_bytes_unchanged=true; dry_report_from=steward; write_task_role=steward; pending_recipient=steward; pending_identity=role=steward;workspace=wG809;pane=wG809:p-steward; write_report_from=steward; steward_case=True; dry_receiver_calls=0; write_prompt_calls=1; write_wait_calls=1; accepted=true
G809 AC2 research-pair=reviewer->orchestrator; event_kind=<omitted>; dry_task_role=orchestrator; dry_pending_bytes_unchanged=true; dry_report_from=orchestrator; write_task_role=orchestrator; pending_recipient=orchestrator; pending_identity=role=orchestrator;workspace=wG809;pane=wG809:p-orchestrator; write_report_from=orchestrator; steward_case=False; dry_receiver_calls=0; write_prompt_calls=1; write_wait_calls=1; accepted=true
G809 AC2 research-pair=reviewer->steward; event_kind=<omitted>; dry_task_role=steward; dry_pending_bytes_unchanged=true; dry_report_from=steward; write_task_role=steward; pending_recipient=steward; pending_identity=role=steward;workspace=wG809;pane=wG809:p-steward; write_report_from=steward; steward_case=True; dry_receiver_calls=0; write_prompt_calls=1; write_wait_calls=1; accepted=true
```

## AC 3 — Steward authority, positive relay, and refusal coverage

Every judgement kind (question, escalation, blocked) refuses without upstream evidence and without transport. A real recorded Architect ruling plus a real downstream reference reaches the explicit assignee. The shared G796 relay retains payload bytes, digest, and origin, permits additive envelope fields, and refuses a one-byte mutation and forged origin.

```text
G809 AC3 refusal event_kind=question; upstream=missing; exit=1; cause=steward-boundary-refused; receiver_calls=0; pending_bytes_unchanged=True
G809 AC3 refusal event_kind=escalation; upstream=missing; exit=1; cause=steward-boundary-refused; receiver_calls=0; pending_bytes_unchanged=True
G809 AC3 refusal event_kind=blocked; upstream=missing; exit=1; cause=steward-boundary-refused; receiver_calls=0; pending_bytes_unchanged=True
G809 AC3 refusal=missing-downstream-evidence; upstream=G809-upstream-question; reference=<omitted>; exit=1; cause=steward-boundary-refused; receiver_calls=0; pending_bytes_unchanged=true
G809 AC3 positive_relay event_kind=question; upstream=G809-upstream-question; downstream=G809-upstream-question-downstream; target=architect; payload_bytes_preserved=true; digest_preserved=true; origin=architect; prompt_calls=1; wait_calls=1; delivered=true
G809 AC3 relay=accepted; envelope_addition=true; payload_bytes_preserved=True; digest_preserved=True; origin_preserved=True; mutation_refused=ruling-digest-mismatch; forged_origin_refused=ruling-origin-mismatch
```

## AC 4 — report/escalate and compatibility boundaries

Only `delegate` uses the explicit-assignee branch. Report/escalate continue to use their established event-kind routing, no-Steward behavior is unchanged, and canonical/legacy role spellings remain accepted. Full Release includes the compatibility suites.

## AC 5 — negative assignments and alternate authoring cwd

Missing `--to`, an unknown role, a known-but-unrecorded role, malformed topology, unavailable receiver/process corroboration, and a second invocation from an alternate authoring cwd all fail closed or resolve against the explicit routing root without substitution or receiver calls.

```text
G809 AC5 missing_to=invalid-notification; known_unrecorded_exit=1; known_unrecorded_to=builder; malformed_exit=1; malformed_to=orchestrator; receiver_calls=0
G809 AC5 unavailable_receiver=orchestrator; exit=1; cause=process-corroboration-unavailable; delivered=false; substitute_default=false; receiver_prompt_calls=0
G809 AC5 unknown_assignee=not-recorded; event_kind=question; exit=1; cause=unknown-role; receiver_calls=0; substitute_default=false
G809 AC5 alternate_authoring_cwd=true; explicit_routing_root=fixture-host; resolved_to=orchestrator; delivered=false; receiver_calls=0; accepted=true
```

## AC 6 — historical dispatch/delivery and read-only host state

Three G805/G806/G807 dispatch rows and their delivered reports/outbox/events are present. The new dry-run, status, and collect probes do not replay or repair them. Queue, labels, runs, claims, topology, and host-state bytes remain unchanged; architect intake is not marked runtime-delegated.

```text
G809 AC6 historic_dispatch_rows=3; historic_delivery_rows=3; dry_run_exit=0; status_exit=0; collect_exit=1; pending_reports_preserved=true; queue_labels_runs_claims_topology_host_state_unchanged=true; runtime_delegated=false; startup_status_collect_repair=false; bytes_unchanged=true
```

## AC 7 — guide/help contract

Design-thread and orchestrator-thread Markdown/JSON plus `notify delegate --help` retain explicit assignment precedence, dry-run recipient verification, canonical routing-root guidance, unchanged report/escalate routing, Steward guards, and no historical replay. Existing route names and compatibility surfaces remain unchanged.

```text
G809 AC7 guides=design-thread markdown+json, orchestrator-thread markdown+json, notify delegate help; explicit-assignment-precedence=true; dry-run-recipient-verification=true; Steward-guards-retained=true; report/escalate-routing-unchanged=true; historical-replay=false
```

## AC 8 — actual parent output and absence proof

The new regression file is absent from the parent build:

```text
$ git show origin/main:tests/IntentSystem.Cli.Tests/NotifyRoutingG809Tests.cs
fatal: path 'tests/IntentSystem.Cli.Tests/NotifyRoutingG809Tests.cs' exists on disk, but not in 'origin/main'
```

Actual parent/head live command output (captured by the independent review against the real host) was:

```text
## G809 review — REQUEST_UPDATE (exact head cef91f06e96ef014184761db23812d136c89192e)
| case (omitted event kind) | parent 80270af5 | head cef91f06 |
| architect -> builder | architect | builder (w4B, pane w4B:p2) |
| architect -> orchestrator | architect | orchestrator |
| orchestration -> builder (legacy sender) | architect | builder |
| reviewer -> orchestrator | architect | orchestrator |
| architect -> steward | architect | steward (external reader append) |
```

That parent output is the failing command-path demonstration; the new command-path fixtures are the durable corrected oracle.

## Validation

Focused command:

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --no-restore --filter FullyQualifiedName~NotifyRoutingG809Tests --logger 'trx;LogFileName=/tmp/g809-repair-focused4.trx'
Passed 126, Failed 0, Skipped 0, Total 126, RC 0
```

Full Release authoritative TRX `/tmp/g809-repair-full.trx`:

```text
ResultSummary outcome="Completed"
Counters total="5925" executed="5924" passed="5924" failed="0" error="0" timeout="0" aborted="0"
One expected skip; RC 0
```

Exact-head CI run `34054719464` is green for the pushed repair head `5fbbaf3a75b52674ac3ec2278ab1d4dba20e1cf3`:

```text
Build and test (source contract) — pass — https://github.com/J-Tech-Japan/intent-system/actions/runs/34054719464/job/101544407007
npm package dry-run (no publish) — pass — https://github.com/J-Tech-Japan/intent-system/actions/runs/34054719464/job/101545185416
```

No host metadata, workflow labels, merge, replay, resend, or release action was performed. The existing PR remains non-draft and retains `Closes #1763`.
