### PR TITLE
G815: carry explicit team through worker claim ownership verification

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -809,7 +809,8 @@ internal static class GuideOrchestratorThreadCommand
         string Apply(string template) => template
             .Replace("<domain>", domain, StringComparison.Ordinal)
             .Replace("<owner/repo>", repo, StringComparison.Ordinal)
-            .Replace("<agent>", agent, StringComparison.Ordinal);
+            .Replace("<agent>", agent, StringComparison.Ordinal)
+            .Replace("<team>", values["<team>"], StringComparison.Ordinal);
 
         // G589: a CI wait is only survivable when the rendered mode names the
         // thing that will observe the exact head becoming terminal. intent-cli
@@ -1070,7 +1071,7 @@ internal static class GuideOrchestratorThreadCommand
                     "OPTIONAL fallback/legacy polling — Codex automation (run every 5 minutes) for the coordinating "
                     + "thread, domain `<domain>` against `<owner/repo>` using `<agent>`: on each run perform exactly "
                     + "ONE orchestrator wake — check design-side progress and agmsg replies, ask intent-cli for state "
-                    + "(`intent status`, `worker next-action --github-only`, `automation host-review-preflight`), "
+                    + "(`intent status`, `worker next-action --team <team> --github-only`, `automation host-review-preflight`), "
                     + "verify the GitHub facts (CI/approval/merge/closeout), then send this wake's messages under the "
                     + "G524 cap — AT MOST ONE DELEGATION PER RECEIVER (implementation, review), NOT at-most-one-message "
                     + "overall, so a publish plus its same-wake delegation, one repair per stalled receiver, and one "
@@ -1093,7 +1094,7 @@ internal static class GuideOrchestratorThreadCommand
                     "A wake is triggered either by an incoming agmsg reply from implementation/review (the message-driven steady state) or by the optional fallback/legacy timer firing — either trigger runs exactly one orchestrator pass below.",
                     Apply("Check design-side progress: newly published packets/issues and intent status changes via `intent-cli intent status --domain <domain> --format json`."),
                     "Read pending agmsg replies from the implementation/review receivers (signals only — re-verify against intent-cli / GitHub).",
-                    Apply("Ask intent-cli for worker state: `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
+                    Apply("Ask intent-cli for worker state: `intent-cli worker next-action --repo <owner/repo> --team <team> --github-only --format json`. On a claims-enabled host, the invoking team is required; never infer it."),
                     Apply("Check host review readiness: `intent-cli automation host-review-preflight --repo <owner/repo> --format json`."),
                     "Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.",
                     "Classify each open PR's CI: pending = wait using the named mode-specific CI re-check producer (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate. Pending CI is normal progress, not a reason to message the operator.",
@@ -1521,7 +1522,7 @@ internal static class GuideOrchestratorThreadCommand
                 Checks = new[]
                 {
                     "Check the design/HITL inbox for unread human-facing escalations or unanswered questions (`inbox.sh` on the design role).",
-                    Apply("Check orchestrator staleness: read-only intent-cli / GitHub facts (`worker next-action --repo <owner/repo> --github-only --format json`, open PR/CI/label state) compared against the last known orchestrator activity."),
+                    Apply("Check orchestrator staleness: read-only intent-cli / GitHub facts (`worker next-action --repo <owner/repo> --team <team> --github-only --format json`, open PR/CI/label state) compared against the last known orchestrator activity."),
                     Apply("Run `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json` — the RECOMMENDED primary check; it wraps `automation stalled-work` (G523) and returns a ready-to-send `message_body` naming every stale item and its canonical next command."),
                 },
                 Action =
@@ -2126,7 +2127,7 @@ internal static class GuideOrchestratorThreadCommand
                         + "perform semantic review, or mutate GitHub/intent-cli workflow state yourself. agmsg is a "
                         + "signal layer only — intent-cli and GitHub are authoritative. Per wake: read pending agmsg "
                         + "replies, ask intent-cli for the real state (`intent-cli intent status --domain <domain> "
-                        + "--format json`, `intent-cli worker next-action --repo <owner/repo> --github-only --format "
+                        + "--format json`, `intent-cli worker next-action --repo <owner/repo> --team <team> --github-only --format "
                         + "json`, `intent-cli automation host-review-preflight --repo <owner/repo> --format json`), "
                         + "verify the GitHub facts that an agmsg reply claims (merged PR, CI, labels). Treat pending/"
                         + "running CI as an active wait state — re-check it on a later wake rather than asking the "
@@ -2276,7 +2277,7 @@ internal static class GuideOrchestratorThreadCommand
                 "Confirm you are the ONLY orchestrator for this domain/repo; if a second is detected, STOP and escalate (fail closed).",
                 Apply("Confirm domain scope: in single-domain mode, treat other-domain items visible in the host repo as OUT OF SCOPE (escalate, never delegate); in multi-domain mode, attach full routing metadata (domain, execution unit, target repo, implementation + review cwd/worktree, base branch policy, destination thread) before each delegation. Visibility is not authorization, and an execution-unit prefix mismatch alone is not a wrong-repo signal."),
                 "Read pending agmsg replies from the implementation/review threads (signals only — do not trust them as state).",
-                Apply("Ask intent-cli for the real state: `intent-cli intent status --domain <domain> --format json` and `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
+                Apply("Ask intent-cli for the real state: `intent-cli intent status --domain <domain> --format json` and `intent-cli worker next-action --repo <owner/repo> --team <team> --github-only --format json`. On a claims-enabled host, the invoking team is required; never infer it."),
                 "Verify every GitHub fact an agmsg reply claims (PR merged, CI concluded, labels) before acting on it.",
                 "The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER, not at-most-one-message overall (G524): a publish this wake must be delegated to implementation in this SAME wake — never defer that delegation to an unscheduled next wake — alongside any repair requests (one per stalled receiver) or one operator escalation.",
                 "Send workflow notifications only through `intent-cli notify`; it resolves the recorded transport and validates the recipient before delivery, failing closed on an unknown role (G524/G578).",

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -79,7 +79,7 @@ internal static class GuidePromptMatrixCommand
     private const string TopologySameRepo = "same-repo";
 
     private const string UsageLine =
-        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--topology same-repo] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic|copilot|copilot-cloud|copilot-local] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--implementation-base <branch>] [--allow-base-branch-override] [--format markdown|json]";
+        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--topology same-repo] [--domain <name>] [--team <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic|copilot|copilot-cloud|copilot-local] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--implementation-base <branch>] [--allow-base-branch-override] [--format markdown|json]";
 
     private static readonly string[] ForbiddenSources =
     [
@@ -112,7 +112,7 @@ internal static class GuidePromptMatrixCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var targetRepo, out var agent, out var frequency, out var baseBranchPolicy, out var topology, out var implementationBase, out var allowBaseBranchOverride, out var error))
+        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var team, out var targetRepo, out var agent, out var frequency, out var baseBranchPolicy, out var topology, out var implementationBase, out var allowBaseBranchOverride, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -139,7 +139,7 @@ internal static class GuidePromptMatrixCommand
             return 1;
         }
 
-        var entries = BuildEntries(context, mode, domain, targetRepo, agent, frequency, baseBranchPolicy, topology, branchDecision, policyDefaultBranch);
+        var entries = BuildEntries(context, mode, domain, team, targetRepo, agent, frequency, baseBranchPolicy, topology, branchDecision, policyDefaultBranch);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -209,6 +209,7 @@ internal static class GuidePromptMatrixCommand
         CliContext context,
         string? mode,
         string? domain,
+        string? team,
         string? targetRepo,
         string? agent,
         string? frequency,
@@ -218,6 +219,7 @@ internal static class GuidePromptMatrixCommand
         string policyDefaultBranch)
     {
         var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
+        var teamPlaceholder = string.IsNullOrWhiteSpace(team) ? "<TEAM>" : team;
         var targetRepoPlaceholder = string.IsNullOrWhiteSpace(targetRepo) ? "<TARGET-REPO>" : targetRepo;
         var resolvedPolicy = ResolveEffectivePolicy(context, baseBranchPolicy);
 
@@ -237,7 +239,7 @@ internal static class GuidePromptMatrixCommand
                 ? BuildCopilotChildLoop(resolvedPolicy)
                 : isCopilotLocal
                     ? BuildCopilotLocalChildLoop(resolvedPolicy, isSameRepo)
-                    : BuildChildLoop(domainPlaceholder, agent, frequency, resolvedPolicy, isSameRepo),
+                    : BuildChildLoop(domainPlaceholder, teamPlaceholder, agent, frequency, resolvedPolicy, isSameRepo),
 
             // host-loop: copilot-local CAN run intent-cli in host cwd.
             isCopilotCloud
@@ -251,7 +253,7 @@ internal static class GuidePromptMatrixCommand
                 ? BuildCopilotChildOneshot(resolvedPolicy)
                 : isCopilotLocal
                     ? BuildCopilotLocalChildOneshot(resolvedPolicy, isSameRepo)
-                    : BuildChildOneshot(domainPlaceholder, resolvedPolicy, isSameRepo),
+                    : BuildChildOneshot(domainPlaceholder, teamPlaceholder, resolvedPolicy, isSameRepo),
 
             // host-oneshot: copilot-local CAN run intent-cli host steps.
             isCopilotCloud
@@ -586,7 +588,7 @@ $@"Base branch policy: `{baseBranchPolicy}` (expected base branch: `{expected}`)
 - Base-branch policy enforcement is HOST / operator-owned. Copilot does NOT invoke any `intent-cli` command from the implementation side; the host's intent review loop runs the mismatch check on its own cadence.";
     }
 
-    private static GuidePromptMatrixEntry BuildChildLoop(string domainPlaceholder, string? agent, string? frequency, string baseBranchPolicy, bool isSameRepo = false)
+    private static GuidePromptMatrixEntry BuildChildLoop(string domainPlaceholder, string teamPlaceholder, string? agent, string? frequency, string baseBranchPolicy, bool isSameRepo = false)
     {
         var resolvedAgent = NormalizeAgent(agent);
         var frequencyBlock = RenderFrequencyBlock(agent, frequency);
@@ -615,10 +617,10 @@ Loop body (single wake; the operator drives subsequent wakes if any):
 1. Save the child worktree path: `CHILD_WORKTREE=""$PWD""`. Confirm it is a git worktree root. Stop with `wrong-worktree` if not.
 2. Resolve `<OWNER>/<REPO>` from the child cwd: `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
 3. `git fetch --all --prune` and `git status --short`. If dirty in a dedicated automation worktree, clean local residue (`git reset --hard`, `git clean -fd`, submodule reset). Never `git clean -fdx`. Never clean a personal/shared checkout.
-4. From the child cwd (the child implementation loop does NOT require parent host root access — G333 child-cwd / GitHub-contract-only mode), run `intent-cli worker next-action --repo <OWNER>/<REPO> --github-only --format json`. Pass `--github-only` so the selector is pinned to the label-only data path and the result records the binding (`github_only: true`). Dispatch on `action`:
+4. From the child cwd (the child implementation loop does NOT require parent host root access — G333 child-cwd / GitHub-contract-only mode), run `intent-cli worker next-action --repo <OWNER>/<REPO> --team {teamPlaceholder} --github-only --format json`. Pass `--github-only` so the selector is pinned to the label-only data path and the result records the binding (`github_only: true`). On a claims-enabled host, `{teamPlaceholder}` is required and must be the invoking team; never infer a team. Dispatch on `action`:
    - `none` → stop with `idle`.
-   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr --repo <OWNER>/<REPO> ...` and `worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
-   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix --repo <OWNER>/<REPO> ...` and `worker complete --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
+   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --team {teamPlaceholder} --github-only --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr --repo <OWNER>/<REPO> ...` and `worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
+   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --repo <OWNER>/<REPO> --team {teamPlaceholder} --github-only --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix --repo <OWNER>/<REPO> ...` and `worker complete --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
 
 Host metadata gaps surfaced by `worker complete` (e.g. `linked_pr_synced: false` from child-cwd mode, G330) are HOST-owned blockers, not child instructions to enter the host repo. The child loop records the gap and moves on; parent host metadata reconciliation runs on the host/review-runtime loop via `intent-cli review closeout-plan --pr <n> --repo <OWNER>/<REPO> --write-recovered-linkage` (G329) — never from the child cwd.
 
@@ -795,7 +797,7 @@ Hard rules:
         };
     }
 
-    private static GuidePromptMatrixEntry BuildChildOneshot(string domainPlaceholder, string baseBranchPolicy, bool isSameRepo = false)
+    private static GuidePromptMatrixEntry BuildChildOneshot(string domainPlaceholder, string teamPlaceholder, string baseBranchPolicy, bool isSameRepo = false)
     {
         var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Honor");
         var sameRepoBlock = isSameRepo ? $"\n{RenderSameRepoTopologyBlock()}" : string.Empty;
@@ -816,10 +818,10 @@ Loop body (single wake only — do not repeat):
 1. Save the child worktree path: `CHILD_WORKTREE=""$PWD""`. Confirm it is a git worktree root. Stop with `wrong-worktree` if not.
 2. Resolve `<OWNER>/<REPO>` from the child cwd: `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
 3. `git fetch --all --prune` and `git status --short`. If dirty in a dedicated automation worktree, clean local residue (`git reset --hard`, `git clean -fd`, submodule reset). Never `git clean -fdx`. Never clean a personal/shared checkout.
-4. From the child cwd (the child one-shot does NOT require parent host root access — G333 child-cwd / GitHub-contract-only mode), run `intent-cli worker next-action --repo <OWNER>/<REPO> --github-only --format json`. Pass `--github-only` so the selector is pinned to the label-only data path. Dispatch on `action`:
+4. From the child cwd (the child one-shot does NOT require parent host root access — G333 child-cwd / GitHub-contract-only mode), run `intent-cli worker next-action --repo <OWNER>/<REPO> --team {teamPlaceholder} --github-only --format json`. Pass `--github-only` so the selector is pinned to the label-only data path. On a claims-enabled host, `{teamPlaceholder}` is required and must be the invoking team; never infer a team. Dispatch on `action`:
    - `none` → stop with `idle`.
-   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr --repo <OWNER>/<REPO> ...` and `worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
-   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix --repo <OWNER>/<REPO> ...` and `worker complete --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
+   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --team {teamPlaceholder} --github-only --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr --repo <OWNER>/<REPO> ...` and `worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
+   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --repo <OWNER>/<REPO> --team {teamPlaceholder} --github-only --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix --repo <OWNER>/<REPO> ...` and `worker complete --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
 
 Host metadata gaps surfaced by `worker complete` (e.g. `linked_pr_synced: false` from child-cwd mode, G330) are HOST-owned blockers, not child instructions to enter the host repo.
 
@@ -1556,6 +1558,7 @@ Hard rules:
         out string? mode,
         out string format,
         out string? domain,
+        out string? team,
         out string? targetRepo,
         out string? agent,
         out string? frequency,
@@ -1568,6 +1571,7 @@ Hard rules:
         mode = null;
         format = FormatMarkdown;
         domain = null;
+        team = null;
         targetRepo = null;
         agent = null;
         frequency = null;
@@ -1630,6 +1634,17 @@ Hard rules:
                     }
 
                     domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--team":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--team requires a value.";
+                        return false;
+                    }
+
+                    team = args[index + 1];
                     index++;
                     break;
 
@@ -1755,7 +1770,7 @@ Hard rules:
         writer.WriteLine($"- {ModeHostOneshot}  one-shot host review/next-slice");
         writer.WriteLine();
         writer.WriteLine("Omit --mode to get all four entries.");
-        writer.WriteLine("--domain, --target-repo, --agent, --frequency, and --topology are optional; provide them to render a concrete paste-ready prompt instead of one with placeholders.");
+        writer.WriteLine("--domain, --team, --target-repo, --agent, --frequency, and --topology are optional; provide them to render a concrete paste-ready prompt instead of one with placeholders.");
         writer.WriteLine("--agent values: claude (same-thread `/loop`), codex (current-thread heartbeat), generic, copilot / copilot-cloud (G345 — cloud/assignment-oriented; supported for child-oneshot, returns structured unsupported-loop guidance for child-loop, structured host-oneshot-human-driven guidance for host-oneshot, and structured unsupported-mode-agent-combination for host-loop), copilot-local (G349 — local Copilot coding-agent in a host cwd; can exec intent-cli for host operations; child cwd usage remains host-state-free).");
         writer.WriteLine("--frequency examples: 5m, 20m, 1h. Omit to keep the rendered prompt's ask-the-operator instruction.");
         writer.WriteLine($"--base-branch-policy values: {CliRuntimeContracts.DirectMainBaseBranchPolicy} (default; child PRs target `{CliRuntimeContracts.DirectMainBaseBranch}`), {CliRuntimeContracts.MainAiBaseBranchPolicy} (child PRs target `{CliRuntimeContracts.MainAiIntegrationBaseBranch}`).");

--- a/src/IntentSystem.Cli/Commands/GuideWorkerIssueToPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerIssueToPrCommand.cs
@@ -19,7 +19,7 @@ internal static class GuideWorkerIssueToPrCommand
     private const string FormatMarkdown = "markdown";
 
     private const string UsageLine =
-        "Usage: intent-cli guide worker issue-to-pr [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
+        "Usage: intent-cli guide worker issue-to-pr [--repo <owner/repo>] [--domain <name>] [--team <name>] [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -33,14 +33,14 @@ internal static class GuideWorkerIssueToPrCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var repo, out var domain, out var format, out var error))
+        if (!TryParseArguments(args, out var repo, out var domain, out var team, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
             return 1;
         }
 
-        var result = BuildIssueToPr(repo, domain);
+        var result = BuildIssueToPr(repo, domain, team);
         return EmitResult(writer, format, result);
     }
 
@@ -59,10 +59,11 @@ internal static class GuideWorkerIssueToPrCommand
         return 0;
     }
 
-    private static GuideWorkerIssueToPrResult BuildIssueToPr(string? repo, string? domain)
+    private static GuideWorkerIssueToPrResult BuildIssueToPr(string? repo, string? domain, string? team)
     {
         var repoLabel = string.IsNullOrWhiteSpace(repo) ? "the repo in the current worktree" : $"`{repo}`";
         var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
+        var teamPlaceholder = string.IsNullOrWhiteSpace(team) ? "<TEAM>" : team;
 
         var seatHostBoundary = ChildHostDutyBoundaryGuidance.Build(domainPlaceholder);
         var prompt =
@@ -93,7 +94,7 @@ If any required section is missing or if the real contract lives only in linked 
 G717 claim precedence remains in force: the claim registry is authoritative over lifecycle labels; stale shadow state never overrides it, and an active or unavailable claim remains an ownership stop. Follow the worker surface without adding/removing that label by hand; no raw GitHub label mutation is permitted.
 
 Implementation steps:
-1. From the child cwd, select with `intent-cli worker next-action --repo <OWNER>/<REPO> --github-only --format json` and use its returned issue URL/number. Claim only the target-repository lifecycle label with `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`. These GitHub-only worker calls do not acquire the execution-unit claim and do not read host metadata.
+1. From the child cwd, select with `intent-cli worker next-action --repo <OWNER>/<REPO> --team {teamPlaceholder} --github-only --format json` and use its returned issue URL/number. Claim only the target-repository lifecycle label with `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --team {teamPlaceholder} --github-only --write --format json`. On a claims-enabled host, `{teamPlaceholder}` is required and MUST be the invoking team; never infer or substitute a team. These GitHub-only worker calls do not acquire the execution-unit claim and do not read host metadata.
    Execution-unit claim acquisition is a host duty. Before editing, consume the host-provided JSON evidence: `status=acquired`, `push_succeeded=true`, matching scope/actor/team and pushed `commit`, followed by `intent-cli claim verify ...` with `passed=true` and `status=owned`. If that evidence is missing, send the exact G733 `intent-cli notify report ... --status question ...` host-duty request above. Never run host claim acquire from the seat, widen roots, or treat `intent-issue-in-progress`, a local claim file, or `worker issue-preflight` as ownership. If a canonical child preflight refuses because it cannot reach host `FETCH_HEAD`, record the exact refusal and route the duty; do not retry by entering the host repo.
 2. Fetch origin/main: `git fetch origin main`. Create a new branch `claude/<slug>` from `origin/main`. Never reuse an existing unrelated branch.
 3. Read only the source files needed to implement the issue correctly. Match the repository's existing style and patterns.
@@ -140,6 +141,7 @@ Repeated-stall recovery (G408: when the same issue has stalled without progress 
             Kind = "issue-to-pr",
             Repo = string.IsNullOrWhiteSpace(repo) ? null : repo,
             Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            Team = string.IsNullOrWhiteSpace(team) ? null : team,
             Prompt = prompt,
             FirstCalls = new[]
             {
@@ -210,6 +212,10 @@ Repeated-stall recovery (G408: when the same issue has stalled without progress 
         if (!string.IsNullOrWhiteSpace(result.Domain))
         {
             writer.WriteLine($"- domain: {result.Domain}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.Team))
+        {
+            writer.WriteLine($"- team: {result.Team}");
         }
         writer.WriteLine();
 
@@ -321,11 +327,13 @@ Repeated-stall recovery (G408: when the same issue has stalled without progress 
         string[] args,
         out string? repo,
         out string? domain,
+        out string? team,
         out string format,
         out string error)
     {
         repo = null;
         domain = null;
+        team = null;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -353,6 +361,17 @@ Repeated-stall recovery (G408: when the same issue has stalled without progress 
                     }
 
                     domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--team":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--team requires a value.";
+                        return false;
+                    }
+
+                    team = args[index + 1];
                     index++;
                     break;
 
@@ -392,6 +411,7 @@ Repeated-stall recovery (G408: when the same issue has stalled without progress 
         writer.WriteLine();
         writer.WriteLine("  --repo is optional; omit to derive the repo from the current child worktree.");
         writer.WriteLine("  --domain is optional; omit to emit a <DOMAIN> placeholder in the generated prompt.");
+        writer.WriteLine("  --team is optional; omit to emit a <TEAM> prerequisite for claims-enabled hosts. Never infer a team.");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -412,6 +432,9 @@ internal sealed record GuideWorkerIssueToPrResult
 
     [JsonPropertyName("domain")]
     public string? Domain { get; init; }
+
+    [JsonPropertyName("team")]
+    public string? Team { get; init; }
 
     [JsonPropertyName("prompt")]
     public required string Prompt { get; init; }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskImplementationLoopCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskImplementationLoopCommand.cs
@@ -20,7 +20,7 @@ internal static class GuideWorkflowTaskImplementationLoopCommand
     internal const string Mode = "child-loop";
 
     internal const string UsageLine =
-        "Usage: intent-cli guide workflow task implementation-loop [--target-repo <owner/repo>] [--agent claude|codex|generic] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--domain <name>] [--format markdown|json]";
+        "Usage: intent-cli guide workflow task implementation-loop [--target-repo <owner/repo>] [--agent claude|codex|generic] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--domain <name>] [--team <name>] [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -71,6 +71,7 @@ internal static class GuideWorkflowTaskImplementationLoopCommand
         writer.WriteLine("- --frequency <NNm|NNh>          schedule cadence (e.g. 5m, 20m, 1h); otherwise the prompt asks the operator.");
         writer.WriteLine("- --base-branch-policy direct-main|main-ai  base-branch enforcement; defaults to direct-main.");
         writer.WriteLine("- --domain <name>                hint for prompt placeholders; child loop does not require host-side domain metadata.");
+        writer.WriteLine("- --team <name>                  invoking team for claim-aware worker selector/claim; omitted renders an explicit <TEAM> prerequisite.");
         writer.WriteLine("- --format markdown|json         output format; markdown is the default.");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskLoopForwarder.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskLoopForwarder.cs
@@ -17,7 +17,7 @@ internal static class GuideWorkflowTaskLoopForwarder
     /// Flags both task wrappers accept and forward verbatim to
     /// <see cref="GuidePromptMatrixCommand"/>. Mirror exactly the
     /// `--target-repo` / `--agent` / `--frequency` /
-    /// `--base-branch-policy` / `--domain` / `--format` set that
+    /// `--base-branch-policy` / `--domain` / `--team` / `--format` set that
     /// the underlying prompt-matrix parser knows about. Listed as
     /// an explicit allow-list so an unknown flag is rejected with
     /// the wrapper's own usage line (not the prompt-matrix one).
@@ -29,6 +29,7 @@ internal static class GuideWorkflowTaskLoopForwarder
         "--frequency",
         "--base-branch-policy",
         "--domain",
+        "--team",
         "--format",
         "--help"
     };

--- a/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
@@ -716,7 +716,7 @@ internal static class SessionLayerFragments
             Descriptive("Receivers are NEVER scheduled; when an explicit fallback/legacy timer is used (message-driven wakes are the default), the orchestrator is the only thread ever scheduled.")),
         Fragment(
             S4,
-            Transport("OPTIONAL fallback/legacy polling — Codex automation (run every 5 minutes) for the coordinating thread, domain `__DOMAIN__` against `__OWNER__/__REPO__` using `__AGENT__`: on each run perform exactly ONE orchestrator wake — check design-side progress and agmsg replies, ask intent-cli for state (`intent status`, `worker next-action --github-only`, `automation host-review-preflight`), verify the GitHub facts (CI/approval/merge/closeout), then send this wake's messages under the G524 cap — AT MOST ONE DELEGATION PER RECEIVER (implementation, review), NOT at-most-one-message overall, so a publish plus its same-wake delegation, one repair per stalled receiver, and one operator escalation may all go out together — and exit."),
+            Transport("OPTIONAL fallback/legacy polling — Codex automation (run every 5 minutes) for the coordinating thread, domain `__DOMAIN__` against `__OWNER__/__REPO__` using `__AGENT__`: on each run perform exactly ONE orchestrator wake — check design-side progress and agmsg replies, ask intent-cli for state (`intent status`, `worker next-action --team __G815_TEAM__ --github-only`, `automation host-review-preflight`), verify the GitHub facts (CI/approval/merge/closeout), then send this wake's messages under the G524 cap — AT MOST ONE DELEGATION PER RECEIVER (implementation, review), NOT at-most-one-message overall, so a publish plus its same-wake delegation, one repair per stalled receiver, and one operator escalation may all go out together — and exit."),
             Scaffold(" "),
             Transport("Prefer the message-driven steady state (implementation/review agmsg replies already wake the orchestrator); use this timer only when the operator explicitly wants scheduled fallback/legacy polling."),
             Scaffold(" "),
@@ -733,7 +733,11 @@ internal static class SessionLayerFragments
         Fragment(S4, Transport("- A wake is triggered either by an incoming agmsg reply from implementation/review (the message-driven steady state) or by the optional fallback/legacy timer firing — either trigger runs exactly one orchestrator pass below.")),
         Fragment(S4, Operative("- Check design-side progress: newly published packets/issues and intent status changes via `intent-cli intent status --domain __DOMAIN__ --format json`.")),
         Fragment(S4, Transport("- Read pending agmsg replies from the implementation/review receivers (signals only — re-verify against intent-cli / GitHub).")),
-        Fragment(S4, Operative("- Ask intent-cli for worker state: `intent-cli worker next-action --repo __OWNER__/__REPO__ --github-only --format json`.")),
+        Fragment(
+            S4,
+            Operative("- Ask intent-cli for worker state: `intent-cli worker next-action --repo __OWNER__/__REPO__ --team __G815_TEAM__ --github-only --format json`."),
+            Scaffold(" "),
+            Operative("On a claims-enabled host, the invoking team is required; never infer it.")),
         Fragment(S4, Operative("- Check host review readiness: `intent-cli automation host-review-preflight --repo __OWNER__/__REPO__ --format json`.")),
         Fragment(S4, Operative("- Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.")),
         Fragment(
@@ -1045,7 +1049,9 @@ internal static class SessionLayerFragments
             S11,
             Descriptive("1."),
             Scaffold(" "),
-            Operative("Ask intent-cli for the real state: `intent-cli intent status --domain __DOMAIN__ --format json` and `intent-cli worker next-action --repo __OWNER__/__REPO__ --github-only --format json`.")),
+            Operative("Ask intent-cli for the real state: `intent-cli intent status --domain __DOMAIN__ --format json` and `intent-cli worker next-action --repo __OWNER__/__REPO__ --team __G815_TEAM__ --github-only --format json`."),
+            Scaffold(" "),
+            Operative("On a claims-enabled host, the invoking team is required; never infer it.")),
         Fragment(
             S11,
             Descriptive("1."),
@@ -1781,7 +1787,7 @@ internal static class SessionLayerFragments
             Descriptive("Receivers are NEVER scheduled; when an explicit fallback/legacy timer is used (message-driven wakes are the default), the orchestrator is the only thread ever scheduled.")),
         Fragment(
             "scheduling",
-            Transport("OPTIONAL fallback/legacy polling — Codex automation (run every 5 minutes) for the coordinating thread, domain `__DOMAIN__` against `__OWNER__/__REPO__` using `__AGENT__`: on each run perform exactly ONE orchestrator wake — check design-side progress and agmsg replies, ask intent-cli for state (`intent status`, `worker next-action --github-only`, `automation host-review-preflight`), verify the GitHub facts (CI/approval/merge/closeout), then send this wake's messages under the G524 cap — AT MOST ONE DELEGATION PER RECEIVER (implementation, review), NOT at-most-one-message overall, so a publish plus its same-wake delegation, one repair per stalled receiver, and one operator escalation may all go out together — and exit."),
+            Transport("OPTIONAL fallback/legacy polling — Codex automation (run every 5 minutes) for the coordinating thread, domain `__DOMAIN__` against `__OWNER__/__REPO__` using `__AGENT__`: on each run perform exactly ONE orchestrator wake — check design-side progress and agmsg replies, ask intent-cli for state (`intent status`, `worker next-action --team __G815_TEAM__ --github-only`, `automation host-review-preflight`), verify the GitHub facts (CI/approval/merge/closeout), then send this wake's messages under the G524 cap — AT MOST ONE DELEGATION PER RECEIVER (implementation, review), NOT at-most-one-message overall, so a publish plus its same-wake delegation, one repair per stalled receiver, and one operator escalation may all go out together — and exit."),
             Scaffold(" "),
             Transport("Prefer the message-driven steady state (implementation/review agmsg replies already wake the orchestrator); use this timer only when the operator explicitly wants scheduled fallback/legacy polling."),
             Scaffold(" "),
@@ -1798,7 +1804,11 @@ internal static class SessionLayerFragments
         Fragment("scheduling", Transport("A wake is triggered either by an incoming agmsg reply from implementation/review (the message-driven steady state) or by the optional fallback/legacy timer firing — either trigger runs exactly one orchestrator pass below.")),
         Fragment("scheduling", Operative("Check design-side progress: newly published packets/issues and intent status changes via `intent-cli intent status --domain __DOMAIN__ --format json`.")),
         Fragment("scheduling", Transport("Read pending agmsg replies from the implementation/review receivers (signals only — re-verify against intent-cli / GitHub).")),
-        Fragment("scheduling", Operative("Ask intent-cli for worker state: `intent-cli worker next-action --repo __OWNER__/__REPO__ --github-only --format json`.")),
+        Fragment(
+            "scheduling",
+            Operative("Ask intent-cli for worker state: `intent-cli worker next-action --repo __OWNER__/__REPO__ --team __G815_TEAM__ --github-only --format json`."),
+            Scaffold(" "),
+            Operative("On a claims-enabled host, the invoking team is required; never infer it.")),
         Fragment("scheduling", Operative("Check host review readiness: `intent-cli automation host-review-preflight --repo __OWNER__/__REPO__ --format json`.")),
         Fragment("scheduling", Operative("Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.")),
         Fragment(
@@ -2012,7 +2022,11 @@ internal static class SessionLayerFragments
             Scaffold(" "),
             Descriptive("Visibility is not authorization, and an execution-unit prefix mismatch alone is not a wrong-repo signal.")),
         Fragment("orchestrator_first_wake", Transport("Read pending agmsg replies from the implementation/review threads (signals only — do not trust them as state).")),
-        Fragment("orchestrator_first_wake", Operative("Ask intent-cli for the real state: `intent-cli intent status --domain __DOMAIN__ --format json` and `intent-cli worker next-action --repo __OWNER__/__REPO__ --github-only --format json`.")),
+        Fragment(
+            "orchestrator_first_wake",
+            Operative("Ask intent-cli for the real state: `intent-cli intent status --domain __DOMAIN__ --format json` and `intent-cli worker next-action --repo __OWNER__/__REPO__ --team __G815_TEAM__ --github-only --format json`."),
+            Scaffold(" "),
+            Operative("On a claims-enabled host, the invoking team is required; never infer it.")),
         Fragment("orchestrator_first_wake", Transport("Verify every GitHub fact an agmsg reply claims (PR merged, CI concluded, labels) before acting on it.")),
         Fragment("orchestrator_first_wake", Operative("The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER, not at-most-one-message overall (G524): a publish this wake must be delegated to implementation in this SAME wake — never defer that delegation to an unscheduled next wake — alongside any repair requests (one per stalled receiver) or one operator escalation.")),
         Fragment("orchestrator_first_wake", Operative("Send workflow notifications only through `intent-cli notify`; it resolves the recorded transport and validates the recipient before delivery, failing closed on an unknown role (G524/G578).")),
@@ -2172,6 +2186,7 @@ internal static class SessionLayerFragments
         ("__REVIEWPATH__", "<review-path>"),
         ("__DELIVERY__", "<delivery-mode>"),
         ("__DOMAIN__", "<domain>"),
+        ("__G815_TEAM__", "<team>"),
         ("__OAGENT__", "<orchestrator-agent>"),
         ("__IAGENT__", "<implementer-agent>"),
         ("__RAGENT__", "<reviewer-agent>"),
@@ -2208,6 +2223,12 @@ internal static class SessionLayerFragments
         foreach (var (sentinel, key) in Interpolations)
         {
             values.TryGetValue(key, out var value);
+            if (value is null && string.Equals(sentinel, "__G815_TEAM__", StringComparison.Ordinal))
+            {
+                // Team is optional on the unscoped renderer; keep the literal
+                // placeholder so declarations still match that safe output.
+                value = "<team>";
+            }
             if (string.IsNullOrWhiteSpace(value) && RoleAgentSentinels.Contains(sentinel))
             {
                 value = agent;

--- a/src/IntentSystem.Cli/Commands/WorkerClaimAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimAnalyzer.cs
@@ -179,12 +179,22 @@ internal static class WorkerClaimAnalyzer
 
     private static bool IsActiveOrUnavailableClaim(ClaimOwnershipVerification claim) =>
         claim.StoreConfigured
-        && (claim.Status == ClaimOwnershipVerification.StatusOwned
+        && ((claim.Status == ClaimOwnershipVerification.StatusOwned
+                && !SameInvokingTeamOwnsClaim(claim))
             || claim.Status == ClaimOwnershipVerification.StatusHeldByOtherTeam
             || claim.Status == ClaimOwnershipVerification.StatusTeamRequired
             || claim.Status == ClaimOwnershipVerification.StatusCanonicalUnavailable
             || claim.Status == ClaimOwnershipVerification.StatusMetadataBranchOnly
             || claim.Status == ClaimOwnershipVerification.StatusInvalid);
+
+    // G815: the host execution-unit claim is the authority that permits the
+    // matching child worker to perform its lifecycle transition. A matching
+    // invoking team is therefore an ownership success, while another team,
+    // omitted context, and unavailable evidence remain hard refusals above.
+    private static bool SameInvokingTeamOwnsClaim(ClaimOwnershipVerification claim) =>
+        claim.Status == ClaimOwnershipVerification.StatusOwned
+        && !string.IsNullOrWhiteSpace(claim.InvokingTeam)
+        && string.Equals(claim.InvokingTeam, claim.HolderTeam, StringComparison.Ordinal);
 
     /// <summary>
     /// G211: Pure data record returned by

--- a/src/IntentSystem.Cli/Commands/WorkerClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimCommand.cs
@@ -66,6 +66,7 @@ internal static class WorkerClaimCommand
                 out var repo,
                 out var kind,
                 out var number,
+                out var invokingTeam,
                 out var mode,
                 out var githubOnly,
                 out var format,
@@ -107,7 +108,8 @@ internal static class WorkerClaimCommand
             context,
             repo!,
             kind!,
-            number);
+            number,
+            invokingTeam);
         var decision = WorkerClaimAnalyzer.Analyze(
             kind!,
             currentNames,
@@ -185,7 +187,8 @@ internal static class WorkerClaimCommand
         CliContext context,
         string repo,
         string kind,
-        int number)
+        int number,
+        string? invokingTeam)
     {
         if (!string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal))
         {
@@ -219,7 +222,7 @@ internal static class WorkerClaimCommand
             return ClaimOwnershipVerifier.Verify(
                 context.RepoRoot,
                 $"execution-unit:{match.Value}",
-                invokingTeam: null,
+                invokingTeam,
                 allowUnheld: true);
         }
         catch (Exception exception) when (
@@ -283,6 +286,7 @@ internal static class WorkerClaimCommand
         out string? repo,
         out string? kind,
         out int number,
+        out string? invokingTeam,
         out string mode,
         out bool githubOnly,
         out string format,
@@ -291,6 +295,7 @@ internal static class WorkerClaimCommand
         repo = null;
         kind = null;
         number = 0;
+        invokingTeam = null;
         mode = WorkerClaimCompleteConstants.Modes.DryRun;
         githubOnly = false;
         format = FormatText;
@@ -333,6 +338,16 @@ internal static class WorkerClaimCommand
                     index++;
                     break;
 
+                case "--team":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--team requires a non-empty value.";
+                        return false;
+                    }
+                    invokingTeam = args[index + 1];
+                    index++;
+                    break;
+
                 case "--write":
                     mode = WorkerClaimCompleteConstants.Modes.Write;
                     break;
@@ -369,7 +384,7 @@ internal static class WorkerClaimCommand
 
                 default:
                     error =
-                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --kind <issue|pr> --number <N> [--write] [--dry-run] [--github-only] [--format text|json].";
+                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --kind <issue|pr> --number <N> [--team <team>] [--write] [--dry-run] [--github-only] [--format text|json].";
                     return false;
             }
         }

--- a/tests/IntentSystem.Cli.Tests/G815WorkerClaimTeamTests.cs
+++ b/tests/IntentSystem.Cli.Tests/G815WorkerClaimTeamTests.cs
@@ -1,0 +1,287 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G815: the child worker must carry the explicit invoking team through the
+/// issue claim path. These tests exercise the production command boundary,
+/// the selector/claim pair, and the read-only refusal/no-label guarantees.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class G815WorkerClaimTeamTests : IDisposable
+{
+    public G815WorkerClaimTeamTests()
+    {
+        WorkerClaimCommand.MutatorFactory = null;
+        WorkerClaimCommand.IssueLookupFactory = null;
+        WorkerNextActionCommand.CandidateListerFactory = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerClaimCommand.MutatorFactory = null;
+        WorkerClaimCommand.IssueLookupFactory = null;
+        WorkerNextActionCommand.CandidateListerFactory = null;
+    }
+
+    [Fact]
+    public void MatchingTeamPasses_OmittedAndWrongTeamRefuse_WithoutLabelEffects()
+    {
+        using var fixture = new ClaimFixture();
+        fixture.WriteClaim("G815", "builder", "intent-cli-dev");
+        var mutator = new RecordingMutator("intent-target");
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+        WorkerClaimCommand.IssueLookupFactory = () => new IssueLookup("G815 team forwarding");
+
+        var matching = ExecuteClaim(fixture.Context, "--team", "intent-cli-dev");
+        Assert.True(matching.ExitCode == 0, string.Join(" | ", matching.Result.Errors));
+        Assert.True(matching.Result.Proceed);
+        Assert.False(matching.Result.Applied);
+        Assert.Empty(mutator.Transitions);
+
+        var omitted = ExecuteClaim(fixture.Context);
+        Assert.Equal(2, omitted.ExitCode);
+        Assert.False(omitted.Result.Proceed);
+        Assert.Contains(omitted.Result.Errors, error =>
+            error.Contains("--team is required", StringComparison.Ordinal));
+        Assert.Empty(mutator.Transitions);
+
+        var wrong = ExecuteClaim(fixture.Context, "--team", "other-team");
+        Assert.Equal(2, wrong.ExitCode);
+        Assert.False(wrong.Result.Proceed);
+        Assert.Contains(wrong.Result.Errors, error =>
+            error.Contains("does not hold it", StringComparison.Ordinal));
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void InvalidAuthorityRefusesClosedWithoutMutation()
+    {
+        using var fixture = new ClaimFixture();
+        fixture.WriteRawClaim("G815", "not-json\n");
+        var mutator = new RecordingMutator("intent-target");
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+        WorkerClaimCommand.IssueLookupFactory = () => new IssueLookup("G815 authority unavailable");
+
+        var result = ExecuteClaim(fixture.Context, "--team", "intent-cli-dev");
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.False(result.Result.Proceed);
+        Assert.Contains(result.Result.Errors, error =>
+            error.Contains(WorkerClaimCompleteConstants.ErrorCodes.ClaimRegistryRefused, StringComparison.Ordinal));
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void BlankTeamArgumentIsRejectedBeforeAnyGitHubCall()
+    {
+        using var fixture = new ClaimFixture();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerClaimCommand.Execute(
+            fixture.Context,
+            [
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "815",
+                "--team", "",
+                "--dry-run",
+                "--github-only",
+                "--format", "json",
+            ],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--team requires a non-empty value", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SelectorAndClaimUseTheSameExplicitTeam_AndEligibleIssueBeatsBlockedClaim()
+    {
+        using var fixture = new ClaimFixture();
+        fixture.WriteClaim("G815", "other-builder", "other-team");
+        fixture.WriteClaim("G816", "builder", "intent-cli-dev");
+        var blocked = Candidate(815, "G815 blocked", "2026-09-08T00:00:00Z", "intent-target", "intent-issue-in-progress");
+        var eligible = Candidate(816, "G816 eligible", "2026-09-08T01:00:00Z", "intent-target");
+        WorkerNextActionCommand.CandidateListerFactory = () => new CandidateLister(blocked, eligible);
+
+        using var nextWriter = new StringWriter();
+        var nextExit = WorkerNextActionCommand.Execute(
+            fixture.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--team", "intent-cli-dev", "--github-only", "--format", "json"],
+            nextWriter);
+
+        Assert.Equal(0, nextExit);
+        var next = JsonSerializer.Deserialize<WorkerNextActionResult>(nextWriter.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.IssueToPr, next.Action);
+        Assert.Equal(816, next.Number);
+
+        WorkerClaimCommand.MutatorFactory = () => new RecordingMutator("intent-target");
+        WorkerClaimCommand.IssueLookupFactory = () => new IssueLookup("G816 eligible");
+        var claim = ExecuteClaim(fixture.Context, "--team", "intent-cli-dev", "--number", "816");
+        Assert.Equal(0, claim.ExitCode);
+        Assert.True(claim.Result.Proceed);
+    }
+
+    [Fact]
+    public void GuidesRenderTeamArgumentAndExplicitMissingTeamPrerequisite_InMarkdownAndJson()
+    {
+        using var issueJsonWriter = new StringWriter();
+        Assert.Equal(0, GuideWorkerIssueToPrCommand.Execute(
+            GuideContext(),
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--team", "intent-cli-dev", "--format", "json"],
+            issueJsonWriter));
+        using var issueJson = JsonDocument.Parse(issueJsonWriter.ToString());
+        Assert.Equal("intent-cli-dev", issueJson.RootElement.GetProperty("team").GetString());
+        var issuePrompt = issueJson.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("worker next-action --repo <OWNER>/<REPO> --team intent-cli-dev", issuePrompt, StringComparison.Ordinal);
+        Assert.Contains("worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --team intent-cli-dev", issuePrompt, StringComparison.Ordinal);
+
+        using var missingTeamWriter = new StringWriter();
+        Assert.Equal(0, GuideWorkerIssueToPrCommand.Execute(
+            GuideContext(),
+            ["--format", "markdown"],
+            missingTeamWriter));
+        Assert.Contains("--team <TEAM>", missingTeamWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("never infer or substitute a team", missingTeamWriter.ToString(), StringComparison.Ordinal);
+
+        using var loopWriter = new StringWriter();
+        Assert.Equal(0, GuideWorkflowTaskImplementationLoopCommand.Execute(
+            GuideContext(),
+            ["--team", "intent-cli-dev", "--format", "json"],
+            loopWriter));
+        using var loopJson = JsonDocument.Parse(loopWriter.ToString());
+        Assert.Contains("--team intent-cli-dev", loopJson.RootElement.GetProperty("prompt").GetString()!, StringComparison.Ordinal);
+
+        using var orchestrationWriter = new StringWriter();
+        Assert.Equal(0, GuideOrchestratorThreadCommand.Execute(
+            GuideContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "codex", "--team", "intent-cli-dev", "--format", "markdown"],
+            orchestrationWriter));
+        Assert.Contains("worker next-action", orchestrationWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--team intent-cli-dev", orchestrationWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    private static (int ExitCode, WorkerClaimResult Result) ExecuteClaim(
+        CliContext context,
+        params string[] extra)
+    {
+        var args = new List<string>
+        {
+            "--repo", "J-Tech-Japan/intent-system",
+            "--kind", "issue",
+            "--number", "815",
+            "--dry-run",
+            "--github-only",
+            "--format", "json",
+        };
+        for (var index = 0; index < extra.Length; index++) args.Add(extra[index]);
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(context, args.ToArray(), writer);
+        return (exitCode, JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!);
+    }
+
+    private static CliContext GuideContext() => new()
+    {
+        RepoRoot = Path.GetTempPath(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli", WorktreeRoot = ".intent-cli/worktrees" }
+        }
+    };
+
+    private static GitHubAutomationIssueCandidate Candidate(
+        int number,
+        string title,
+        string createdAt,
+        params string[] labels) => new()
+        {
+            Number = number,
+            Title = title,
+            Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
+            CreatedAt = createdAt,
+            Labels = labels.Select(label => new GitHubAutomationLabel { Name = label }).ToArray(),
+        };
+
+    private sealed class CandidateLister : IGitHubAutomationCandidateLister
+    {
+        private readonly IReadOnlyList<GitHubAutomationIssueCandidate> issues;
+
+        public CandidateLister(params GitHubAutomationIssueCandidate[] issues) => this.issues = issues;
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => Array.Empty<GitHubAutomationPrCandidate>();
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => issues;
+    }
+
+    private sealed class RecordingMutator : IGitHubLabelMutator
+    {
+        private readonly IReadOnlyList<string> labels;
+
+        public RecordingMutator(params string[] labels) => this.labels = labels;
+
+        public List<(IReadOnlyList<string> Add, IReadOnlyList<string> Remove)> Transitions { get; } = new();
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) => labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+        public void ApplyLabelTransitions(string repo, string kind, int number, IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) => Transitions.Add((addLabels.ToArray(), removeLabels.ToArray()));
+        public void ApplyReconcileTransitions(string repo, string kind, int number, IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) => throw new NotSupportedException();
+    }
+
+    private sealed class IssueLookup : IGitHubIssueLookup
+    {
+        private readonly string title;
+
+        public IssueLookup(string title) => this.title = title;
+
+        public GitHubIssueLookupResult Lookup(string repo, int issueNumber) => new()
+        {
+            Number = issueNumber,
+            State = "OPEN",
+            Title = title,
+            Body = "# contract",
+            Labels = new[] { new GitHubIssueLabel { Name = "intent-target" } },
+        };
+    }
+
+    private sealed class ClaimFixture : IDisposable
+    {
+        private readonly string root = Directory.CreateTempSubdirectory("g815-claim-").FullName;
+        public CliContext Context { get; }
+
+        public ClaimFixture()
+        {
+            Context = new CliContext
+            {
+                RepoRoot = root,
+                Config = new CliConfig { Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli", WorktreeRoot = ".intent-cli/worktrees" } }
+            };
+            Directory.CreateDirectory(Path.Combine(root, ".intent-cli", "claims"));
+        }
+
+        public void WriteClaim(string executionUnit, string actor, string team) => WriteRawClaim(
+            executionUnit,
+            JsonSerializer.Serialize(new ClaimRecord(
+                "1",
+                $"execution-unit:{executionUnit}",
+                actor,
+                team,
+                DateTimeOffset.UtcNow,
+                "g815-fixture")));
+
+        public void WriteRawClaim(string executionUnit, string json)
+        {
+            var scope = $"execution-unit:{executionUnit}";
+            var relative = ClaimCommand.ClaimPath(scope).Replace('/', Path.DirectorySeparatorChar);
+            var path = Path.Combine(root, relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, json);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/G815WorkerClaimTeamTests.cs
+++ b/tests/IntentSystem.Cli.Tests/G815WorkerClaimTeamTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
@@ -40,6 +41,10 @@ public sealed class G815WorkerClaimTeamTests : IDisposable
         Assert.True(matching.ExitCode == 0, string.Join(" | ", matching.Result.Errors));
         Assert.True(matching.Result.Proceed);
         Assert.False(matching.Result.Applied);
+        Assert.Equal(
+            new[] { WorkerNextActionConstants.Labels.IntentIssueInProgress },
+            matching.Result.AddLabels);
+        Assert.Empty(matching.Result.RemoveLabels);
         Assert.Empty(mutator.Transitions);
 
         var omitted = ExecuteClaim(fixture.Context);
@@ -55,6 +60,46 @@ public sealed class G815WorkerClaimTeamTests : IDisposable
         Assert.Contains(wrong.Result.Errors, error =>
             error.Contains("does not hold it", StringComparison.Ordinal));
         Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void MatchingTeamWriteAppliesExactlyTheCanonicalTransition_RefusalsRemainNoOp()
+    {
+        using var fixture = new ClaimFixture();
+        fixture.WriteClaim("G815", "builder", "intent-cli-dev");
+        var mutator = new RecordingMutator("intent-target");
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+        WorkerClaimCommand.IssueLookupFactory = () => new IssueLookup("G815 isolated write fixture");
+
+        var matching = ExecuteWriteClaim(fixture.Context, "--team", "intent-cli-dev");
+        Assert.Equal(0, matching.ExitCode);
+        Assert.True(matching.Result.Proceed);
+        Assert.True(matching.Result.Applied);
+        Assert.Equal(
+            new[] { WorkerNextActionConstants.Labels.IntentIssueInProgress },
+            matching.Result.AddLabels);
+        Assert.Empty(matching.Result.RemoveLabels);
+        Assert.Single(mutator.Transitions);
+        Assert.Equal(
+            new[] { WorkerNextActionConstants.Labels.IntentIssueInProgress },
+            mutator.Transitions[0].Add);
+        Assert.Empty(mutator.Transitions[0].Remove);
+
+        var omitted = ExecuteWriteClaim(fixture.Context);
+        Assert.Equal(2, omitted.ExitCode);
+        Assert.False(omitted.Result.Proceed);
+        Assert.False(omitted.Result.Applied);
+        Assert.Contains(omitted.Result.Errors, error =>
+            error.Contains("--team is required", StringComparison.Ordinal));
+
+        var wrong = ExecuteWriteClaim(fixture.Context, "--team", "other-team");
+        Assert.Equal(2, wrong.ExitCode);
+        Assert.False(wrong.Result.Proceed);
+        Assert.False(wrong.Result.Applied);
+        Assert.Contains(wrong.Result.Errors, error =>
+            error.Contains("does not hold it", StringComparison.Ordinal));
+
+        Assert.Single(mutator.Transitions);
     }
 
     [Fact]
@@ -94,6 +139,28 @@ public sealed class G815WorkerClaimTeamTests : IDisposable
         Assert.False(result.Result.Proceed);
         Assert.Contains(result.Result.Errors, error =>
             error.Contains(WorkerClaimCompleteConstants.ErrorCodes.ClaimRegistryRefused, StringComparison.Ordinal));
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void CanonicalUnavailableThroughWorkerClaimRefusesWithoutMutation()
+    {
+        using var fixture = new ClaimFixture();
+        fixture.InitializeBrokenOrigin();
+        var mutator = new RecordingMutator("intent-target");
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+        WorkerClaimCommand.IssueLookupFactory = () => new IssueLookup("G815 unavailable authority");
+
+        var result = ExecuteClaim(fixture.Context, "--team", "intent-cli-dev");
+
+        Assert.Equal(2, result.ExitCode);
+        Assert.False(result.Result.Proceed);
+        Assert.False(result.Result.Applied);
+        Assert.Empty(result.Result.AddLabels);
+        Assert.Empty(result.Result.RemoveLabels);
+        Assert.Contains(result.Result.Errors, error =>
+            error.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.ClaimRegistryRefused, StringComparison.Ordinal)
+            && error.Contains("canonical Git evidence is unavailable", StringComparison.Ordinal));
         Assert.Empty(mutator.Transitions);
     }
 
@@ -190,13 +257,24 @@ public sealed class G815WorkerClaimTeamTests : IDisposable
     private static (int ExitCode, WorkerClaimResult Result) ExecuteClaim(
         CliContext context,
         params string[] extra)
+        => ExecuteClaimWithMode(context, WorkerClaimCompleteConstants.Modes.DryRun, extra);
+
+    private static (int ExitCode, WorkerClaimResult Result) ExecuteWriteClaim(
+        CliContext context,
+        params string[] extra)
+        => ExecuteClaimWithMode(context, WorkerClaimCompleteConstants.Modes.Write, extra);
+
+    private static (int ExitCode, WorkerClaimResult Result) ExecuteClaimWithMode(
+        CliContext context,
+        string mode,
+        params string[] extra)
     {
         var args = new List<string>
         {
             "--repo", "J-Tech-Japan/intent-system",
             "--kind", "issue",
             "--number", "815",
-            "--dry-run",
+            mode == WorkerClaimCompleteConstants.Modes.Write ? "--write" : "--dry-run",
             "--github-only",
             "--format", "json",
         };
@@ -299,6 +377,34 @@ public sealed class G815WorkerClaimTeamTests : IDisposable
             var path = Path.Combine(root, relative);
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, json);
+        }
+
+        public void InitializeBrokenOrigin()
+        {
+            RunGit(root, "init", "--quiet");
+            RunGit(root, "remote", "add", "origin", Path.Combine(root, "missing-origin.git"));
+        }
+
+        private static void RunGit(string workingDirectory, params string[] arguments)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "git",
+                WorkingDirectory = workingDirectory,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            foreach (var argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using var process = Process.Start(startInfo);
+            Assert.NotNull(process);
+            var error = process!.StandardError.ReadToEnd();
+            process.WaitForExit();
+            Assert.True(process.ExitCode == 0, error);
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/G815WorkerClaimTeamTests.cs
+++ b/tests/IntentSystem.Cli.Tests/G815WorkerClaimTeamTests.cs
@@ -58,6 +58,28 @@ public sealed class G815WorkerClaimTeamTests : IDisposable
     }
 
     [Fact]
+    public void LegacyImplementationActorRecord_MatchingTeamProceeds_DifferentTeamRefuses_WithoutLabelEffects()
+    {
+        using var fixture = new ClaimFixture();
+        fixture.WriteClaim("G815", "implementation", "intent-cli-dev");
+        var mutator = new RecordingMutator("intent-target");
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+        WorkerClaimCommand.IssueLookupFactory = () => new IssueLookup("G815 legacy implementation actor");
+
+        var matching = ExecuteClaim(fixture.Context, "--team", "intent-cli-dev");
+        Assert.Equal(0, matching.ExitCode);
+        Assert.True(matching.Result.Proceed);
+        Assert.False(matching.Result.Applied);
+        Assert.Empty(mutator.Transitions);
+
+        var differing = ExecuteClaim(fixture.Context, "--team", "other-team");
+        Assert.Equal(2, differing.ExitCode);
+        Assert.False(differing.Result.Proceed);
+        Assert.False(differing.Result.Applied);
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
     public void InvalidAuthorityRefusesClosedWithoutMutation()
     {
         using var fixture = new ClaimFixture();

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadCommandTests.cs
@@ -95,7 +95,7 @@ public sealed class GuideDesignThreadCommandTests
             Assert.Contains("G811 completion channel", rendered, StringComparison.Ordinal);
             var parentProjection = RemoveG811CompletionGuidance(rendered);
             var hash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(parentProjection)));
-            Assert.Equal("9cb6691f1a11e22966ea5d218d4c0b7ac13db7a4dc600109d19b1386cc9f0a5a", hash);
+                Assert.Equal("0b0c0a6cec04351fe55f4f35f574e043308340134ef1a7eebcd44073f7697d9d", hash);
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -17,7 +17,7 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     // G684 extends shared orchestrator guidance with envelope-only recipe drift.
     // G685/G686/G690/G699/G707/G708/G719/G776/G781/G797/G809/G811 intentionally extend the shared guide while preserving
     // the G594 preflight contract. G696/G697/G700 add structured role-facing routes.
-    private const string G594AgmsgBaselineSha256 = "9cb6691f1a11e22966ea5d218d4c0b7ac13db7a4dc600109d19b1386cc9f0a5a";
+    private const string G594AgmsgBaselineSha256 = "0b0c0a6cec04351fe55f4f35f574e043308340134ef1a7eebcd44073f7697d9d";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -13,7 +13,7 @@ public sealed class HerdrWakeSourcesG581Tests : IDisposable
     // assertion explicit so a future wake-source or route change remains
     // intentional.
     private const string G594AgmsgGuideSha256 =
-        "581E802D835FB9BD1997ED9F9628E10EB45257F0BF8087C9CD305C828FF0C2E0";
+        "8D24CCDCC33CDF41D3975A3AB8F7EC8EEBAA26BE2DD379BA4052A2D772ABEA93";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/WorkerEvidencePasteG785Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerEvidencePasteG785Tests.cs
@@ -75,10 +75,10 @@ public sealed class WorkerEvidencePasteG785Tests : IDisposable
         // only the new rendered rule. This prevents an evidence-guide change
         // from smuggling unrelated prompt or workflow edits into G785.
         Assert.Equal(
-            "a4b127234b70964de16278fc333a3a507121f2c9aaa1e3019167d3647d8785b2",
+            "20107b6986c7aa0c1846bd8137796c77ea34fe84e838b55de8c1d0612c0258e3",
             Sha256(RemoveEvidenceRuleFromJson(issueJson)));
         Assert.Equal(
-            "9e053b805cab22020fa59ee024e8bbab83a5b179d8dd19d002a6d53717dc3e25",
+            "48f5273ec19d0656980751c8f7780e3d300d239654f303f45906a44b3eeec667",
             Sha256(RemoveEvidenceRuleFromMarkdown(issueMarkdown)));
         Assert.Equal(
             "5d8aec25a1111a1fcdaaee52ed8f04a9d6debc9f68900b4f3fbbf222c64cfbc8",


### PR DESCRIPTION
## Summary

Closes #1775

Carry explicit invoking team through worker claim ownership verification and existing guide consumers. Preserve missing/wrong-team and unavailable-authority refusals and existing lifecycle effects.

## Verification

- Builder reports Release CLI build succeeded.
- Focused G815 tests passed 8/8, including exact dry-run label effects, isolated write effects and CanonicalUnavailable refusal.
- Targeted whitespace verification and git diff --check passed.
- Existing package smoke script syntax check passed; this is not runtime smoke qualification.

## Pending qualification

Full Release/package smoke, exact-head CI, independent review, #1774 read-only rehearsal and required knowledge writeback remain pending. This PR is not release-qualified yet.

The prior local full-suite attempt had two packaged invocation failures and no final green result. AIC host confirmed no active intent-system test suite before this publication; unrelated Sekiban suites were left untouched.

Existing AIC team takeover is operator-approved. No live G813 changes, AIC merge, Azure changes or ownership bypass are included.
