### PR TITLE
G813: preserve team identity through worker and host loop

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -8,7 +8,9 @@ namespace IntentSystem.Cli.Commands;
 
 /// <summary>
 /// G308: <c>intent-cli automation host-loop-next-action --repo
-/// &lt;owner/repo&gt; [--format markdown|json]</c> — read-only
+/// &lt;owner/repo&gt; [--domain &lt;domain&gt;] [--team &lt;team&gt;]
+/// [--task-id &lt;task&gt;] [--result-nonce &lt;nonce&gt;]
+/// [--routing-root &lt;root&gt;] [--format markdown|json]</c> — read-only
 /// aggregator that captures the highest-priority host loop signal from
 /// the candidate lister (review PR / WIP cap / lease) plus optional
 /// preflight inputs, calls
@@ -30,6 +32,15 @@ internal static class AutomationHostLoopNextActionCommand
     private const string FormatMarkdown = "markdown";
 
     public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
+
+    /// <summary>
+    /// G813: source-bound identity capture is injectable so tests can prove
+    /// the team/task/nonce envelope without consulting a host store. The
+    /// production capture is read-only and only observes cwd and Git facts.
+    /// </summary>
+    public static Func<CliContext, HostLoopIdentityCapture>? IdentityCaptureFactory { get; set; }
+
+    public const string ClassificationIdentityUnresolved = "identity-unresolved";
 
     /// <summary>
     /// G318: testability seam for the automatic <c>intent next-slice --dry-run</c>
@@ -155,6 +166,98 @@ internal static class AutomationHostLoopNextActionCommand
             return 0;
         }
 
+        // G813: a team-scoped request must establish its immutable identity
+        // and restrictive host preflight before remote GitHub enumeration.
+        // Legacy callers (which do not provide any identity fields) retain
+        // the existing result shape and ordering.
+        HostLoopIdentityCapture? identityCapture = null;
+        if (parsed.RequiresIdentity)
+        {
+            try
+            {
+                identityCapture = IdentityCaptureFactory?.Invoke(context)
+                    ?? HostLoopIdentityCapture.Capture(context);
+            }
+            catch (Exception exception) when (
+                exception is IOException
+                or InvalidOperationException
+                or UnauthorizedAccessException)
+            {
+                // Identity capture is an observation boundary. A missing or
+                // unreadable source fact is reported as unresolved rather
+                // than allowing the request to reach GitHub enumeration.
+                identityCapture = new HostLoopIdentityCapture
+                {
+                    Cwd = null,
+                    Origin = null,
+                    Ref = null,
+                    Head = null,
+                    DispatchGeneration = null,
+                    DispatchDigest = null,
+                };
+            }
+        }
+        var preflightSyncClassification = parsed.SyncClassification;
+        var preflightSafeStashRequired = parsed.SafeStashRequired;
+        if (parsed.RequiresIdentity
+            && string.IsNullOrWhiteSpace(preflightSyncClassification)
+            && !preflightSafeStashRequired)
+        {
+            var syncProbe = HostSyncPreflightProbeFactory?.Invoke(context)
+                ?? new IntentCliHostSyncPreflightProbe(context);
+            var syncProbed = syncProbe.Probe();
+            if (syncProbed is not null)
+            {
+                preflightSyncClassification = syncProbed.Classification;
+                if (string.Equals(
+                        syncProbed.Classification,
+                        HostSyncPreflightAnalyzer.ClassificationDirtyUnrelatedSubmodule,
+                        StringComparison.Ordinal))
+                {
+                    preflightSafeStashRequired = true;
+                }
+            }
+        }
+
+        var identityResolution = parsed.RequiresIdentity
+            ? ResolveIdentity(parsed, identityCapture!)
+            : null;
+        if (parsed.RequiresIdentity
+            && IsRestrictiveSyncClassification(preflightSyncClassification))
+        {
+            var dirtyEvidence = new List<string>
+            {
+                $"host-sync-preflight classification: {preflightSyncClassification} (caller-supplied or locally observed).",
+                "G304/G306 dirty-host-state is a hard stop; remote GitHub enumeration was not attempted."
+            };
+            if (identityResolution is { Qualified: false })
+            {
+                dirtyEvidence.AddRange(identityResolution.MissingEvidence);
+            }
+            EmitIdentityBoundary(
+                writer,
+                parsed,
+                identityCapture,
+                identityResolution,
+                HostLoopNextActionAnalyzer.ClassificationDirtyHostState,
+                dirtyEvidence,
+                "Dirty durable host-state present — refusing to mutate or select a candidate (G304/G306).");
+            return 0;
+        }
+
+        if (parsed.RequiresIdentity && identityResolution is { Qualified: false })
+        {
+            EmitIdentityBoundary(
+                writer,
+                parsed,
+                identityCapture,
+                identityResolution,
+                ClassificationIdentityUnresolved,
+                identityResolution.MissingEvidence,
+                "Team-scoped host-loop identity is unresolved — no candidate or mutation is permitted.");
+            return 0;
+        }
+
         IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
         IReadOnlyList<GitHubAutomationIssueCandidate> openIssues;
         try
@@ -172,6 +275,10 @@ internal static class AutomationHostLoopNextActionCommand
         catch (GitHubApiRequestException exception)
         {
             var degraded = BuildGitHubUnavailableResult(parsed.Repo, parsed.Domain, exception);
+            if (parsed.RequiresIdentity)
+            {
+                degraded = ApplyIdentity(degraded, parsed, identityCapture!, identityResolution!);
+            }
             if (string.Equals(parsed.Format, FormatJson, StringComparison.Ordinal))
             {
                 writer.Write(JsonSerializer.Serialize(degraded, JsonOptions));
@@ -310,9 +417,11 @@ internal static class AutomationHostLoopNextActionCommand
         // `dirty-host-durable-state` and `dirty-mixed` flip to the
         // `dirty-host-state` block-and-surface lane so the host loop
         // never silently publishes on top of dirty durable state.
-        var syncClassification = parsed.SyncClassification;
-        var safeStashRequired = parsed.SafeStashRequired;
-        if (string.IsNullOrWhiteSpace(syncClassification) && !safeStashRequired)
+        var syncClassification = preflightSyncClassification;
+        var safeStashRequired = preflightSafeStashRequired;
+        if (!parsed.RequiresIdentity
+            && string.IsNullOrWhiteSpace(syncClassification)
+            && !safeStashRequired)
         {
             var syncProbe = HostSyncPreflightProbeFactory?.Invoke(context)
                 ?? new IntentCliHostSyncPreflightProbe(context);
@@ -411,6 +520,11 @@ internal static class AutomationHostLoopNextActionCommand
             Summary = result.Summary
         };
 
+        if (parsed.RequiresIdentity)
+        {
+            emitted = ApplyIdentity(emitted, parsed, identityCapture!, identityResolution!);
+        }
+
         if (string.Equals(parsed.Format, FormatJson, StringComparison.Ordinal))
         {
             writer.Write(JsonSerializer.Serialize(emitted, JsonOptions));
@@ -422,6 +536,153 @@ internal static class AutomationHostLoopNextActionCommand
         }
         return 0;
     }
+
+    private static bool IsRestrictiveSyncClassification(string? classification) =>
+        string.Equals(classification, "dirty-host-durable-state", StringComparison.Ordinal)
+        || string.Equals(classification, "dirty-mixed", StringComparison.Ordinal)
+        || string.Equals(classification, "unsafe", StringComparison.Ordinal)
+        || string.Equals(classification, "ff-blocked", StringComparison.Ordinal)
+        || string.Equals(classification, "diverged", StringComparison.Ordinal);
+
+    private static HostLoopIdentityResolution ResolveIdentity(
+        ParsedArgs parsed,
+        HostLoopIdentityCapture capture)
+    {
+        var missing = new List<string>();
+        if (string.IsNullOrWhiteSpace(parsed.Team)) missing.Add("team");
+        if (string.IsNullOrWhiteSpace(parsed.TaskId)) missing.Add("task_id");
+        if (string.IsNullOrWhiteSpace(parsed.ResultNonce)) missing.Add("result_nonce");
+        if (string.IsNullOrWhiteSpace(parsed.RoutingRoot)) missing.Add("routing_root");
+        if (string.IsNullOrWhiteSpace(capture.Cwd)) missing.Add("captured_cwd");
+        if (string.IsNullOrWhiteSpace(capture.Origin)) missing.Add("captured_origin");
+        if (string.IsNullOrWhiteSpace(capture.Ref)) missing.Add("captured_ref");
+        if (string.IsNullOrWhiteSpace(capture.Head)) missing.Add("captured_head");
+        if (string.IsNullOrWhiteSpace(capture.DispatchGeneration)) missing.Add("dispatch_generation");
+        if (string.IsNullOrWhiteSpace(capture.DispatchDigest)) missing.Add("dispatch_digest");
+
+        if (missing.Count == 0)
+        {
+            return new HostLoopIdentityResolution(
+                Qualified: true,
+                MissingEvidence: Array.Empty<string>(),
+                Source: "authoritative-dispatch-identity");
+        }
+
+        return new HostLoopIdentityResolution(
+            Qualified: false,
+            MissingEvidence: new[]
+            {
+                "identity-unresolved: authoritative team-scoped dispatch identity is incomplete.",
+                $"missing_fields: {string.Join(", ", missing)}.",
+                "Legacy/no-team host-loop output remains readable but cannot certify modern ownership or mutation."
+            },
+            Source: "identity-unresolved");
+    }
+
+    private static void EmitIdentityBoundary(
+        TextWriter writer,
+        ParsedArgs parsed,
+        HostLoopIdentityCapture? capture,
+        HostLoopIdentityResolution? identity,
+        string classification,
+        IReadOnlyList<string> evidence,
+        string summary)
+    {
+        var result = new HostLoopNextActionEmittedResult
+        {
+            Repo = parsed.Repo,
+            Domain = parsed.Domain,
+            Classification = classification,
+            MutationAllowed = false,
+            RecommendedCommand = null,
+            CandidateExecutionUnit = null,
+            Evidence = evidence,
+            Summary = summary,
+        };
+        if (parsed.RequiresIdentity && capture is not null && identity is not null)
+        {
+            result = ApplyIdentity(result, parsed, capture, identity);
+        }
+
+        if (string.Equals(parsed.Format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+    }
+
+    private static HostLoopNextActionEmittedResult ApplyIdentity(
+        HostLoopNextActionEmittedResult result,
+        ParsedArgs parsed,
+        HostLoopIdentityCapture capture,
+        HostLoopIdentityResolution identity)
+    {
+        var observedAt = DateTimeOffset.UtcNow;
+        DateTimeOffset? expiresAt = parsed.TimeoutSeconds is int timeout
+            ? observedAt.AddSeconds(timeout)
+            : null;
+        return result with
+        {
+            Operation = "automation host-loop-next-action",
+            Version = "1",
+            RequestedRepo = parsed.Repo,
+            ResolvedRepo = parsed.Repo,
+            RequestedDomain = parsed.Domain,
+            ResolvedDomain = parsed.Domain,
+            RequestedTeam = parsed.Team,
+            ResolvedTeam = parsed.Team,
+            Team = parsed.Team,
+            TaskId = parsed.TaskId,
+            ResultNonce = parsed.ResultNonce,
+            IdentityQualification = identity.Qualified ? "qualified" : ClassificationIdentityUnresolved,
+            IdentitySource = identity.Source,
+            CompletionIdentity = identity.Qualified
+                ? BuildCompletionIdentity(parsed, capture)
+                : null,
+            RecipientContext = capture.RecipientContext,
+            DispatchGeneration = capture.DispatchGeneration,
+            DispatchDigest = capture.DispatchDigest,
+            RoutingRoot = parsed.RoutingRoot,
+            CapturedCwd = capture.Cwd,
+            CapturedOrigin = capture.Origin,
+            CapturedRef = capture.Ref,
+            CapturedHead = capture.Head,
+            ObservedAt = observedAt.ToUniversalTime().ToString("O"),
+            ExpiresAt = expiresAt?.ToUniversalTime().ToString("O"),
+            TimeoutSeconds = parsed.TimeoutSeconds,
+            UpstreamTimeout = false,
+            Owner = capture.Owner,
+            Action = capture.Action,
+            Deadline = capture.Deadline,
+            GateEvidence = result.Evidence,
+            Provenance = identity.Qualified
+                ? new[] { "authoritative-dispatch-identity", "read-only-source-observation" }
+                : new[] { "identity-unresolved", "read-only-source-observation" },
+            ElapsedMilliseconds = null,
+        };
+    }
+
+    private static string BuildCompletionIdentity(
+        ParsedArgs parsed,
+        HostLoopIdentityCapture capture) =>
+        string.Join("/", [
+            parsed.Repo,
+            parsed.Domain ?? string.Empty,
+            parsed.Team ?? string.Empty,
+            parsed.TaskId ?? string.Empty,
+            parsed.ResultNonce ?? string.Empty,
+            capture.DispatchGeneration ?? string.Empty,
+            capture.DispatchDigest ?? string.Empty,
+        ]);
+
+    private sealed record HostLoopIdentityResolution(
+        bool Qualified,
+        IReadOnlyList<string> MissingEvidence,
+        string Source);
 
     private static HostLoopNextActionEmittedResult BuildGitHubUnavailableResult(
         string repo,
@@ -830,6 +1091,24 @@ internal static class AutomationHostLoopNextActionCommand
     {
         writer.WriteLine($"# automation host-loop-next-action (G308) — `{result.Repo}`");
         writer.WriteLine();
+        if (result.Operation is not null)
+        {
+            writer.WriteLine($"- operation: `{result.Operation}` (v{result.Version})");
+            writer.WriteLine($"- team: `{result.Team ?? "(unresolved)"}`");
+            writer.WriteLine($"- task_id: `{result.TaskId ?? "(unresolved)"}`");
+            writer.WriteLine($"- result_nonce: `{result.ResultNonce ?? "(unresolved)"}`");
+            writer.WriteLine($"- identity_qualification: `{result.IdentityQualification ?? "(unresolved)"}`");
+            writer.WriteLine($"- completion_identity: `{result.CompletionIdentity ?? "(none)"}`");
+            writer.WriteLine($"- recipient_context: `{result.RecipientContext ?? "(none)"}`");
+            writer.WriteLine($"- captured_cwd: `{result.CapturedCwd ?? "(unresolved)"}`");
+            writer.WriteLine($"- captured_origin: `{result.CapturedOrigin ?? "(unresolved)"}`");
+            writer.WriteLine($"- captured_ref: `{result.CapturedRef ?? "(unresolved)"}`");
+            writer.WriteLine($"- captured_head: `{result.CapturedHead ?? "(unresolved)"}`");
+            if (result.Provenance is { Count: > 0 })
+            {
+                writer.WriteLine($"- provenance: `{string.Join(", ", result.Provenance)}`");
+            }
+        }
         writer.WriteLine($"- classification: **{result.Classification}**");
         writer.WriteLine($"- mutation_allowed: {(result.MutationAllowed ? "yes" : "no")}");
         if (!string.IsNullOrEmpty(result.RecommendedCommand))
@@ -856,6 +1135,11 @@ internal static class AutomationHostLoopNextActionCommand
 
         string? repo = null;
         string? domain = null;
+        string? team = null;
+        string? taskId = null;
+        string? resultNonce = null;
+        string? routingRoot = null;
+        int? timeoutSeconds = null;
         var staleCli = false;
         string? syncClassification = null;
         var safeStashRequired = false;
@@ -887,6 +1171,45 @@ internal static class AutomationHostLoopNextActionCommand
                         error = "--domain requires a value."; return false;
                     }
                     domain = args[++index].Trim();
+                    break;
+                case "--team":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--team requires a non-empty value."; return false;
+                    }
+                    team = args[++index].Trim();
+                    break;
+                case "--task-id":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--task-id requires a non-empty value."; return false;
+                    }
+                    taskId = args[++index].Trim();
+                    break;
+                case "--result-nonce":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--result-nonce requires a non-empty value."; return false;
+                    }
+                    resultNonce = args[++index].Trim();
+                    break;
+                case "--routing-root":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--routing-root requires a non-empty value."; return false;
+                    }
+                    routingRoot = args[++index].Trim();
+                    break;
+                case "--timeout-seconds":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], out var timeout)
+                        || timeout <= 0
+                        || timeout > 30)
+                    {
+                        error = "--timeout-seconds requires an integer from 1 through 30."; return false;
+                    }
+                    timeoutSeconds = timeout;
+                    index++;
                     break;
                 case "--stale-cli":
                     staleCli = true;
@@ -979,7 +1302,7 @@ internal static class AutomationHostLoopNextActionCommand
                     format = requested;
                     break;
                 default:
-                    error = $"Unknown argument '{args[index]}'."; return false;
+                    error = $"Unknown argument '{args[index]}'. Supported: --repo <owner/repo> [--domain <domain>] [--team <team>] [--task-id <task>] [--result-nonce <nonce>] [--routing-root <root>] [--timeout-seconds <1..30>] [--format markdown|json]."; return false;
             }
         }
 
@@ -993,6 +1316,11 @@ internal static class AutomationHostLoopNextActionCommand
         {
             Repo = repo!,
             Domain = domain,
+            Team = team,
+            TaskId = taskId,
+            ResultNonce = resultNonce,
+            RoutingRoot = routingRoot,
+            TimeoutSeconds = timeoutSeconds,
             StaleCli = staleCli,
             SyncClassification = syncClassification,
             SafeStashRequired = safeStashRequired,
@@ -1035,6 +1363,16 @@ internal static class AutomationHostLoopNextActionCommand
     {
         public required string Repo { get; init; }
         public string? Domain { get; init; }
+        public string? Team { get; init; }
+        public string? TaskId { get; init; }
+        public string? ResultNonce { get; init; }
+        public string? RoutingRoot { get; init; }
+        public int? TimeoutSeconds { get; init; }
+        public bool RequiresIdentity => Team is not null
+            || TaskId is not null
+            || ResultNonce is not null
+            || RoutingRoot is not null
+            || TimeoutSeconds is not null;
         public required bool StaleCli { get; init; }
         public string? SyncClassification { get; init; }
         public required bool SafeStashRequired { get; init; }
@@ -1053,6 +1391,40 @@ internal static class AutomationHostLoopNextActionCommand
 
 internal sealed record HostLoopNextActionEmittedResult
 {
+    /// <summary>G813: versioned, read-only identity envelope.</summary>
+    [JsonPropertyName("operation")] public string? Operation { get; init; }
+    [JsonPropertyName("version")] public string? Version { get; init; }
+    [JsonPropertyName("requested_repo")] public string? RequestedRepo { get; init; }
+    [JsonPropertyName("resolved_repo")] public string? ResolvedRepo { get; init; }
+    [JsonPropertyName("requested_domain")] public string? RequestedDomain { get; init; }
+    [JsonPropertyName("resolved_domain")] public string? ResolvedDomain { get; init; }
+    [JsonPropertyName("requested_team")] public string? RequestedTeam { get; init; }
+    [JsonPropertyName("resolved_team")] public string? ResolvedTeam { get; init; }
+    [JsonPropertyName("team")] public string? Team { get; init; }
+    [JsonPropertyName("task_id")] public string? TaskId { get; init; }
+    [JsonPropertyName("result_nonce")] public string? ResultNonce { get; init; }
+    [JsonPropertyName("identity_qualification")] public string? IdentityQualification { get; init; }
+    [JsonPropertyName("identity_source")] public string? IdentitySource { get; init; }
+    [JsonPropertyName("completion_identity")] public string? CompletionIdentity { get; init; }
+    [JsonPropertyName("recipient_context")] public string? RecipientContext { get; init; }
+    [JsonPropertyName("dispatch_generation")] public string? DispatchGeneration { get; init; }
+    [JsonPropertyName("dispatch_digest")] public string? DispatchDigest { get; init; }
+    [JsonPropertyName("routing_root")] public string? RoutingRoot { get; init; }
+    [JsonPropertyName("captured_cwd")] public string? CapturedCwd { get; init; }
+    [JsonPropertyName("captured_origin")] public string? CapturedOrigin { get; init; }
+    [JsonPropertyName("captured_ref")] public string? CapturedRef { get; init; }
+    [JsonPropertyName("captured_head")] public string? CapturedHead { get; init; }
+    [JsonPropertyName("observed_at")] public string? ObservedAt { get; init; }
+    [JsonPropertyName("expires_at")] public string? ExpiresAt { get; init; }
+    [JsonPropertyName("timeout_seconds")] public int? TimeoutSeconds { get; init; }
+    [JsonPropertyName("upstream_timeout")] public bool? UpstreamTimeout { get; init; }
+    [JsonPropertyName("owner")] public string? Owner { get; init; }
+    [JsonPropertyName("action")] public string? Action { get; init; }
+    [JsonPropertyName("deadline")] public string? Deadline { get; init; }
+    [JsonPropertyName("gate_evidence")] public IReadOnlyList<string>? GateEvidence { get; init; }
+    [JsonPropertyName("provenance")] public IReadOnlyList<string>? Provenance { get; init; }
+    [JsonPropertyName("elapsed_ms")] public long? ElapsedMilliseconds { get; init; }
+
     [JsonPropertyName("repo")] public required string Repo { get; init; }
     [JsonPropertyName("domain")] public string? Domain { get; init; }
     [JsonPropertyName("classification")] public required string Classification { get; init; }

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -78,7 +78,7 @@ internal static class CommandRouter
         "automation durable-state-preflight [--format markdown|json]",
         "automation heartbeat --domain <d> --repo <r> [--stale-minutes <m, default 45>] [--format json|markdown]",
         "automation ci-wait record|clear|show [--domain <d>] --repo <r> --pr <n> [--head <sha>] [--transition <t>] [--dry-run|--write] [--format json|markdown]",
-        "automation host-loop-next-action --repo <r> [--sync-classification <c>] [--publish-recovery-repairs <N>] [--next-slice-issue-cut-ready] [--publish-next-execution-unit <u>]",
+        "automation host-loop-next-action --repo <r> [--domain <d>] [--team <t> --task-id <id> --result-nonce <nonce> --routing-root <root> --timeout-seconds <1..30>] [--sync-classification <c>] [--publish-recovery-repairs <N>] [--next-slice-issue-cut-ready] [--publish-next-execution-unit <u>]",
         "automation host-loop-wake --repo <r> [--domain <d>] [--team <t>] [--completion-signal-id <id>|--task-id <id>] [--write] [--format json|markdown]",
         "automation continuation-chain --domain <d> --team <t> [--task-id <id>|--completion-signal-id <id>|--chain-id <id>] [--format json|markdown]",
         "automation host-queue-item-recovery --repo <r> [--unit <u>] [--issue <n>] [--pr <m>] [--write]",

--- a/src/IntentSystem.Cli/Commands/HostLoopIdentityCapture.cs
+++ b/src/IntentSystem.Cli/Commands/HostLoopIdentityCapture.cs
@@ -1,0 +1,94 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only source facts attached to a team-scoped host-loop request.
+/// Dispatch identity is deliberately not invented here: callers must supply
+/// the authoritative task/result nonce and, when a qualified route is
+/// required, an immutable generation and digest through the testable seam.
+/// </summary>
+internal sealed record HostLoopIdentityCapture
+{
+    public string? Cwd { get; init; }
+    public string? Origin { get; init; }
+    public string? Ref { get; init; }
+    public string? Head { get; init; }
+    public string? DispatchGeneration { get; init; }
+    public string? DispatchDigest { get; init; }
+    public string? RecipientContext { get; init; }
+    public string? Owner { get; init; }
+    public string? Action { get; init; }
+    public string? Deadline { get; init; }
+
+    /// <summary>
+    /// Capture local source facts without reading queue, claims, packets, or
+    /// any other durable host state. A bounded non-interactive Git runner is
+    /// used so a remote credential prompt cannot hold the host loop.
+    /// </summary>
+    public static HostLoopIdentityCapture Capture(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var cwd = Directory.GetCurrentDirectory();
+        var runner = new CheckoutFreshnessGitCommandRunner(TimeSpan.FromSeconds(2));
+        var origin = ReadGit(runner, context.RepoRoot, ["remote", "get-url", "origin"]);
+        var reference = ReadGit(runner, context.RepoRoot, ["symbolic-ref", "--quiet", "--short", "HEAD"]);
+        var head = ReadGit(runner, context.RepoRoot, ["rev-parse", "HEAD"]);
+
+        return new HostLoopIdentityCapture
+        {
+            Cwd = cwd,
+            Origin = origin,
+            Ref = reference,
+            Head = head,
+        };
+    }
+
+    internal static string ComputeDigest(
+        string repo,
+        string? domain,
+        string? team,
+        string? taskId,
+        string? resultNonce,
+        HostLoopIdentityCapture capture)
+    {
+        var canonical = string.Join("\n", [
+            repo,
+            domain ?? string.Empty,
+            team ?? string.Empty,
+            taskId ?? string.Empty,
+            resultNonce ?? string.Empty,
+            capture.DispatchGeneration ?? string.Empty,
+            capture.Cwd ?? string.Empty,
+            capture.Origin ?? string.Empty,
+            capture.Ref ?? string.Empty,
+            capture.Head ?? string.Empty,
+        ]);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical))).ToLowerInvariant();
+    }
+
+    private static string? ReadGit(
+        IGitRemoteCommandRunner runner,
+        string workingDirectory,
+        IReadOnlyList<string> arguments)
+    {
+        try
+        {
+            var result = runner.Run(workingDirectory, arguments);
+            if (result.ExitCode == 0 && !result.TimedOut)
+            {
+                var value = result.StdOut.Trim();
+                return value.Length == 0 ? null : value;
+            }
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            // Source capture is an observation. The command reports the
+            // missing fact as identity-unresolved instead of guessing.
+        }
+
+        return null;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerClaimAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimAnalyzer.cs
@@ -179,12 +179,21 @@ internal static class WorkerClaimAnalyzer
 
     private static bool IsActiveOrUnavailableClaim(ClaimOwnershipVerification claim) =>
         claim.StoreConfigured
-        && (claim.Status == ClaimOwnershipVerification.StatusOwned
+        && ((claim.Status == ClaimOwnershipVerification.StatusOwned
+                && !SameInvokingTeamOwnsClaim(claim))
             || claim.Status == ClaimOwnershipVerification.StatusHeldByOtherTeam
             || claim.Status == ClaimOwnershipVerification.StatusTeamRequired
             || claim.Status == ClaimOwnershipVerification.StatusCanonicalUnavailable
             || claim.Status == ClaimOwnershipVerification.StatusMetadataBranchOnly
             || claim.Status == ClaimOwnershipVerification.StatusInvalid);
+
+    // G813: an explicit invoking team is part of the ownership identity. A
+    // matching team may consume an owned execution-unit claim; omitted or
+    // different teams remain fail-closed in ClaimOwnershipVerifier above.
+    private static bool SameInvokingTeamOwnsClaim(ClaimOwnershipVerification claim) =>
+        claim.Status == ClaimOwnershipVerification.StatusOwned
+        && !string.IsNullOrWhiteSpace(claim.InvokingTeam)
+        && string.Equals(claim.InvokingTeam, claim.HolderTeam, StringComparison.Ordinal);
 
     /// <summary>
     /// G211: Pure data record returned by

--- a/src/IntentSystem.Cli/Commands/WorkerClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimCommand.cs
@@ -66,6 +66,7 @@ internal static class WorkerClaimCommand
                 out var repo,
                 out var kind,
                 out var number,
+                out var invokingTeam,
                 out var mode,
                 out var githubOnly,
                 out var format,
@@ -107,7 +108,8 @@ internal static class WorkerClaimCommand
             context,
             repo!,
             kind!,
-            number);
+            number,
+            invokingTeam);
         var decision = WorkerClaimAnalyzer.Analyze(
             kind!,
             currentNames,
@@ -138,6 +140,7 @@ internal static class WorkerClaimCommand
         {
             Kind = kind!,
             Repo = repo!,
+            Team = invokingTeam,
             Number = number,
             Mode = mode,
             Proceed = decision.Proceed,
@@ -185,7 +188,8 @@ internal static class WorkerClaimCommand
         CliContext context,
         string repo,
         string kind,
-        int number)
+        int number,
+        string? invokingTeam)
     {
         if (!string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal))
         {
@@ -219,7 +223,7 @@ internal static class WorkerClaimCommand
             return ClaimOwnershipVerifier.Verify(
                 context.RepoRoot,
                 $"execution-unit:{match.Value}",
-                invokingTeam: null,
+                invokingTeam,
                 allowUnheld: true);
         }
         catch (Exception exception) when (
@@ -283,6 +287,7 @@ internal static class WorkerClaimCommand
         out string? repo,
         out string? kind,
         out int number,
+        out string? invokingTeam,
         out string mode,
         out bool githubOnly,
         out string format,
@@ -291,6 +296,7 @@ internal static class WorkerClaimCommand
         repo = null;
         kind = null;
         number = 0;
+        invokingTeam = null;
         mode = WorkerClaimCompleteConstants.Modes.DryRun;
         githubOnly = false;
         format = FormatText;
@@ -333,6 +339,16 @@ internal static class WorkerClaimCommand
                     index++;
                     break;
 
+                case "--team":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--team requires a non-empty value.";
+                        return false;
+                    }
+                    invokingTeam = args[index + 1];
+                    index++;
+                    break;
+
                 case "--write":
                     mode = WorkerClaimCompleteConstants.Modes.Write;
                     break;
@@ -369,7 +385,7 @@ internal static class WorkerClaimCommand
 
                 default:
                     error =
-                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --kind <issue|pr> --number <N> [--write] [--dry-run] [--github-only] [--format text|json].";
+                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --kind <issue|pr> --number <N> [--team <team>] [--write] [--dry-run] [--github-only] [--format text|json].";
                     return false;
             }
         }

--- a/src/IntentSystem.Cli/Commands/WorkerClaimResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimResult.cs
@@ -22,6 +22,16 @@ internal sealed record WorkerClaimResult
     [JsonPropertyName("repo")]
     public required string Repo { get; init; }
 
+    /// <summary>
+    /// G813: the invoking team is an explicit part of the ownership
+    /// identity. Null preserves the legacy unqualified invocation shape.
+    /// </summary>
+    [JsonPropertyName("team")]
+    public string? Team { get; init; }
+
+    [JsonPropertyName("invoking_team")]
+    public string? InvokingTeam => Team;
+
     [JsonPropertyName("number")]
     public required int Number { get; init; }
 

--- a/tests/IntentSystem.Cli.Tests/G813TeamAwareIdentityTests.cs
+++ b/tests/IntentSystem.Cli.Tests/G813TeamAwareIdentityTests.cs
@@ -1,0 +1,430 @@
+using System.Diagnostics;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G813: focused production-boundary coverage for the explicit invoking team
+/// and the read-only host-loop identity envelope.  The fixtures intentionally
+/// use only in-memory seams or a temporary claim store; no host metadata,
+/// queue state, or GitHub label is touched by these tests.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class G813TeamAwareIdentityTests : IDisposable
+{
+    public G813TeamAwareIdentityTests()
+    {
+        WorkerClaimCommand.MutatorFactory = null;
+        WorkerClaimCommand.IssueLookupFactory = null;
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = null;
+        AutomationHostLoopNextActionCommand.IdentityCaptureFactory = null;
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = null;
+        AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerClaimCommand.MutatorFactory = null;
+        WorkerClaimCommand.IssueLookupFactory = null;
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = null;
+        AutomationHostLoopNextActionCommand.IdentityCaptureFactory = null;
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = null;
+        AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = null;
+    }
+
+    [Fact]
+    public void WorkerClaim_LegacyImplementationActor_MatchingTeamProceeds_DifferentTeamRefusesWithoutMutation()
+    {
+        using var fixture = new LocalClaimFixture();
+        fixture.WriteClaim("G813", "implementation", "intent-cli-dev");
+        var mutator = new RecordingMutator("intent-target");
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+        WorkerClaimCommand.IssueLookupFactory = () => new IssueLookup("G813 team-aware claim");
+
+        var matching = ExecuteClaim(fixture, "intent-cli-dev");
+        Assert.Equal(0, matching.ExitCode);
+        Assert.True(matching.Result.Proceed);
+        Assert.False(matching.Result.Applied);
+        Assert.Equal("intent-cli-dev", matching.Result.Team);
+        Assert.Equal("intent-cli-dev", matching.Result.InvokingTeam);
+        Assert.Empty(mutator.Transitions);
+
+        var differing = ExecuteClaim(fixture, "other-team");
+        Assert.Equal(2, differing.ExitCode);
+        Assert.False(differing.Result.Proceed);
+        Assert.False(differing.Result.Applied);
+        Assert.Contains(differing.Result.Errors, error =>
+            error.Contains("does not hold it", StringComparison.Ordinal));
+        Assert.Empty(mutator.Transitions);
+
+        var omitted = ExecuteClaim(fixture, null);
+        Assert.Equal(2, omitted.ExitCode);
+        Assert.False(omitted.Result.Proceed);
+        Assert.Contains(omitted.Result.Errors, error =>
+            error.Contains("--team is required", StringComparison.Ordinal));
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void HostLoop_QualifiedTeamIdentity_IsRetainedAcrossJsonAndMarkdown_WithoutMutation()
+    {
+        var lister = new CountingLister();
+        ConfigureIdentityFixtures(lister);
+
+        var args = new[]
+        {
+            "--repo", "J-Tech-Japan/intent-system",
+            "--domain", "intent-cli",
+            "--team", "intent-cli-dev",
+            "--task-id", "G813-implementation-v1",
+            "--result-nonce", "G813-IMPLEMENTATION-TEAM-AWARE-20260912-1",
+            "--routing-root", "/registered-host",
+            "--sync-classification", "clean",
+            "--timeout-seconds", "30",
+            "--format", "json",
+        };
+
+        using var jsonWriter = new StringWriter();
+        Assert.Equal(0, AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(), args, jsonWriter));
+        using var json = JsonDocument.Parse(jsonWriter.ToString());
+        var root = json.RootElement;
+        Assert.Equal("automation host-loop-next-action", root.GetProperty("operation").GetString());
+        Assert.Equal("1", root.GetProperty("version").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("requested_repo").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("resolved_repo").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("requested_domain").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("resolved_domain").GetString());
+        Assert.Equal("intent-cli-dev", root.GetProperty("requested_team").GetString());
+        Assert.Equal("intent-cli-dev", root.GetProperty("resolved_team").GetString());
+        Assert.Equal("intent-cli-dev", root.GetProperty("team").GetString());
+        Assert.Equal("G813-implementation-v1", root.GetProperty("task_id").GetString());
+        Assert.Equal("G813-IMPLEMENTATION-TEAM-AWARE-20260912-1", root.GetProperty("result_nonce").GetString());
+        Assert.Equal("qualified", root.GetProperty("identity_qualification").GetString());
+        Assert.Equal(
+            "J-Tech-Japan/intent-system/intent-cli/intent-cli-dev/G813-implementation-v1/G813-IMPLEMENTATION-TEAM-AWARE-20260912-1/generation-1/digest-1",
+            root.GetProperty("completion_identity").GetString());
+        Assert.Equal("generation-1", root.GetProperty("dispatch_generation").GetString());
+        Assert.Equal("digest-1", root.GetProperty("dispatch_digest").GetString());
+        Assert.Equal("/registered-host", root.GetProperty("routing_root").GetString());
+        Assert.Equal("/child", root.GetProperty("captured_cwd").GetString());
+        Assert.False(root.GetProperty("mutation_allowed").GetBoolean());
+        Assert.Equal(2, lister.TotalCalls);
+
+        using var markdownWriter = new StringWriter();
+        Assert.Equal(0, AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(), args[..^2].Concat(["--format", "markdown"]).ToArray(), markdownWriter));
+        var markdown = markdownWriter.ToString();
+        Assert.Contains("team: `intent-cli-dev`", markdown, StringComparison.Ordinal);
+        Assert.Contains("task_id: `G813-implementation-v1`", markdown, StringComparison.Ordinal);
+        Assert.Contains("identity_qualification: `qualified`", markdown, StringComparison.Ordinal);
+        Assert.Contains("captured_origin: `https://github.com/J-Tech-Japan/intent-system.git`", markdown, StringComparison.Ordinal);
+        Assert.Equal(4, lister.TotalCalls);
+    }
+
+    [Fact]
+    public void HostLoop_MissingIdentity_RefusesBeforeCandidateEnumeration()
+    {
+        var lister = new CountingLister();
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => lister;
+        AutomationHostLoopNextActionCommand.IdentityCaptureFactory = _ => new HostLoopIdentityCapture
+        {
+            Cwd = "/child",
+            Origin = "https://github.com/J-Tech-Japan/intent-system.git",
+            Ref = "claude/g813-completion-channel",
+            Head = "head-1",
+        };
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ =>
+            new FixedSyncProbe(HostSyncPreflightAnalyzer.ClassificationClean);
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            [
+                "--repo", "J-Tech-Japan/intent-system",
+                "--domain", "intent-cli",
+                "--team", "intent-cli-dev",
+                "--task-id", "G813-implementation-v1",
+                "--routing-root", "/registered-host",
+                "--sync-classification", "clean",
+                "--format", "json",
+            ],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var json = JsonDocument.Parse(writer.ToString());
+        var root = json.RootElement;
+        Assert.Equal(AutomationHostLoopNextActionCommand.ClassificationIdentityUnresolved,
+            root.GetProperty("classification").GetString());
+        Assert.False(root.GetProperty("mutation_allowed").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("candidate_execution_unit").ValueKind);
+        Assert.Equal("identity-unresolved", root.GetProperty("identity_qualification").GetString());
+        var evidence = string.Join(" ", root.GetProperty("evidence").EnumerateArray()
+            .Select(item => item.GetString()));
+        Assert.Contains("result_nonce", evidence, StringComparison.Ordinal);
+        Assert.Contains("dispatch_generation", evidence, StringComparison.Ordinal);
+        Assert.Equal(0, lister.TotalCalls);
+    }
+
+    [Fact]
+    public void HostLoop_DirtyIdentity_RefusesBeforeCandidateEnumeration()
+    {
+        var lister = new CountingLister();
+        ConfigureIdentityFixtures(lister);
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            [
+                "--repo", "J-Tech-Japan/intent-system",
+                "--domain", "intent-cli",
+                "--team", "intent-cli-dev",
+                "--task-id", "G813-implementation-v1",
+                "--result-nonce", "G813-dirty",
+                "--routing-root", "/registered-host",
+                "--sync-classification", "dirty-mixed",
+                "--format", "json",
+            ],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var json = JsonDocument.Parse(writer.ToString());
+        var root = json.RootElement;
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationDirtyHostState,
+            root.GetProperty("classification").GetString());
+        Assert.False(root.GetProperty("mutation_allowed").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("candidate_execution_unit").ValueKind);
+        var evidence = string.Join(" ", root.GetProperty("evidence").EnumerateArray()
+            .Select(item => item.GetString()));
+        Assert.Contains("dirty-mixed", evidence, StringComparison.Ordinal);
+        Assert.Contains("remote GitHub enumeration was not attempted", evidence, StringComparison.Ordinal);
+        Assert.Equal(0, lister.TotalCalls);
+    }
+
+    private static void ConfigureIdentityFixtures(CountingLister lister)
+    {
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => lister;
+        AutomationHostLoopNextActionCommand.IdentityCaptureFactory = _ => new HostLoopIdentityCapture
+        {
+            Cwd = "/child",
+            Origin = "https://github.com/J-Tech-Japan/intent-system.git",
+            Ref = "claude/g813-completion-channel",
+            Head = "head-1",
+            DispatchGeneration = "generation-1",
+            DispatchDigest = "digest-1",
+            RecipientContext = "intent-cli-dev",
+            Owner = "builder",
+            Action = "issue-to-pr",
+            Deadline = "2026-09-12T06:00:00Z",
+        };
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ =>
+            new FixedNextSliceProbe("no-actionable-item");
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ =>
+            new FixedRecoveryProbe();
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ =>
+            new FixedSyncProbe(HostSyncPreflightAnalyzer.ClassificationClean);
+        AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = _ =>
+            new FixedDriftProbe();
+    }
+
+    private static (int ExitCode, WorkerClaimResult Result) ExecuteClaim(
+        LocalClaimFixture fixture,
+        string? team)
+    {
+        var args = new List<string>
+        {
+            "--repo", "J-Tech-Japan/intent-system",
+            "--kind", "issue",
+            "--number", "813",
+            "--dry-run",
+            "--github-only",
+            "--format", "json",
+        };
+        if (team is not null)
+        {
+            args.Add("--team");
+            args.Add(team);
+        }
+
+        using var writer = new StringWriter();
+        var exit = WorkerClaimCommand.Execute(fixture.Context, args.ToArray(), writer);
+        return (exit, JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!);
+    }
+
+    private static CliContext CreateContext() => new()
+    {
+        RepoRoot = Path.GetTempPath(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private sealed class CountingLister : IGitHubAutomationCandidateLister
+    {
+        public int TotalCalls { get; private set; }
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels)
+        {
+            TotalCalls++;
+            return Array.Empty<GitHubAutomationPrCandidate>();
+        }
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels)
+        {
+            TotalCalls++;
+            return Array.Empty<GitHubAutomationIssueCandidate>();
+        }
+    }
+
+    private sealed class FixedNextSliceProbe : INextSliceDryRunProbe
+    {
+        private readonly string outcome;
+
+        public FixedNextSliceProbe(string outcome) => this.outcome = outcome;
+
+        public NextSliceProbeResult Probe(string repo, string domain) => new()
+        {
+            RecommendedOutcome = outcome,
+        };
+    }
+
+    private sealed class FixedRecoveryProbe : IPublishRecoveryProbe
+    {
+        public PublishRecoveryProbeResult Probe(string repo) => new()
+        {
+            SafeRepairCount = 0,
+            UnsafeStopCount = 0,
+        };
+    }
+
+    private sealed class FixedSyncProbe : IHostSyncPreflightProbe
+    {
+        private readonly string classification;
+
+        public FixedSyncProbe(string classification) => this.classification = classification;
+
+        public HostSyncPreflightProbeResult Probe() => new() { Classification = classification };
+    }
+
+    private sealed class FixedDriftProbe : ICloseoutDriftCheckProbe
+    {
+        public CloseoutDriftCheckProbeResult Probe(string repo) => new()
+        {
+            SafeRepairCount = 0,
+            UnsafeStopCount = 0,
+        };
+    }
+
+    private sealed class RecordingMutator : IGitHubLabelMutator
+    {
+        private readonly IReadOnlyList<string> labels;
+
+        public RecordingMutator(params string[] labels) => this.labels = labels;
+
+        public List<(IReadOnlyList<string> Add, IReadOnlyList<string> Remove)> Transitions { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            Transitions.Add((addLabels.ToArray(), removeLabels.ToArray()));
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class IssueLookup : IGitHubIssueLookup
+    {
+        private readonly string title;
+
+        public IssueLookup(string title) => this.title = title;
+
+        public GitHubIssueLookupResult Lookup(string repo, int issueNumber) => new()
+        {
+            Number = issueNumber,
+            State = "OPEN",
+            Title = title,
+            Body = "# G813 contract",
+            Labels = new[] { new GitHubIssueLabel { Name = "intent-target" } },
+        };
+    }
+
+    private sealed class LocalClaimFixture : IDisposable
+    {
+        private readonly string root = Directory.CreateTempSubdirectory("g813-claim-").FullName;
+
+        public LocalClaimFixture()
+        {
+            Context = new CliContext
+            {
+                RepoRoot = root,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+            Directory.CreateDirectory(Path.Combine(root, ".intent-cli", "claims"));
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteClaim(string executionUnit, string actor, string team)
+        {
+            var scope = $"execution-unit:{executionUnit}";
+            var path = Path.Combine(
+                root,
+                ClaimCommand.ClaimPath(scope).Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var record = new ClaimRecord(
+                "1",
+                scope,
+                actor,
+                team,
+                DateTimeOffset.UtcNow,
+                "g813-focused-fixture");
+            File.WriteAllText(path, JsonSerializer.Serialize(record));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Historical/source linkage: #1774. Implementation direction: #1771 under
G304-G813-OPERATOR-SCOPE-RULING-20260912. This PR does not close either issue.

This PR implements the bounded G813 team-identity/host-loop contract. It does
not implement the wider Orca/mailbox contract or change lifecycle policy or
host metadata.

- `worker claim` accepts an explicit `--team`, carries it into the existing
  `ClaimOwnershipVerifier`, and permits an already-owned claim only for the
  matching invoking team. Omitted or different teams remain fail-closed.
- `automation host-loop-next-action` accepts the proposed team/task/nonce/
  routing/timeout context and emits a versioned read-only identity envelope.
  Missing authoritative identity is `identity-unresolved`; dirty durable host
  state is a `dirty-host-state` hard stop. Both return no candidate and never
  enumerate GitHub before the refusal.
- Source identity capture observes only read-only cwd/origin/ref/head facts;
  it never reads or writes claims, queue state, packets, labels, or runs.

## Criterion evidence — team-aware claim

The dedicated production-command regression writes a temporary legacy actor
record (`actor=implementation`, `team=intent-cli-dev`) and invokes the real
`WorkerClaimCommand` seam:

```text
matching --team intent-cli-dev: exit=0, proceed=true, applied=false,
add=[intent-issue-in-progress], transitions=[]
differing --team other-team: exit=2, proceed=false, applied=false,
error contains "does not hold it", transitions=[]
omitted --team: exit=2, proceed=false, error contains "--team is required",
transitions=[]
```

The JSON result preserves both `team` and `invoking_team` as
`intent-cli-dev`; no label mutator transition occurs in the dry-run fixture.

## Criterion evidence — qualified host-loop identity

The real `AutomationHostLoopNextActionCommand.Execute` path with the
read-only fake seams emits JSON and Markdown with:

```text
operation=automation host-loop-next-action, version=1
requested_repo=resolved_repo=J-Tech-Japan/intent-system
requested_domain=resolved_domain=intent-cli
requested_team=resolved_team=team=intent-cli-dev
task_id=G813-implementation-v1
result_nonce=G813-IMPLEMENTATION-TEAM-AWARE-20260912-1
identity_qualification=qualified
dispatch_generation=generation-1, dispatch_digest=digest-1
completion_identity=J-Tech-Japan/intent-system/intent-cli/intent-cli-dev/G813-implementation-v1/G813-IMPLEMENTATION-TEAM-AWARE-20260912-1/generation-1/digest-1
routing_root=/registered-host, captured_cwd=/child
captured_origin=https://github.com/J-Tech-Japan/intent-system.git
captured_ref=claude/g813-completion-channel, captured_head=head-1
mutation_allowed=false, candidate_execution_unit=null
```

## Criterion evidence — fail-closed boundaries

```text
missing identity: classification=identity-unresolved, mutation_allowed=false,
candidate_execution_unit=null, missing_fields includes result_nonce and
dispatch_generation, candidate lister calls=0
dirty-mixed identity: classification=dirty-host-state,
mutation_allowed=false, candidate_execution_unit=null, evidence includes
caller-supplied/locally observed dirty-mixed and remote enumeration not
attempted, candidate lister calls=0
```

## Parent absence and validation

```text
git cat-file -e HEAD:src/IntentSystem.Cli/Commands/HostLoopIdentityCapture.cs
fatal: path ... exists on disk, but not in 'HEAD'
PARENT_HOST_LOOP_IDENTITY_RC:128
git cat-file -e HEAD:tests/IntentSystem.Cli.Tests/G813TeamAwareIdentityTests.cs
fatal: path ... exists on disk, but not in 'HEAD'
PARENT_G813_TEST_RC:128
git diff --check
DIFF_CHECK_RC:0
```

Focused Release command (new tests plus existing claim/selector/host-loop
coverage):

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --no-restore --filter 'FullyQualifiedName~G813TeamAwareIdentityTests|FullyQualifiedName~AutomationHostLoopNextActionCommandTests|FullyQualifiedName~ClaimCommandG679Tests|FullyQualifiedName~WorkerNextActionCommandTests'
RC:0; total=94, executed=94, passed=94, failed=0, skipped=0
```

Full CLI Release exact-head evidence for `8f1400b196f07e23cede0bb4e5c93219ed44d5b0`:

```text
total=5983, executed=5982, passed=5982, failed=0, skipped=1 (expected NotExecuted)
TRX SHA256=67dcd6d494d888e20660480dc725aa00361a5d37fc389230a2cca1e60a57464f
log SHA256=b78703add3b8372bc3af4e671b7e82d6c0e02b46ed5c36a556b31bbe533d9906
all four G813TeamAwareIdentityTests outcome=Passed
```

The earlier `5527 total / 5526 executed and passed` measurement belongs to the
earlier `8578d66f7162c5796d23b034f6e6acecb6fbd6ee` source inventory and is retained
as historical evidence; it is not the exact-head result.

No tags, releases, package publication, merge, or host-state mutation are part
of this branch. CI is requested against the exact head after PR creation.
